### PR TITLE
Add fallback install logic for WSL setup

### DIFF
--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -12,6 +12,23 @@ sudo apt-get install -y \
     starship \
     zoxide
 
+# Ensure starship is available; install from the official script if apt didn't
+# provide it.
+if ! command -v starship >/dev/null; then
+    curl -sS https://starship.rs/install.sh | sh -s -- -y
+fi
+
+# Ensure zoxide is available; prefer Cargo for installation with a curl-based
+# fallback when Cargo is missing.
+if ! command -v zoxide >/dev/null; then
+    if command -v cargo >/dev/null; then
+        cargo install --locked zoxide
+    else
+        curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh \
+            | bash -s -- --yes
+    fi
+fi
+
 # Provide helpful symlinks for batcat and fdfind if they exist
 if command -v batcat >/dev/null && ! command -v bat >/dev/null; then
     sudo ln -sf $(command -v batcat) /usr/local/bin/bat

--- a/tests/test_setup_wsl.py
+++ b/tests/test_setup_wsl.py
@@ -1,0 +1,15 @@
+import pathlib
+
+SCRIPT_PATH = pathlib.Path('scripts/setup-wsl.sh')
+
+
+def test_starship_install_fallback():
+    text = SCRIPT_PATH.read_text(encoding='utf-8')
+    assert 'command -v starship' in text
+    assert 'starship.rs/install.sh' in text
+
+
+def test_zoxide_install_fallback():
+    text = SCRIPT_PATH.read_text(encoding='utf-8')
+    assert 'command -v zoxide' in text
+    assert 'cargo install --locked zoxide' in text or 'zoxide/main/install.sh' in text


### PR DESCRIPTION
## Summary
- install starship and zoxide via curl or cargo if they aren't available after `apt-get`
- add unit tests covering the new fallback logic

## Testing
- `python -m pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856241fb53483268b5fea66d35498d5