### PR TITLE
Update WSL bashrc to use starship

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "d0tTino",
   "version": "1.0.0",
   "scripts": {
-    "test": "echo \"No JS tests\""
-
+    "test": "echo \"No JS tests\"",
+    "lint": "eslint . --ext .js"
+  },
+  "devDependencies": {
+    "eslint": "^9.29.0"
   }
 }

--- a/tablet-config/wsl/.bashrc
+++ b/tablet-config/wsl/.bashrc
@@ -1,6 +1,5 @@
-theme_file="$(dirname "${BASH_SOURCE[0]}")/../oh-my-posh/custom_tokyo.omp.json"
-if command -v oh-my-posh >/dev/null; then
-    eval "$(oh-my-posh init bash --config "$theme_file")"
+if command -v starship >/dev/null; then
+    eval "$(starship init bash)"
 fi
 if command -v zoxide >/dev/null; then
     eval "$(zoxide init bash)"


### PR DESCRIPTION
## Summary
- use starship instead of Oh-My-Posh in `tablet-config/wsl/.bashrc`
- keep zoxide initialization
- add eslint dev dependency and lint script to package.json

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855e2c1ad808326967d76fbb2efdf13