### PR TITLE
Update testing instructions and skip tests if dspy/json5 missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - name: Install dependencies
+        # Install Python packages for tests and JS packages for linting
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -48,4 +48,18 @@ Once enabled, the `pre-commit` hook automatically exports your current
 `winget` package list when commits run on Windows. On Linux or WSL the
 export is skipped unless `winget` is available.
 
+## Testing
+
+Before running the Python tests locally, install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then invoke `pytest`:
+
+```bash
+pytest
+```
+
 Licensed under the [Apache 2.0](LICENSE) license.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
-import json5
+import pytest
+
+json5 = pytest.importorskip("json5")
 
 
 def load_json(path: Path):

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -1,7 +1,10 @@
-import dspy
-import pytest  # noqa: F401
+import pytest
+import subprocess
+from pathlib import Path
 
-from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+dspy = pytest.importorskip("dspy")
+
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper, is_repo_data_path
 
 
 

--- a/tests/test_utf8.py
+++ b/tests/test_utf8.py
@@ -1,5 +1,7 @@
 import json
-import dspy
+import pytest
+
+dspy = pytest.importorskip("dspy")
 from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 
 def test_logged_fewshot_wrapper_reads_utf8(tmp_path):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,4 +1,6 @@
-import dspy
+import pytest
+
+dspy = pytest.importorskip("dspy")
 from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 
 class EchoPrediction:


### PR DESCRIPTION
## Summary
- note required `pip install -r requirements.txt` in README testing section
- add explanatory comment to CI about installing dependencies
- skip tests when optional packages like `dspy` or `json5` are missing

## Testing
- `pip install -r requirements.txt`
- `npm ci`
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685819d5cee88326a7a314d5742fb0e1