### PR TITLE
Fix zoxide init ordering in user_profile

### DIFF
--- a/powershell/user_profile.ps1
+++ b/powershell/user_profile.ps1
@@ -8,13 +8,13 @@ if (Get-Command starship -ErrorAction SilentlyContinue) {
 # posh-git (branch + status decorations)
 Import-Module posh-git -ErrorAction SilentlyContinue
 
-# zoxide smart cd (if installed)
-if (Get-Command zoxide -ErrorAction SilentlyContinue) {
-    Invoke-Expression ((& zoxide init powershell) -join "`n")
-}
 # fzf tab-completion
 if (Get-Module -ListAvailable -Name PSReadLine) {
     Import-Module PSReadLine
     Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
+}
+# zoxide smart cd (if installed)
+if (Get-Command zoxide -ErrorAction SilentlyContinue) {
+    Invoke-Expression ((& zoxide init powershell) -join "`n")
 }
 # ========================================================================

--- a/tests/test_powershell.py
+++ b/tests/test_powershell.py
@@ -13,3 +13,18 @@ def test_user_profile_contains_required_commands():
     assert any("starship" in line.lower() for line in lines), "starship invocation missing"
     assert any("posh-git" in line.lower() for line in lines), "posh-git invocation missing"
     assert any("zoxide" in line.lower() for line in lines), "zoxide invocation missing"
+
+
+def test_zoxide_after_fzf_block():
+    """Ensure zoxide initialization occurs after the fzf setup."""
+    lines = USER_PROFILE_PATH.read_text().splitlines()
+    fzf_index = None
+    zoxide_index = None
+    for idx, line in enumerate(lines):
+        if "Set-PSReadLineKeyHandler" in line:
+            fzf_index = idx
+        if "zoxide init powershell" in line:
+            zoxide_index = idx
+    assert fzf_index is not None, "fzf block not found"
+    assert zoxide_index is not None, "zoxide init not found"
+    assert zoxide_index > fzf_index, "zoxide initialization should follow fzf block"


### PR DESCRIPTION
## Summary
- move zoxide initialization to end of profile
- keep starship and posh-git sections intact
- enforce zoxide ordering in tests

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685789e023e88326a3421029383f3a4b