### PR TITLE
Improve fix-path.ps1 truncation handling

### DIFF
--- a/scripts/fix-path.ps1
+++ b/scripts/fix-path.ps1
@@ -16,6 +16,9 @@ if ($unique -notcontains $userBin) {
 
 $newPath = $unique -join ';'
 if ($newPath.Length -gt 1023) {
+    Write-Warning "PATH length exceeds 1023 characters and will be truncated."
+    $removed = $newPath.Substring(1023)
+    Write-Verbose "Removed portion: $removed" -Verbose
     $newPath = $newPath.Substring(0, 1023)
 }
 


### PR DESCRIPTION
## Summary
- warn when PATH exceeds 1023 characters before truncating
- output removed segment when running with `-Verbose`

## Testing
- `npm test`
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856c46eb63c8326b1d12cd56a5acaa4