### PR TITLE
Verify curl availability in setup-wsl

### DIFF
--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -10,7 +10,15 @@ sudo apt-get install -y \
     fzf \
     build-essential \
     starship \
-    zoxide
+    zoxide \
+    curl
+
+# Verify that curl is available; exit with a helpful message if not.
+if ! command -v curl >/dev/null; then
+    echo "Error: curl is required but could not be installed." >&2
+    echo "Please install curl using your package manager and re-run this script." >&2
+    exit 1
+fi
 
 # Ensure starship is available; install from the official script if apt didn't
 # provide it.


### PR DESCRIPTION
## Summary
- check that `curl` installed in `setup-wsl.sh`

## Testing
- `npm run lint`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562bfa7cf4832687a97eb2044848ae