### PR TITLE
Add split pane bindings

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,28 @@ def test_windows_terminal_settings():
     assert 'actions' in data and data['actions'], "action bindings missing"
 
 
+def test_windows_terminal_split_bindings():
+    """The starter settings should bind Alt+V and Alt+H for pane splitting."""
+    data = load_json(Path('windows-terminal') / 'settings.json')
+    actions = data.get('actions', [])
+
+    def find_binding(key):
+        for action in actions:
+            if action.get('keys') == key:
+                return action
+        return None
+
+    binding_v = find_binding('alt+v')
+    assert binding_v, 'Alt+V binding missing'
+    assert binding_v.get('command', {}).get('action') == 'splitPane'
+    assert binding_v.get('command', {}).get('split') == 'vertical'
+
+    binding_h = find_binding('alt+h')
+    assert binding_h, 'Alt+H binding missing'
+    assert binding_h.get('command', {}).get('action') == 'splitPane'
+    assert binding_h.get('command', {}).get('split') == 'horizontal'
+
+
 
 def test_tablet_windows_terminal():
     data = load_json(Path('tablet-config/windows-terminal') / 'settings.json')

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -6,6 +6,14 @@
             "command": { "action": "paste" },
             "keys": "ctrl+v"
 
+        },
+        {
+            "command": { "action": "splitPane", "split": "vertical" },
+            "keys": "alt+v"
+        },
+        {
+            "command": { "action": "splitPane", "split": "horizontal" },
+            "keys": "alt+h"
         }
     ],
     "profiles": {


### PR DESCRIPTION
## Summary
- add Windows Terminal split-pane shortcuts
- verify them in tests

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a101f69083268b49530d450ce3ad