### PR TITLE
Expand starship example configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ winget-packages.lock.json
 
 # Python cache
 __pycache__/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Key directories:
 - `powershell/` – PowerShell profile scripts
 - `windows-terminal/` – starter Windows Terminal settings
 - `tablet-config/` – full example configuration for a tablet, including Windows Terminal
-- `starship.toml` – minimal Starship prompt configuration
+- `starship.toml` – example Starship prompt configuration
 - `vscode/` – VS Code user settings
 - `llm/` – prompts and other LLM-related files
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -89,7 +89,7 @@ This repository includes example setups for various tools:
 - `dotfiles/work_laptop` – configs for a work laptop.
 - `windows-terminal` – minimal starter `settings.json` for Windows Terminal.
 - `tablet-config/windows-terminal` – full example configuration for a tablet.
-- `starship.toml` – minimal Starship prompt configuration.
+- `starship.toml` – example Starship prompt configuration.
 - `vscode` – basic VS Code user settings.
 
 ### Linking on macOS/Linux

--- a/starship.toml
+++ b/starship.toml
@@ -1,1 +1,11 @@
-format = "$directory$git_branch$character"
+# Example Starship prompt configuration
+format = "$time$directory$git_branch$git_status$character"
+
+[time]
+disabled = false
+style = "dimmed cyan"
+time_format = "%R "
+
+[git_status]
+disabled = false
+style = "bold green"

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_starship_has_time_and_git_status():
+    text = Path('starship.toml').read_text(encoding='utf-8')
+    assert '[time]' in text
+    assert '[git_status]' in text


### PR DESCRIPTION
## Summary
- expand starship config with `[time]` and `[git_status]`
- verify these sections exist
- clarify README and docs referencing the example configuration

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685789ddbc008326b954f9029095fa1e