### PR TITLE
Fix recompilation and clean up test

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -80,7 +80,9 @@ class LoggedFewShotWrapper(dspy.Module):
 
     def recompile_from_fewshot(self) -> None:
         """Reload few-shot data from file and recompile."""
-        self.__init__(
+        # Recreate a fresh instance to avoid duplicating initialization
+        # side effects such as optimizer state or file handles.
+        new_instance = self.__class__(
             self.wrapped,
             optimiser_cls=self.optimiser_cls,
             optimiser_kwargs=self.optimiser_kwargs,
@@ -88,6 +90,9 @@ class LoggedFewShotWrapper(dspy.Module):
             log_dir=self.log_dir,
             fewshot_dir=self.fewshot_dir,
         )
+        # Replace all internal state with the freshly created instance.
+        self.__dict__.clear()
+        self.__dict__.update(new_instance.__dict__)
 
     def forward(self, **inputs):
         prediction = self.compiled(**inputs)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,40 @@
+import dspy
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+
+class EchoPrediction:
+    def __init__(self, text: str) -> None:
+        self.out = text
+
+    def as_dict(self):
+        return {"out": self.out}
+
+class EchoModule(dspy.Module):
+    def forward(self, text: str):
+        return EchoPrediction(text.upper())
+
+def test_multiple_recompilations(tmp_path):
+    log_dir = tmp_path / "logs"
+    fewshot_dir = tmp_path / "fewshot"
+    wrapper = LoggedFewShotWrapper(
+        EchoModule(),
+        log_dir=log_dir,
+        fewshot_dir=fewshot_dir,
+    )
+
+    # Log a single example
+    wrapper(text="hello")
+    wrapper.snapshot_log_to_fewshot(replace=True)
+    wrapper.recompile_from_fewshot()
+    first_trainset_size = len(wrapper._trainset)
+    first_compiled_id = id(wrapper.compiled)
+
+    # Recompile again; should not raise and trainset size should remain
+    wrapper.recompile_from_fewshot()
+    assert len(wrapper._trainset) == first_trainset_size == 1
+    second_compiled_id = id(wrapper.compiled)
+    assert second_compiled_id != first_compiled_id
+
+    # A third recompile for good measure
+    wrapper.recompile_from_fewshot()
+    assert len(wrapper._trainset) == 1
+    assert id(wrapper.compiled) != second_compiled_id


### PR DESCRIPTION
## Summary
- reset wrapper state when recompiling
- extend regression test for repeated recompilation

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857a0ffe4308326a56efa3cd2d5a8b9