### PR TITLE
Add README header test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,2 +1,8 @@
-def test_placeholder():
-    assert True
+import pathlib
+
+
+def test_readme_has_config_header():
+    """README should mention the configuration header."""
+    readme_path = pathlib.Path(__file__).resolve().parent.parent / "README.md"
+    text = readme_path.read_text(encoding="utf-8")
+    assert "# d0tTino Configuration" in text


### PR DESCRIPTION
## Summary
- test that README includes a configuration header

## Testing
- `npm test`
- `pytest -q`
- `ruff check tests/test_basic.py`


------
https://chatgpt.com/codex/tasks/task_e_685595f06a088326a3abbbee6b57639a