### PR TITLE
Wrap winget export with error handling

### DIFF
--- a/scripts/export-winget.ps1
+++ b/scripts/export-winget.ps1
@@ -1,2 +1,7 @@
 # Export installed packages list using winget
-winget export -o winget-packages.json --accept-source-agreements
+try {
+    winget export -o "winget-packages.json" --accept-source-agreements
+} catch {
+    Write-Error "winget export failed: $_"
+    exit 1
+}


### PR DESCRIPTION
## Summary
- report errors when exporting packages on Windows

## Testing
- `npm test`
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856c46f7c788326b38425a555a31b77