### PR TITLE
Drop Path import in WSL test

### DIFF
--- a/tests/test_setup_wsl.py
+++ b/tests/test_setup_wsl.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from pathlib import Path
 
 def create_exe(path, contents="#!/usr/bin/env bash\n"):
     path.write_text(contents)

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -2,7 +2,7 @@ import warnings
 from pathlib import Path
 
 import dspy
-import pytest
+import pytest  # noqa: F401
 
 from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 


### PR DESCRIPTION
## Summary
- remove unused `Path` import from `test_setup_wsl.py`
- clarify the `pytest` import in `test_universal_dspy_wrapper_v2.py`
- run linters and tests

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857a85b628c8326bdd55cf66be26194