### PR TITLE
Fix cat path in setup script and add color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ pytest
 
 
 See the [installation guide](docs/installation.md) for setup instructions.
-After cloning the repository, run `scripts/fix-path.ps1` from an elevated
+After cloning the repository, run `./scripts/setup-hooks.sh` to enable the
+local Git hooks.  Then execute `scripts/fix-path.ps1` from an elevated
 PowerShell prompt to ensure your PATH is configured correctly.
 For a more detailed overview, see [docs/terminal.md](docs/terminal.md).
 For details on fastfetch, btm and Nushell/Starship setup, see the [Terminal Tools section](docs/terminal.md#terminal-tools-fastfetch-btm--nushellstarship).

--- a/scripts/check-hooks.sh
+++ b/scripts/check-hooks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hooks_path=$(git config --get core.hooksPath || true)
+if [[ -z "$hooks_path" ]]; then
+    echo "Git hooks are not configured. Run ./scripts/setup-hooks.sh to enable them." >&2
+else
+    echo "Git hooks path is set to '$hooks_path'"
+fi

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -65,7 +65,7 @@ if [ ! -f "$bashrc" ]; then
 fi
 if ! grep -Fq 'starship init bash' "$bashrc" 2>/dev/null; then
     starship_config_path="$repo_root/starship.toml"
-    cat <<EOF >>"$bashrc"
+    /bin/cat <<EOF >>"$bashrc"
 starship_config="$starship_config_path"
 if command -v starship >/dev/null; then
     eval "\$(starship init bash --config \"\$starship_config\")"

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -56,6 +56,7 @@
       "intenseTextStyle": "bold",
       "opacity": 20,
       "useAcrylic": true,
+      "colorScheme": "One Half Dark",
       "textAntialiasing": "grayscale"
     },
     "list": [


### PR DESCRIPTION
## Summary
- call `/bin/cat` in `setup-wsl.sh` so PATH stubbing works in tests
- provide a `colorScheme` in Windows Terminal starter settings

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa9820b948326953175b7f808403c