### PR TITLE
Update Windows Terminal schema and tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,11 +14,15 @@ def load_json(path: Path):
 def test_windows_terminal_settings():
     data = load_json(Path('windows-terminal') / 'settings.json')
     assert 'profiles' in data
+    assert 'actions' in data
+    assert data['profiles']['list']
 
 
 def test_tablet_windows_terminal():
     data = load_json(Path('tablet-config/windows-terminal') / 'settings.json')
     assert '$schema' in data
+    assert 'profiles' in data
+    assert 'actions' in data
 
 
 def test_load_json5(tmp_path):

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -1,12 +1,78 @@
 {
+    "$help": "https://aka.ms/terminal-documentation",
+    "$schema": "https://aka.ms/terminal-profiles-schema",
+    "actions": 
+    [
+        {
+            "command": 
+            {
+                "action": "globalSummon",
+                "desktop": "any",
+                "monitor": "any",
+                "name": "_quake"
+            },
+            "id": "User.globalSummon.90584B03"
+        }
+    ],
+    "copyFormatting": "none",
+    "copyOnSelect": false,
     "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-    "profiles": {
-        "defaults": {
-            "font": {
+    "keybindings": 
+    [
+        {
+            "id": "User.globalSummon.90584B03",
+            "keys": "ctrl+;"
+        }
+    ],
+    "newTabMenu": 
+    [
+        {
+            "type": "remainingProfiles"
+        }
+    ],
+    "profiles": 
+    {
+        "defaults": 
+        {
+            "compatibility.input.forceVT": true,
+            "font": 
+            {
                 "face": "CascaydiaCove Nerd Font",
-                "size": 11
-            }
+                "weight": "normal"
+            },
+            "intenseTextStyle": "bold",
+            "opacity": 20,
+            "useAcrylic": true,
+            "textAntialiasing": "grayscale"
         },
-        "list": []
-    }
+        "list": 
+        [
+            {
+                "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                "hidden": false,
+                "name": "PowerShell",
+                "source": "Windows.Terminal.PowershellCore"
+            },
+            {
+                "guid": "{1857054d-df21-5f4a-bd44-865a14a14d59}",
+                "hidden": false,
+                "name": "Ubuntu",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "commandline": "%SystemRoot%\\System32\\cmd.exe",
+                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+                "hidden": false,
+                "name": "Command Prompt"
+            },
+            {
+                "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+                "hidden": false,
+                "name": "Windows PowerShell"
+            }
+        ]
+    },
+    "schemes": [],
+    "themes": [],
+    "useAcrylicInTabRow": true
 }


### PR DESCRIPTION
## Summary
- expand `windows-terminal/settings.json` to full schema
- validate profiles and actions in unit tests

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685789dc140c832689fcc1b175422add