### PR TITLE
Add Windows config examples and ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Windows specific ignores
+Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk
+
+# PowerShell history and state
+Microsoft.PowerShell_*/*.txt
+PowerShell/ConsoleHost_history.txt
+
+# Editor and OS generated files
+*.log
+*.tmp
+*.swp
+.DS_Store
+
+# Node and Python artifacts
+node_modules/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -95,9 +95,14 @@ Whether it’s spinning up a new LLM pipeline at dawn or fine-tuning memory grap
    cd ~/d0tTino
    stow shell
    stow vim
+   # Windows examples
+   stow windows-terminal
+   stow powertoys
    ```
 
    Stow cleanly manages symlinks, letting you enable or disable packages with `stow -D <name>`.
+
+   Example Windows configurations live under `windows-terminal/` and `powertoys/`. Use Stow to symlink these files into `%USERPROFILE%` when working on Windows.
 
 3. **Host-specific overrides** live under `hosts/<hostname>` and can be applied with:
 

--- a/powertoys/config.json
+++ b/powertoys/config.json
@@ -1,0 +1,11 @@
+{
+  "powertoys": [
+    {
+      "name": "FancyZones",
+      "properties": {
+        "zoneCount": 3,
+        "spacing": 10
+      }
+    }
+  ]
+}

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://aka.ms/terminal-profiles-schema",
+  "defaultProfile": "{00000000-0000-0000-0000-000000000000}",
+  "profiles": {
+    "defaults": {
+      "fontFace": "Cascadia Mono",
+      "fontSize": 12
+    },
+    "list": []
+  }
+}


### PR DESCRIPTION
## Summary
- add sample Windows Terminal and PowerToys configs
- create a gitignore tuned for Windows and temp files
- document using stow for the new configs in the readme

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6854759a55c08326aa4338f8e39e23fa