### PR TITLE
Add fix-path integration test

### DIFF
--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -1,7 +1,9 @@
 import dspy
 import pytest  # noqa: F401
+from pathlib import Path
+import subprocess
 
-from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper, is_repo_data_path
 
 
 


### PR DESCRIPTION
## Summary
- add helper to capture fix-path.ps1 output
- verify PATH deduplication via subprocess
- fix missing imports in universal dspy wrapper tests
- read only last line from Powershell output

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68581a00a6988326afe8229f058baee7