### PR TITLE
Update Windows Terminal default profile

### DIFF
--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -34,7 +34,7 @@
   ],
   "copyFormatting": "none",
   "copyOnSelect": false,
-  "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+  "defaultProfile": "{1857054d-df21-5f4a-bd44-865a14a14d59}",
   "keybindings": [
     {
       "id": "User.globalSummon.90584B03",
@@ -69,7 +69,8 @@
         "guid": "{1857054d-df21-5f4a-bd44-865a14a14d59}",
         "hidden": false,
         "name": "Ubuntu",
-        "source": "Microsoft.WSL"
+        "source": "Microsoft.WSL",
+        "colorScheme": "Campbell"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- set Ubuntu profile as the Windows Terminal default
- keep custom color scheme on the Ubuntu profile

## Testing
- `npm run lint`
- `pytest -k windows_terminal_settings -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa99114008326b5c1128af044f113