### PR TITLE
Check availability of posh and zoxide in WSL bashrc

### DIFF
--- a/tablet-config/wsl/.bashrc
+++ b/tablet-config/wsl/.bashrc
@@ -1,3 +1,7 @@
 theme_file="$(dirname "${BASH_SOURCE[0]}")/../oh-my-posh/custom_tokyo.omp.json"
-eval "$(oh-my-posh init bash --config \"${theme_file}\")"
-eval "$(zoxide init bash)"
+if command -v oh-my-posh >/dev/null; then
+    eval "$(oh-my-posh init bash --config "$theme_file")"
+fi
+if command -v zoxide >/dev/null; then
+    eval "$(zoxide init bash)"
+fi


### PR DESCRIPTION
## Summary
- guard `oh-my-posh` initialization in WSL `.bashrc`
- guard `zoxide` initialization in WSL `.bashrc`
- fix quoting of the theme path

## Testing
- `pytest -q`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_6855c04f07e48326b3e08e86d4330805