### PR TITLE
Fix symlink quoting

### DIFF
--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -31,8 +31,8 @@ fi
 
 # Provide helpful symlinks for batcat and fdfind if they exist
 if command -v batcat >/dev/null && ! command -v bat >/dev/null; then
-    sudo ln -sf $(command -v batcat) /usr/local/bin/bat
+    sudo ln -sf "$(command -v batcat)" /usr/local/bin/bat
 fi
 if command -v fdfind >/dev/null && ! command -v fd >/dev/null; then
-    sudo ln -sf $(command -v fdfind) /usr/local/bin/fd
+    sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 fi


### PR DESCRIPTION
## Summary
- quote `command -v` results before passing to `ln -sf`

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68562bfec3348326afe4f2debbeb5c1d