### PR TITLE
Update fix-path script for USERPROFILE handling

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,11 +10,12 @@ Follow these steps to set up the configuration files on a new system.
    ```
 2. Copy or symlink the files from this repository to your profile directory.
 3. Restart the terminal to load the new settings.
-4. If your PATH looks incorrect, run the following from an elevated PowerShell prompt:
+4. After installing everything, or whenever you notice duplicate or missing entries in your PATH, run the following from an elevated PowerShell prompt:
    ```powershell
    scripts/fix-path.ps1
    ```
-   The script cleans up duplicate entries and ensures `%USERPROFILE%\bin` is included.
+   The script cleans up duplicate entries and ensures your `bin` directory is included.
+   If `$Env:USERPROFILE` isn't defined (e.g. on Linux), it falls back to `$HOME`.
 
 ## WSL
 

--- a/scripts/fix-path.ps1
+++ b/scripts/fix-path.ps1
@@ -13,12 +13,25 @@ foreach ($p in $paths) {
     }
 }
 
-$userBin = Join-Path $Env:USERPROFILE 'bin'
-$userBinLower = $userBin.ToLower()
-if ($uniqueLower -notcontains $userBinLower) {
-    $unique += $userBin
-    $uniqueLower += $userBinLower
+$userProfile = $Env:USERPROFILE
+if (-not $userProfile) {
+    $userProfile = $Env:HOME
+}
+if (-not $userProfile) {
+    try {
+        $userProfile = [Environment]::GetFolderPath('UserProfile')
+    } catch {
+        $userProfile = $null
+    }
+}
+if ($userProfile) {
+    $userBin = Join-Path $userProfile 'bin'
+    $userBinLower = $userBin.ToLower()
+    if ($uniqueLower -notcontains $userBinLower) {
+        $unique += $userBin
+        $uniqueLower += $userBinLower
 
+    }
 }
 
 $joinedPath = $unique -join ';'


### PR DESCRIPTION
## Summary
- handle missing `USERPROFILE` when running `scripts/fix-path.ps1`
- mention the new fallback in the installation instructions

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685789d1c34c8326a042ed751ca4a721