### PR TITLE
Update PowerShell profile checks

### DIFF
--- a/tablet-config/powershell/Microsoft.PowerShell_profile.ps1
+++ b/tablet-config/powershell/Microsoft.PowerShell_profile.ps1
@@ -1,6 +1,10 @@
-# Initialize Oh My Posh
+# Initialize Oh My Posh if available
 $ThemePath = Join-Path $PSScriptRoot "..\oh-my-posh\custom_tokyo.omp.json"
-Invoke-Expression (& { (oh-my-posh init powershell --config $ThemePath | Out-String) })
+if (Get-Command oh-my-posh -ErrorAction SilentlyContinue) {
+    Invoke-Expression (& { (oh-my-posh init powershell --config $ThemePath | Out-String) })
+}
 
-# Initialize Zoxide
-Invoke-Expression (& { (zoxide init powershell | Out-String) })
+# Initialize Zoxide if available
+if (Get-Command zoxide -ErrorAction SilentlyContinue) {
+    Invoke-Expression (& { (zoxide init powershell | Out-String) })
+}


### PR DESCRIPTION
## Summary
- clarify initialization comments for `oh-my-posh` and `zoxide`
- only initialize them if each command is available

## Testing
- `npm test`
- `pytest -q`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_6855c04f876c83269700840bb1e7e548