### PR TITLE
Fix case-insensitive path deduplication

### DIFF
--- a/scripts/fix-path.ps1
+++ b/scripts/fix-path.ps1
@@ -1,17 +1,24 @@
 # Clean up and persist the user's PATH value
 $paths = $Env:Path -split ';'
 $unique = @()
+$uniqueLower = @()
 
 foreach ($p in $paths) {
     $trim = $p.Trim()
-    if ($trim -and $unique -notcontains $trim) {
+    if (-not $trim) { continue }
+
+    $lower = $trim.ToLower()
+    if ($uniqueLower -notcontains $lower) {
         $unique += $trim
+        $uniqueLower += $lower
     }
 }
 
 $userBin = Join-Path $Env:USERPROFILE 'bin'
-if ($unique -notcontains $userBin) {
+$userBinLower = $userBin.ToLower()
+if ($uniqueLower -notcontains $userBinLower) {
     $unique += $userBin
+    $uniqueLower += $userBinLower
 }
 
 $newPath = $unique -join ';'


### PR DESCRIPTION
## Summary
- avoid keeping duplicated PATH entries that only differ by case by normalizing to lowercase on membership checks

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68562c0621a48326881f0f377e1dac0d