### PR TITLE
Add caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          npm ci
       - name: Run tests
         run: pytest -q
       - name: Run lint
-        run: |
-          npm install
-          npm run lint
+        run: npm run lint


### PR DESCRIPTION
## Summary
- enable pip caching in Python setup
- add Node setup with npm caching
- install npm packages once during dependency step
- run lint without npm install

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68578c1c10308326bd24a857a19d3fb0