### PR TITLE
Add fastfetch and btm config defaults

### DIFF
--- a/dotfiles/btm/config.toml
+++ b/dotfiles/btm/config.toml
@@ -1,0 +1,3 @@
+# Default configuration for bottom (btm)
+# update_rate: refresh interval in milliseconds
+update_rate = 1000

--- a/dotfiles/fastfetch/config.conf
+++ b/dotfiles/fastfetch/config.conf
@@ -1,0 +1,3 @@
+# Default configuration for fastfetch
+# show_logo: controls whether to display the distribution logo
+show_logo=true

--- a/tests/test_dotfiles.py
+++ b/tests/test_dotfiles.py
@@ -12,7 +12,12 @@ def has_non_comment_line(path: str) -> bool:
 
 
 def test_dotfiles_have_non_comment_lines():
-    for folder in ("dotfiles/desktop", "dotfiles/work_laptop"):
+    for folder in (
+        "dotfiles/desktop",
+        "dotfiles/work_laptop",
+        "dotfiles/fastfetch",
+        "dotfiles/btm",
+    ):
         for file_path in glob.glob(os.path.join(folder, "*")):
             assert os.path.isfile(file_path), f"{file_path} should exist"
             assert has_non_comment_line(


### PR DESCRIPTION
## Summary
- add configuration placeholders for fastfetch and btm
- ensure dotfiles tests check fastfetch and btm directories

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a8874f9c83268d36889dd7f2411e