### PR TITLE
Update docs for fix-path script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ pytest
 
 
 See the [installation guide](docs/installation.md) for setup instructions.
-If your PATH isn't updating correctly on Windows, run
-`scripts/fix-path.ps1` from an elevated PowerShell prompt.
+After cloning the repository, run `scripts/fix-path.ps1` from an elevated
+PowerShell prompt to ensure your PATH is configured correctly.
 For a more detailed overview, see [docs/terminal.md](docs/terminal.md).
 For details on fastfetch, btm and Nushell/Starship setup, see the [Terminal Tools section](docs/terminal.md#terminal-tools-fastfetch-btm--nushellstarship).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,13 +20,17 @@ Alternatively, download the official installer from [nodejs.org](https://nodejs.
    winget import winget-packages.json
    ```
 2. Copy or symlink the files from this repository to your profile directory.
-3. Restart the terminal to load the new settings.
-4. After installing everything, or whenever you notice duplicate or missing entries in your PATH, run the following from an elevated PowerShell prompt:
+3. Run the PATH cleanup script from an elevated PowerShell prompt:
    ```powershell
    scripts/fix-path.ps1
    ```
    The script cleans up duplicate entries and ensures your `bin` directory is included.
    If `$Env:USERPROFILE` isn't defined (e.g. on Linux), it falls back to `$HOME`.
+   You can also call this automatically from a `bootstrap.ps1` script:
+   ```powershell
+   & "$PSScriptRoot/scripts/fix-path.ps1"
+   ```
+4. Restart the terminal to load the new settings.
 
 ## WSL
 
@@ -45,4 +49,8 @@ sudo bash scripts/setup-wsl.sh
    git clone https://github.com/d0tTino/d0tTino.git
    ```
 2. Use `stow` or your preferred method to symlink the dotfiles into place.
-3. Launch a new shell to pick up the configuration.
+3. Run the PATH cleanup script:
+   ```powershell
+   scripts/fix-path.ps1
+   ```
+4. Launch a new shell to pick up the configuration.


### PR DESCRIPTION
## Summary
- instruct running `scripts/fix-path.ps1` after cloning in README and docs
- add optional snippet for running the script automatically from `bootstrap.ps1`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859f5d3636c8326bdd148aa70725097