### PR TITLE
Update pre-commit hook for OS detection

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,12 +1,27 @@
 #!/bin/sh
 set -e
-if command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoLogo -NoProfile -File scripts/export-winget.ps1
-elif command -v powershell >/dev/null 2>&1; then
-    powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/export-winget.ps1
-else
-    echo "PowerShell is not installed" >&2
-    exit 1
-fi
-
-git add winget-packages.json
+OS=$(uname -s)
+case "$OS" in
+    CYGWIN*|MINGW*|MSYS*|Windows_NT)
+        if command -v pwsh >/dev/null 2>&1; then
+            pwsh -NoLogo -NoProfile -File scripts/export-winget.ps1
+        elif command -v powershell >/dev/null 2>&1; then
+            powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/export-winget.ps1
+        else
+            echo "PowerShell is not installed" >&2
+            exit 1
+        fi
+        git add winget-packages.json
+        ;;
+    Linux*)
+        if command -v winget >/dev/null 2>&1; then
+            winget export -o winget-packages.json --accept-source-agreements
+            git add winget-packages.json
+        else
+            echo "Skipping winget export on Linux"
+        fi
+        ;;
+    *)
+        echo "Skipping winget export on unsupported OS: $OS"
+        ;;
+esac

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ git config core.hooksPath .githooks
 ```
 
 Once enabled, the `pre-commit` hook automatically exports your current
-`winget` package list.
+`winget` package list when commits run on Windows. On Linux or WSL the
+export is skipped unless `winget` is available.
 
 Licensed under the [Apache 2.0](LICENSE) license.


### PR DESCRIPTION
## Summary
- update pre-commit hook to run Winget export only on Windows
- add Linux skip logic with optional Winget usage
- document new pre-commit behavior

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856241a7b988326a295c529cac54de9