### PR TITLE
Fix UTF-8 file handling

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -45,7 +45,7 @@ class LoggedFewShotWrapper(dspy.Module):
 
         trainset: List[dspy.Example] = []
         if self._fewshot_file.exists():
-            with self._fewshot_file.open() as fh:
+            with self._fewshot_file.open(encoding="utf-8") as fh:
                 for line in fh:
                     obj = json.loads(line)
                     ex = dspy.Example(**obj.get("inputs", obj), **obj.get("outputs", {}))

--- a/tests/test_utf8.py
+++ b/tests/test_utf8.py
@@ -1,0 +1,15 @@
+import json
+import dspy
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+
+def test_logged_fewshot_wrapper_reads_utf8(tmp_path):
+    data = {"inputs": {"x": "café"}, "outputs": {"y": "naïve"}}
+    fewshot_file = tmp_path / "Dummy_fewshot.jsonl"
+    fewshot_file.write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    class Dummy(dspy.Module):
+        def forward(self, x):
+            return x
+
+    wrapper = LoggedFewShotWrapper(Dummy(), fewshot_dir=tmp_path, log_dir=tmp_path)
+    assert wrapper._trainset[0].x == "café"


### PR DESCRIPTION
## Summary
- open fewshot file with UTF-8 encoding in `LoggedFewShotWrapper`
- add regression test reading non-ASCII UTF-8 data

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a108b53483268fbbe78c4447a0c5