### PR TITLE
Handle case-insensitive PATH entries

### DIFF
--- a/scripts/fix-path.ps1
+++ b/scripts/fix-path.ps1
@@ -1,17 +1,22 @@
 # Clean up and persist the user's PATH value
 $paths = $Env:Path -split ';'
 $unique = @()
+$uniqueLower = @()
 
 foreach ($p in $paths) {
     $trim = $p.Trim()
-    if ($trim -and $unique -notcontains $trim) {
+    $lower = $trim.ToLower()
+    if ($trim -and $uniqueLower -notcontains $lower) {
         $unique += $trim
+        $uniqueLower += $lower
     }
 }
 
 $userBin = Join-Path $Env:USERPROFILE 'bin'
-if ($unique -notcontains $userBin) {
+$userBinLower = $userBin.ToLower()
+if ($uniqueLower -notcontains $userBinLower) {
     $unique += $userBin
+    $uniqueLower += $userBinLower
 }
 
 $newPath = $unique -join ';'

--- a/tests/test_fix_path.py
+++ b/tests/test_fix_path.py
@@ -43,3 +43,4 @@ def test_run_fix_path_falls_back_to_powershell(monkeypatch):
 def test_fix_path_script_content():
     text = SCRIPT.read_text(encoding='utf-8')
     assert "SetEnvironmentVariable('Path'" in text
+    assert '.ToLower()' in text


### PR DESCRIPTION
## Summary
- dedupe PATH entries ignoring case in `fix-path.ps1`
- check for lowercase normalization in test suite

## Testing
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856c47228e48326b5ad67cdf9139d9e