### PR TITLE
Add winget validation script

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -26,3 +26,6 @@ case "$OS" in
         echo "Skipping winget export on unsupported OS: $OS"
         ;;
 esac
+
+# Validate winget-packages.json after export
+python scripts/validate_winget.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,5 @@ jobs:
         run: pytest -q
       - name: Run lint
         run: npm run lint
+      - name: Validate winget packages
+        run: python scripts/validate_winget.py

--- a/scripts/validate_winget.py
+++ b/scripts/validate_winget.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Validate ``winget-packages.json`` contains sources with packages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def validate(path: Path) -> bool:
+    """Return ``True`` when ``path`` is a valid packages file."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to parse {path}: {exc}", file=sys.stderr)
+        return False
+
+    sources = data.get("Sources")
+    if not isinstance(sources, list) or not sources:
+        print(f"{path} has no sources", file=sys.stderr)
+        return False
+
+    for idx, source in enumerate(sources):
+        if not isinstance(source, dict):
+            print(f"{path} source index {idx} is not an object", file=sys.stderr)
+            return False
+        packages = source.get("Packages")
+        if not isinstance(packages, list) or not packages:
+            name = source.get("Name", f"index {idx}")
+            print(f"{path} source {name} has no packages", file=sys.stderr)
+            return False
+
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", default="winget-packages.json")
+    args = parser.parse_args(argv)
+    return 0 if validate(Path(args.path)) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_winget.py
+++ b/tests/test_validate_winget.py
@@ -1,0 +1,15 @@
+import subprocess
+from pathlib import Path
+import sys
+
+
+def test_validate_winget_malformed(tmp_path: Path) -> None:
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{ invalid json }", encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_winget.py", str(bad_json)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Failed to parse" in result.stderr


### PR DESCRIPTION
## Summary
- add `validate_winget.py` helper under `scripts/`
- check winget packages in pre-commit and CI
- test malformed JSON handling
- refine validation logic and CLI

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/validate_winget.py`


------
https://chatgpt.com/codex/tasks/task_e_6857a112129483268c55e266f6ab496b