### PR TITLE
Add pyproject packaging and editable install fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -e . -r requirements.txt
           npm ci
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install the required Python packages (including test utilities such as
 `pytest` and `json5`):
 
 ```bash
-pip install -r requirements.txt
+pip install -e . -r requirements.txt
 ```
 
 You can then run the test suite to verify the configuration:

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -14,7 +14,7 @@ This document outlines how the repository manages tasks related to local AI work
 2. Install the required Python packages:
 
    ```bash
-   pip install -r requirements.txt
+   pip install -e . -r requirements.txt
    ```
 
 `dspy` powers the local LLM wrapper found in `llm/`, while `pytest` runs the test suite.

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,5 @@
+"""Local LLM utilities."""
+
+from .universal_dspy_wrapper_v2 import LoggedFewShotWrapper, is_repo_data_path
+
+__all__ = ["LoggedFewShotWrapper", "is_repo_data_path"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llm"
+version = "0.1.0"
+description = "Local LLM utilities"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = ["dspy"]
+
+[project.optional-dependencies]
+test = ["pytest", "json5"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["llm*"]

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -1,7 +1,9 @@
 import dspy
 import pytest  # noqa: F401
+from pathlib import Path
+import subprocess
 
-from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper, is_repo_data_path
 
 
 


### PR DESCRIPTION
## Summary
- expose `LoggedFewShotWrapper` via `llm` package
- define package metadata and dependencies in `pyproject.toml`
- install package in editable mode in docs and CI
- fix missing imports in tests
- add package discovery configuration

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685819e0db148326b4c772e815c32514