### PR TITLE
Add script to configure git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ For a more detailed overview, see [docs/terminal.md](docs/terminal.md).
 
 ## Git hooks
 
-Run the following to enable the local hooks:
+Run `scripts/setup-hooks.sh` to enable the local hooks automatically
+(equivalent to running `git config core.hooksPath .githooks`):
 
 ```bash
-git config core.hooksPath .githooks
+./scripts/setup-hooks.sh
 ```
 
 Once enabled, the `pre-commit` hook automatically exports your current

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configure Git to use local hooks directory
+git config core.hooksPath .githooks
+
+echo "Git hooks enabled using .githooks"


### PR DESCRIPTION
## Summary
- add `scripts/setup-hooks.sh` for enabling hooks
- document running the script in the README

## Testing
- `npm install`
- `npm run lint`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685789d489488326a204d5d2e0e5802f