### PR TITLE
Add schema tests

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -1,4 +1,4 @@
-format = "$directory$git_branch$character"
+format = "$time$directory$git_branch$fill$character"
 
 [time]
 disabled = false

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,9 +15,20 @@ def load_json(path: Path):
 
 def test_windows_terminal_settings():
     data = load_json(Path('windows-terminal') / 'settings.json')
+    assert data.get('defaultProfile'), 'default profile missing'
     assert 'profiles' in data
     profiles = data['profiles'].get('list', [])
     assert len(profiles) > 0, "no profiles configured"
+    defaults = data['profiles'].get('defaults', {})
+    assert defaults.get('useAcrylic') is True, 'acrylic not enabled'
+    assert 'opacity' in defaults, 'acrylic opacity missing'
+    color = defaults.get('colorScheme')
+    if not color:
+        for p in profiles:
+            if 'colorScheme' in p:
+                color = p['colorScheme']
+                break
+    assert color, 'color scheme missing'
     assert 'actions' in data and data['actions'], "action bindings missing"
 
 

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -7,3 +7,10 @@ def test_starship_time_and_git_status_sections():
     assert 'time' in data, '[time] section missing'
     assert 'git_status' in data, '[git_status] section missing'
 
+
+def test_starship_format_contains_time_and_fill():
+    data = tomllib.loads(Path('starship.toml').read_text())
+    format_str = data.get('format', '')
+    assert '$time' in format_str, 'format missing $time'
+    assert '$fill' in format_str, 'format missing $fill'
+

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from llm.universal_dspy_wrapper_v2 import (
     LoggedFewShotWrapper,
     is_repo_data_path,
+    _REPO_ROOT,
 )
 
 

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -26,6 +26,7 @@
             "intenseTextStyle": "bold",
             "opacity": 20,
             "useAcrylic": true,
+            "colorScheme": "Campbell",
             "textAntialiasing": "grayscale"
         },
         "list": [


### PR DESCRIPTION
## Summary
- verify Windows Terminal defaults use acrylic with an opacity and color scheme
- update starship format string for `$time` and `$fill`
- assert that starship format string includes `$time` and `$fill`
- import `_REPO_ROOT` in universal dspy wrapper test

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859f5f4361c8326aa6f36876fcc16a1