### PR TITLE
Add tests for PATH fix and WSL symlinks

### DIFF
--- a/tests/test_fix_path.py
+++ b/tests/test_fix_path.py
@@ -1,0 +1,45 @@
+import subprocess
+import shutil
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path('scripts/fix-path.ps1')
+
+def run_fix_path():
+    pwsh = shutil.which('pwsh')
+    if pwsh:
+        subprocess.run([pwsh, '-NoLogo', '-NoProfile', '-File', str(SCRIPT)], check=True)
+    else:
+        subprocess.run([
+            'powershell',
+            '-NoLogo',
+            '-NoProfile',
+            '-ExecutionPolicy', 'Bypass',
+            '-File', str(SCRIPT)
+        ], check=True)
+
+
+def test_run_fix_path_uses_pwsh_if_available(monkeypatch):
+    mock_run = mock.Mock()
+    monkeypatch.setattr(subprocess, 'run', mock_run)
+    monkeypatch.setattr(shutil, 'which', lambda cmd: '/usr/bin/pwsh' if cmd == 'pwsh' else None)
+    run_fix_path()
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert 'pwsh' in args[0]
+    assert args[-1].endswith('fix-path.ps1')
+
+
+def test_run_fix_path_falls_back_to_powershell(monkeypatch):
+    mock_run = mock.Mock()
+    monkeypatch.setattr(subprocess, 'run', mock_run)
+    monkeypatch.setattr(shutil, 'which', lambda cmd: None)
+    run_fix_path()
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert args[0] == 'powershell'
+    assert args[-1].endswith('fix-path.ps1')
+
+def test_fix_path_script_content():
+    text = SCRIPT.read_text(encoding='utf-8')
+    assert "SetEnvironmentVariable('Path'" in text

--- a/tests/test_setup_wsl.py
+++ b/tests/test_setup_wsl.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+from pathlib import Path
+
+def create_exe(path, contents="#!/usr/bin/env bash\n"):
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+def test_setup_wsl_symlinks(tmp_path):
+    fake_root = tmp_path
+    bin_dir = fake_root / "bin"
+    usr_local_bin = fake_root / "usr/local/bin"
+    bin_dir.mkdir(parents=True)
+    usr_local_bin.mkdir(parents=True)
+
+    # Stub commands
+    create_exe(bin_dir / "apt-get", "#!/usr/bin/env bash\nexit 0\n")
+    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n$@\n")
+    create_exe(bin_dir / "batcat")
+    create_exe(bin_dir / "fdfind")
+    # ln wrapper that redirects /usr/local/bin to FAKE_ROOT
+    ln_script = """#!/usr/bin/env bash
+last=${@: -1}
+if [[ $last == /usr/local/bin/* && -n $FAKE_ROOT ]]; then
+  dest=$FAKE_ROOT$last
+  mkdir -p $(dirname "$dest")
+  /bin/ln -sf ${@:1:$(($#-1))} "$dest"
+else
+  /bin/ln "$@"
+fi
+"""
+    create_exe(bin_dir / "ln", ln_script)
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "FAKE_ROOT": str(fake_root),
+    })
+
+    subprocess.run(["bash", "scripts/setup-wsl.sh"], check=True, env=env)
+
+    bat_link = usr_local_bin / "bat"
+    fd_link = usr_local_bin / "fd"
+    assert bat_link.is_symlink()
+    assert os.readlink(bat_link) == str(bin_dir / "batcat")
+    assert fd_link.is_symlink()
+    assert os.readlink(fd_link) == str(bin_dir / "fdfind")


### PR DESCRIPTION
## Summary
- add tests for PowerShell PATH update logic
- ensure setup-wsl.sh links bat and fd when batcat/fdfind exist

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68562423b5e88326aae299322a144c7a