### PR TITLE
Add winget export hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+if command -v pwsh >/dev/null 2>&1; then
+    pwsh -NoLogo -NoProfile -File scripts/export-winget.ps1
+elif command -v powershell >/dev/null 2>&1; then
+    powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/export-winget.ps1
+else
+    echo "PowerShell is not installed" >&2
+    exit 1
+fi
+
+git add winget-packages.json

--- a/README.md
+++ b/README.md
@@ -15,4 +15,15 @@ Key directories:
 See the [installation guide](docs/installation.md) for setup instructions.
 For a more detailed overview, see [docs/terminal.md](docs/terminal.md).
 
+## Git hooks
+
+Run the following to enable the local hooks:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Once enabled, the `pre-commit` hook automatically exports your current
+`winget` package list.
+
 Licensed under the [Apache 2.0](LICENSE) license.

--- a/scripts/export-winget.ps1
+++ b/scripts/export-winget.ps1
@@ -1,0 +1,2 @@
+# Export installed packages list using winget
+winget export -o winget-packages.json --accept-source-agreements


### PR DESCRIPTION
## Summary
- add `export-winget.ps1` script for exporting packages
- create `.githooks/pre-commit` hook invoking the script
- document enabling hooks in the README

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6855e2c70fdc832681e9c77ab341540a