### PR TITLE
Add Quickstart and package checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Verify Python packages
+        run: |
+          python - <<'PY'
+          import importlib, sys
+          required = ["dspy", "pytest", "json5"]
+          missing = [p for p in required if importlib.util.find_spec(p) is None]
+          if missing:
+              print("Missing packages:", ", ".join(missing))
+              sys.exit(1)
+          PY
       - name: Run tests
         run: pytest -q
       - name: Run lint

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Key directories:
 - `vscode/` – VS Code user settings
 - `llm/` – prompts and other LLM-related files
 
+## Quickstart
+
+Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
 See the [installation guide](docs/installation.md) for setup instructions.
 If your PATH isn't updating correctly on Windows, run
 `scripts/fix-path.ps1` from an elevated PowerShell prompt.


### PR DESCRIPTION
## Summary
- add a Quickstart section to README
- verify required Python packages in CI

## Testing
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685789ec798c8326aa473f88dc689fc7