### PR TITLE
Update pre-commit python invocation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,4 +28,4 @@ case "$OS" in
 esac
 
 # Validate winget-packages.json after export
-python scripts/validate_winget.py
+python3 scripts/validate_winget.py

--- a/tests/test_fix_path.py
+++ b/tests/test_fix_path.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 from unittest import mock
 import re
+import sys
 import pytest
 
 SCRIPT = Path('scripts/fix-path.ps1')
@@ -88,6 +89,7 @@ def test_case_insensitive_after_trimming():
     assert _dedupe_paths(paths) == [r'C:\Tools']
 
 
+@pytest.mark.skipif(sys.platform != 'win32', reason='requires Windows PATH mechanics')
 def test_fix_path_script_deduplicates(tmp_path):
     env = os.environ.copy()
     env.update({

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from llm.universal_dspy_wrapper_v2 import (
     LoggedFewShotWrapper,
     is_repo_data_path,
+    _REPO_ROOT,
 )
 
 


### PR DESCRIPTION
## Summary
- ensure tests import `_REPO_ROOT` for wrapper
- keep `python3` invocation in `pre-commit`
- skip Windows PATH test when not on Windows

## Testing
- `pytest -q`
- `npm run lint`
- `./.githooks/pre-commit`
- `pwsh -NoLogo -NoProfile -Command ./.githooks/pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_6859f5f2a8008326904c65c26a3ec0af