### PR TITLE
Fix sudo stub to execute commands in WSL setup test

### DIFF
--- a/tests/test_setup_wsl.py
+++ b/tests/test_setup_wsl.py
@@ -16,7 +16,7 @@ def test_setup_wsl_symlinks(tmp_path):
 
     # Stub commands
     create_exe(bin_dir / "apt-get", "#!/usr/bin/env bash\nexit 0\n")
-    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n$@\n")
+    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n\"$@\"\n")
     create_exe(bin_dir / "batcat")
     create_exe(bin_dir / "fdfind")
     # ln wrapper that redirects /usr/local/bin to FAKE_ROOT


### PR DESCRIPTION
## Summary
- run the stubbed `sudo` command instead of printing arguments so it acts like a pass-through

## Testing
- `pytest -k test_setup_wsl_symlinks -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856c46d0e0c83268a12efeca675eec1