### PR TITLE
Fix stow docs and clarify packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Clone the repository as a bare repo and stow the desired packages:
 git clone --bare https://github.com/d0tTino/d0tTino.git "$HOME/.dots"
 alias dot='git --git-dir=$HOME/.dots/ --work-tree=$HOME'
 cd ~/d0tTino
-stow shell
+stow powertoys
+stow windows-terminal
 ```
 
 See [docs/installation](docs/installation.md) for full setup details.
@@ -21,7 +22,7 @@ See [docs/installation](docs/installation.md) for full setup details.
 - [Terminal Setup](docs/terminal.md)
 - [Navigation](docs/navigation.md)
 - [Desktop Environment](docs/desktop.md)
-- [AI Automation](docs/ai-automation.
+- [AI Automation](docs/ai-automation.md)
 
 ## License
 

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -1,3 +1,3 @@
 # AI Automation
 
-Scripts in the `automation` package streamline tasks like bootstrapping new projects or running local LLM workflows. Stow this package to enable the helper scripts.
+Scripts in an `automation` package could streamline tasks like bootstrapping new projects or running local LLM workflows. Such a package is not part of this repository yet.

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,3 +1,3 @@
 # Desktop Environment
 
-The `desktop` stow package contains settings for window managers and theming. Apply it if you plan to use these dotfiles on a graphical desktop.
+These dotfiles currently do not ship a `desktop` stow package. If you create one, it could hold window manager and theming settings for use on a graphical desktop.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,8 +13,8 @@ Follow these steps to set up the dotfiles on a new machine.
 
    ```bash
    cd ~/d0tTino
-   stow shell
-   stow vim
+   stow powertoys
+   stow windows-terminal
    ```
 
    Stow cleanly manages symlinks, letting you enable or disable packages with `stow -D <name>`.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,3 +1,3 @@
 # Navigation
 
-Configuration in the `navigation` package fine-tunes command-line tools such as `fzf` and `ripgrep` for efficient file browsing. Stow this package if you want the extras.
+A future `navigation` package could fine-tune command-line tools such as `fzf` and `ripgrep` for efficient file browsing. It is not included in this repository yet.

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -1,5 +1,5 @@
 # Terminal Setup
 
-The `shell` stow package provides zsh configuration, aliases, and prompts. After running the installation steps, open a new terminal session to activate the settings.
+The `windows-terminal` directory contains example settings for Microsoft's terminal application. After stowing the package, open a new session to load the configuration.
 
-Common commands are defined in `~/.zshrc` and custom themes live under `shell/themes`.
+Common commands are defined in `~/.zshrc`, and you can place custom themes under a `themes` folder if you create your own shell package.


### PR DESCRIPTION
## Summary
- update install instructions to stow existing folders
- correct quickstart snippet and docs links
- clarify that optional packages are not included yet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549f5d48848326aed235e8ff0002ff