### PR TITLE
Fix setup-wsl test failure

### DIFF
--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -65,13 +65,13 @@ if [ ! -f "$bashrc" ]; then
 fi
 if ! grep -Fq 'starship init bash' "$bashrc" 2>/dev/null; then
     starship_config_path="$repo_root/starship.toml"
-    cat <<EOF >>"$bashrc"
-starship_config="$starship_config_path"
-if command -v starship >/dev/null; then
-    eval "\$(starship init bash --config \"\$starship_config\")"
-fi
-if command -v zoxide >/dev/null; then
-    eval "\$(zoxide init bash)"
-fi
-EOF
+    {
+        printf 'starship_config="%s"\n' "$starship_config_path"
+        printf 'if command -v starship >/dev/null; then\n'
+        printf '    eval "$(starship init bash --config \"$starship_config\")"\n'
+        printf 'fi\n'
+        printf 'if command -v zoxide >/dev/null; then\n'
+        printf '    eval "$(zoxide init bash)"\n'
+        printf 'fi\n'
+    } >>"$bashrc"
 fi

--- a/starship.toml
+++ b/starship.toml
@@ -1,8 +1,14 @@
 format = """
-$directory$git_status$fill$time
+$directory$git_branch$git_state$git_status$fill$time
 $character"""
 
 [git_status]
+disabled = false
+
+[git_branch]
+disabled = false
+
+[git_state]
 disabled = false
 
 [time]

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -5,9 +5,11 @@ def test_starship_time_and_git_status_sections():
     data = tomllib.loads(Path('starship.toml').read_text())
     assert 'time' in data, '[time] section missing'
     assert 'git_status' in data, '[git_status] section missing'
+    assert 'git_branch' in data, '[git_branch] section missing'
+    assert 'git_state' in data, '[git_state] section missing'
 
 def test_starship_multiline_format():
     data = tomllib.loads(Path('starship.toml').read_text())
-    expected = "$directory$git_status$fill$time\n$character"
+    expected = "$directory$git_branch$git_state$git_status$fill$time\n$character"
     assert data.get('format') == expected, 'prompt format mismatch'
 


### PR DESCRIPTION
## Summary
- avoid calling `cat` in `setup-wsl.sh`
- explicitly enable git branch and git state modules in `starship.toml`
- update tests to check for these sections

## Testing
- `pytest tests/test_starship.py -q`
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685aa98ae24083269346aebe18243e1c