### PR TITLE
Handle missing sudo when running as root

### DIFF
--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure sudo is available before attempting any privileged commands
+if ! command -v sudo >/dev/null; then
+    if [ "$(id -u)" -eq 0 ]; then
+        sudo() { "$@"; }
+    else
+        echo "Error: sudo is required but not installed." >&2
+        echo "Please install sudo using your package manager and re-run this script." >&2
+        exit 1
+    fi
+fi
+
 sudo apt-get update
 sudo apt-get install -y \
     git \

--- a/tests/test_setup_wsl.py
+++ b/tests/test_setup_wsl.py
@@ -15,7 +15,7 @@ def test_setup_wsl_symlinks(tmp_path):
     usr_local_bin.mkdir(parents=True)
 
     # Stub commands
-    create_exe(bin_dir / "apt-get", "#!/usr/bin/env bash\nexit 0\n")
+    create_exe(bin_dir / "apt-get", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n\"$@\"\n")
     create_exe(bin_dir / "batcat")
     create_exe(bin_dir / "fdfind")
@@ -46,4 +46,51 @@ fi
     assert os.readlink(bat_link) == str(bin_dir / "batcat")
     assert fd_link.is_symlink()
     assert os.readlink(fd_link) == str(bin_dir / "fdfind")
+
+
+def test_setup_wsl_requires_sudo(tmp_path):
+    fake_root = tmp_path
+    bin_dir = fake_root / "bin"
+    bin_dir.mkdir(parents=True)
+
+    # Stub commands so the script doesn't try to run the real ones
+    create_exe(bin_dir / "apt-get", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "starship", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zoxide", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "id", "#!/bin/sh\necho 1000\n")
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": str(bin_dir),
+    })
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-wsl.sh"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "sudo is required" in result.stderr
+
+
+def test_setup_wsl_root_without_sudo(tmp_path):
+    fake_root = tmp_path
+    bin_dir = fake_root / "bin"
+    bin_dir.mkdir(parents=True)
+
+    create_exe(bin_dir / "apt-get", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "starship", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zoxide", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "id", "#!/bin/sh\necho 0\n")
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": str(bin_dir),
+    })
+
+    subprocess.run(["/bin/bash", "scripts/setup-wsl.sh"], check=True, env=env)
    


### PR DESCRIPTION
## Summary
- exit only when sudo is missing and not running as root
- alias sudo to no-op when running as root
- expand tests to stub required commands
- check root scenario without sudo

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857a10ebfd88326b79e68b3dcd7dac1