### PR TITLE
Fix log snapshot when log file missing

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -70,6 +70,8 @@ class LoggedFewShotWrapper(dspy.Module):
 
     def snapshot_log_to_fewshot(self, replace: bool = False) -> None:
         """Copy logged data into the few-shot file."""
+        if not self._log_file.exists():
+            return
         mode = "w" if replace else "a"
         with self._fewshot_file.open(mode, encoding="utf-8") as out:
             with self._log_file.open(encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
- prevent `snapshot_log_to_fewshot()` from failing when no log file exists

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68562bf3b52c8326808d8b26c4d675e3