### PR TITLE
Handle log write failures

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -10,6 +10,7 @@ import json
 import shutil
 from pathlib import Path
 from typing import Callable, List, Type
+import warnings
 
 import dspy
 from dspy.teleprompt import LabeledFewShot
@@ -97,6 +98,9 @@ class LoggedFewShotWrapper(dspy.Module):
 
         record = {"inputs": inputs, "outputs": serialisable_output}
 
-        with self._log_file.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        try:
+            with self._log_file.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except OSError as exc:
+            warnings.warn(f"Failed to write log data: {exc}")
         return prediction

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -1,0 +1,29 @@
+import warnings
+from pathlib import Path
+
+import dspy
+import pytest
+
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+
+
+class DummyModule(dspy.Module):
+    def forward(self, text: str):
+        return text.upper()
+
+
+def test_forward_write_failure(monkeypatch, tmp_path):
+    wrapper = LoggedFewShotWrapper(DummyModule(), log_dir=tmp_path, fewshot_dir=tmp_path)
+    original_open = Path.open
+
+    def fake_open(self, *args, **kwargs):
+        if self == wrapper._log_file:
+            raise OSError("fail")
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", fake_open)
+    with warnings.catch_warnings(record=True) as w:
+        result = wrapper.forward(text="hello")
+    assert result == "HELLO"
+    assert any("Failed to write log data" in str(warn.message) for warn in w)
+


### PR DESCRIPTION
## Summary
- handle failures when logging predictions by catching `OSError`
- warn instead of raising when the log file can't be written
- test wrapper resilience to `OSError` when writing logs

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a10a98688326a5b4122b4f5a96a5