### PR TITLE
Add config checks and sample updates

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -1,1 +1,8 @@
 format = "$directory$git_branch$character"
+
+[time]
+disabled = false
+format = "[$time]($style) "
+
+[git_status]
+disabled = false

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,9 @@ def load_json(path: Path):
 def test_windows_terminal_settings():
     data = load_json(Path('windows-terminal') / 'settings.json')
     assert 'profiles' in data
+    profiles = data['profiles'].get('list', [])
+    assert len(profiles) > 0, "no profiles configured"
+    assert 'actions' in data and data['actions'], "action bindings missing"
 
 
 def test_tablet_windows_terminal():

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -1,0 +1,9 @@
+import tomllib
+from pathlib import Path
+
+
+def test_starship_time_and_git_status_sections():
+    data = tomllib.loads(Path('starship.toml').read_text())
+    assert 'time' in data, '[time] section missing'
+    assert 'git_status' in data, '[git_status] section missing'
+

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -1,5 +1,12 @@
 {
+    "$schema": "https://aka.ms/terminal-profiles-schema",
     "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+    "actions": [
+        {
+            "command": { "action": "paste" },
+            "keys": "ctrl+v"
+        }
+    ],
     "profiles": {
         "defaults": {
             "font": {
@@ -7,6 +14,12 @@
                 "size": 11
             }
         },
-        "list": []
+        "list": [
+            {
+                "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                "name": "PowerShell",
+                "source": "Windows.Terminal.PowershellCore"
+            }
+        ]
     }
 }


### PR DESCRIPTION
## Summary
- update `windows-terminal/settings.json` to include actions and a profile
- extend tests for Windows Terminal configuration
- add `[time]` and `[git_status]` sections to `starship.toml`
- add tests checking the Starship configuration

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685789eb22f88326990cba32e533921e