### PR TITLE
Add warning when fix-path truncates PATH

### DIFF
--- a/scripts/fix-path.ps1
+++ b/scripts/fix-path.ps1
@@ -14,9 +14,15 @@ if ($unique -notcontains $userBin) {
     $unique += $userBin
 }
 
-$newPath = $unique -join ';'
+$joinedPath = $unique -join ';'
+$newPath = $joinedPath
+$originalCount = $unique.Count
 if ($newPath.Length -gt 1023) {
     $newPath = $newPath.Substring(0, 1023)
+}
+$finalCount = ($newPath -split ';').Count
+if ($finalCount -lt $originalCount) {
+    Write-Warning 'Some PATH entries were dropped due to size limitations.'
 }
 
 [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')


### PR DESCRIPTION
## Summary
- update `fix-path.ps1` to warn if PATH entries were dropped

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562bfde2fc8326b2e11eae24692849