### PR TITLE
Handle git root detection failure

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -18,14 +18,21 @@ import warnings
 import dspy
 from dspy.teleprompt import LabeledFewShot
 
-_REPO_ROOT = Path(
-    subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-)
+try:
+    _REPO_ROOT = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+    warnings.warn(
+        f"Git repo root detection failed: {exc}. Falling back to current working directory.",
+        RuntimeWarning,
+    )
+    _REPO_ROOT = Path.cwd()
 
 _PATH_REGEX = re.compile(
     rf"^(?P<root>{re.escape(_REPO_ROOT.as_posix())})/.+(?P<data>[^/]+\.(?:ya?ml|json))$"

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from llm.universal_dspy_wrapper_v2 import (
     LoggedFewShotWrapper,
     is_repo_data_path,
+    _REPO_ROOT,
 )
 
 
@@ -50,4 +51,21 @@ def test_is_repo_data_path_windows_and_posix():
 
     assert is_repo_data_path(posix_path)
     assert is_repo_data_path(windows_path)
+
+
+def test_repo_root_fallback(monkeypatch):
+    """Ensure repo root falls back to cwd when git command fails."""
+
+    def raise_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0])
+
+    monkeypatch.setattr(subprocess, "run", raise_error)
+    import importlib, sys, warnings
+
+    with warnings.catch_warnings(record=True) as records:
+        sys.modules.pop("llm.universal_dspy_wrapper_v2", None)
+        module = importlib.import_module("llm.universal_dspy_wrapper_v2")
+
+    assert module._REPO_ROOT == Path.cwd()
+    assert any("falling back" in str(w.message).lower() for w in records)
 


### PR DESCRIPTION
## Summary
- warn and fall back to working directory if `git rev-parse` fails
- add fallback test coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f5a91ffc8326a92f4a1047fdb823