### PR TITLE
Add read-only token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- set `contents: read` workflow permission

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68578c1a7ae48326b83ba8068c8d5c13