### PR TITLE
Fix JSON logging output handling

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -88,10 +88,12 @@ class LoggedFewShotWrapper(dspy.Module):
 
     def forward(self, **inputs):
         prediction = self.compiled(**inputs)
-        record = {
-            "inputs": inputs,
-            "outputs": getattr(prediction, "as_dict", lambda: prediction)(),
-        }
+        serialisable_output = (
+            prediction.as_dict() if hasattr(prediction, "as_dict") else str(prediction)
+        )
+
+        record = {"inputs": inputs, "outputs": serialisable_output}
+
         with self._log_file.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
         return prediction


### PR DESCRIPTION
## Summary
- fix universal_dspy_wrapper_v2 logging when predictions aren't JSON serializable

## Testing
- `pytest -q`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68562bf2a09c8326b33f1c20502d0479