### PR TITLE
Fix starship init duplication

### DIFF
--- a/tablet-config/wsl/.bashrc
+++ b/tablet-config/wsl/.bashrc
@@ -1,6 +1,3 @@
-if command -v starship >/dev/null; then
-    eval "$(starship init bash)"
-fi
 starship_config="$(dirname "${BASH_SOURCE[0]}")/../../starship.toml"
 if command -v starship >/dev/null; then
     eval "$(starship init bash --config "$starship_config")"

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -7,8 +7,6 @@
                 "size": 11
             }
         },
-        "list": [
-            // Add profile objects here
-        ]
+        "list": []
     }
 }


### PR DESCRIPTION
## Summary
- clean up starship init in WSL bashrc
- ensure Windows Terminal settings are valid JSON

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855ee030c2883269f9b791d3f5a8863