### PR TITLE
Fix quoting for export script

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,12 +1,13 @@
 #!/bin/sh
 set -e
+SCRIPT="scripts/export-winget.ps1"
 OS=$(uname -s)
 case "$OS" in
     CYGWIN*|MINGW*|MSYS*|Windows_NT)
         if command -v pwsh >/dev/null 2>&1; then
-            pwsh -NoLogo -NoProfile -File scripts/export-winget.ps1
+            pwsh -NoLogo -NoProfile -File "$SCRIPT"
         elif command -v powershell >/dev/null 2>&1; then
-            powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/export-winget.ps1
+            powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$SCRIPT"
         else
             echo "PowerShell is not installed" >&2
             exit 1


### PR DESCRIPTION
## Summary
- quote `scripts/export-winget.ps1` in the `pre-commit` hook
- centralize script path in a variable for clarity

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562bf905308326acb2d608916fb517