### PR TITLE
Add split pane shortcuts

### DIFF
--- a/windows-terminal/README.md
+++ b/windows-terminal/README.md
@@ -6,3 +6,6 @@ To install these settings automatically, run
 `scripts/install-windows-terminal.ps1` from the repository root. The script
 creates `%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState`
 if needed and copies `settings.json` there.
+
+The settings define `Alt+V` to split the active pane vertically and `Alt+H` to
+split it horizontally.

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -1,5 +1,15 @@
 {
     "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+    "actions": [
+        {
+            "command": { "action": "splitPane", "split": "vertical" },
+            "keys": "alt+v"
+        },
+        {
+            "command": { "action": "splitPane", "split": "horizontal" },
+            "keys": "alt+h"
+        }
+    ],
     "profiles": {
         "defaults": {
             "font": {


### PR DESCRIPTION
## Summary
- add split pane keybindings to the Windows Terminal settings
- document the new shortcuts in the Windows Terminal README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685789e739ac8326927e888ccabfba74