### PR TITLE
Fix path matching in Universal DSPy wrapper

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -28,13 +28,14 @@ _REPO_ROOT = Path(
 )
 
 _PATH_REGEX = re.compile(
-    rf"^(?P<root>{re.escape(str(_REPO_ROOT))})/.+(?P<data>[^/]+\.(?:ya?ml|json))$"
+    rf"^(?P<root>{re.escape(_REPO_ROOT.as_posix())})/.+(?P<data>[^/]+\.(?:ya?ml|json))$"
 )
 
 
 def is_repo_data_path(path: str | Path) -> bool:
     """Return True if ``path`` is within the repo and ends with an allowed extension."""
-    return bool(_PATH_REGEX.match(str(path)))
+    normalised = Path(path).as_posix().replace("\\", "/")
+    return bool(_PATH_REGEX.match(normalised))
 
 
 class LoggedFewShotWrapper(dspy.Module):

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -1,7 +1,9 @@
 import dspy
 import pytest  # noqa: F401
+from pathlib import Path
+import subprocess
 
-from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper, is_repo_data_path, _REPO_ROOT
 
 
 
@@ -37,4 +39,12 @@ def test_is_repo_data_path_valid(tmp_path):
     assert is_repo_data_path(valid)
     assert not is_repo_data_path(invalid_root)
     assert not is_repo_data_path(invalid_ext)
+
+
+def test_is_repo_data_path_windows_and_posix():
+    posix_path = Path(f"{_REPO_ROOT.as_posix()}/file.json")
+    windows_path = Path(str(_REPO_ROOT).replace("/", "\\") + "\\file.json")
+
+    assert is_repo_data_path(posix_path)
+    assert is_repo_data_path(windows_path)
 


### PR DESCRIPTION
## Summary
- normalize Path objects to POSIX form before regex matching
- ensure windows-style paths are accepted in is_repo_data_path
- test path recognition for POSIX and Windows forms

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685819d37d54832684f71d615660577b