### PR TITLE
Add bootstrap.ps1 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ pytest
 
 
 See the [installation guide](docs/installation.md) for setup instructions.
-After cloning the repository, run `scripts/fix-path.ps1` from an elevated
-PowerShell prompt to ensure your PATH is configured correctly.
+After cloning the repository, run `bootstrap.ps1` from an elevated
+PowerShell prompt. The script calls `scripts/fix-path.ps1` to ensure your
+`PATH` is configured correctly.
 For a more detailed overview, see [docs/terminal.md](docs/terminal.md).
 For details on fastfetch, btm and Nushell/Starship setup, see the [Terminal Tools section](docs/terminal.md#terminal-tools-fastfetch-btm--nushellstarship).
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,2 @@
+& "$PSScriptRoot/scripts/fix-path.ps1"
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,16 +20,12 @@ Alternatively, download the official installer from [nodejs.org](https://nodejs.
    winget import winget-packages.json
    ```
 2. Copy or symlink the files from this repository to your profile directory.
-3. Run the PATH cleanup script from an elevated PowerShell prompt:
+3. From an elevated PowerShell prompt, run `bootstrap.ps1` to set up your PATH:
    ```powershell
-   scripts/fix-path.ps1
+   ./bootstrap.ps1
    ```
-   The script cleans up duplicate entries and ensures your `bin` directory is included.
+   The script calls `scripts/fix-path.ps1` to clean up duplicate entries and ensure your `bin` directory is included.
    If `$Env:USERPROFILE` isn't defined (e.g. on Linux), it falls back to `$HOME`.
-   You can also call this automatically from a `bootstrap.ps1` script:
-   ```powershell
-   & "$PSScriptRoot/scripts/fix-path.ps1"
-   ```
 4. Restart the terminal to load the new settings.
 
 ## WSL
@@ -49,8 +45,8 @@ sudo bash scripts/setup-wsl.sh
    git clone https://github.com/d0tTino/d0tTino.git
    ```
 2. Use `stow` or your preferred method to symlink the dotfiles into place.
-3. Run the PATH cleanup script:
+3. Run `bootstrap.ps1` to clean up your PATH:
    ```powershell
-   scripts/fix-path.ps1
+   ./bootstrap.ps1
    ```
 4. Launch a new shell to pick up the configuration.

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -65,7 +65,7 @@ if [ ! -f "$bashrc" ]; then
 fi
 if ! grep -Fq 'starship init bash' "$bashrc" 2>/dev/null; then
     starship_config_path="$repo_root/starship.toml"
-    cat <<EOF >>"$bashrc"
+    /bin/cat <<EOF >>"$bashrc"
 starship_config="$starship_config_path"
 if command -v starship >/dev/null; then
     eval "\$(starship init bash --config \"\$starship_config\")"

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -56,6 +56,7 @@
       "intenseTextStyle": "bold",
       "opacity": 20,
       "useAcrylic": true,
+      "colorScheme": "Campbell",
       "textAntialiasing": "grayscale"
     },
     "list": [


### PR DESCRIPTION
## Summary
- add a `bootstrap.ps1` convenience wrapper
- update installation docs and README to use the new script
- ensure Windows Terminal settings declare a color scheme
- update setup-wsl script to use `/bin/cat`

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa97b14988326a7cbc338e0172317