### PR TITLE
Add screenshot env install tests

### DIFF
--- a/tests/test_setup_screenshot_env.py
+++ b/tests/test_setup_screenshot_env.py
@@ -1,0 +1,91 @@
+import os
+import subprocess
+import sys
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_setup_screenshot_env_apt(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    apt_log = tmp_path / "apt.log"
+    create_exe(
+        bin_dir / "apt-get",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{apt_log}'\n",
+    )
+    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n\"$@\"\n")
+    create_exe(bin_dir / "wget", "#!/usr/bin/env bash\n: > $2\n")
+    create_exe(bin_dir / "dpkg", "#!/usr/bin/env bash\n:")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    subprocess.run(["/bin/bash", "scripts/setup-screenshot-env.sh"], check=True, env=env)
+    lines = apt_log.read_text().splitlines()
+    assert lines and lines[0] == "update"
+    assert any("install" in line for line in lines)
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_setup_screenshot_env_pacman(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    pac_log = tmp_path / "pacman.log"
+    create_exe(
+        bin_dir / "pacman",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{pac_log}'\n",
+    )
+    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n\"$@\"\n")
+    create_exe(bin_dir / "uname", "#!/usr/bin/env bash\necho Linux\n")
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    env = os.environ.copy()
+    env["PATH"] = str(bin_dir)
+    subprocess.run(["/bin/bash", "scripts/setup-screenshot-env.sh"], check=True, env=env)
+    lines = pac_log.read_text().splitlines()
+    assert lines and lines[0].startswith("-Sy")
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_setup_screenshot_env_brew(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    brew_log = tmp_path / "brew.log"
+    create_exe(
+        bin_dir / "brew",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{brew_log}'\n",
+    )
+    create_exe(bin_dir / "uname", "#!/usr/bin/env bash\necho Darwin\n")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    subprocess.run(["/bin/bash", "scripts/setup-screenshot-env.sh"], check=True, env=env)
+    lines = brew_log.read_text().splitlines()
+    assert any("install" in line for line in lines)
+
+
+@pytest.mark.skipif(
+    shutil.which("pwsh") is None and shutil.which("powershell") is None,
+    reason="requires PowerShell",
+)
+def test_setup_screenshot_env_ps1(tmp_path: Path) -> None:
+    pwsh = shutil.which("pwsh") or shutil.which("powershell")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    winget_log = tmp_path / "winget.log"
+    create_exe(
+        bin_dir / "winget",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{winget_log}'\n",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    subprocess.run(
+        [pwsh, "-NoLogo", "-NoProfile", "-File", "scripts/setup-screenshot-env.ps1"],
+        check=True,
+        env=env,
+    )
+    assert winget_log.read_text().strip(), "winget should be invoked"

--- a/tests/test_setup_wsl.py
+++ b/tests/test_setup_wsl.py
@@ -91,6 +91,7 @@ def test_setup_wsl_requires_sudo(tmp_path):
 
     (bin_dir / "grep").symlink_to("/usr/bin/grep")
     (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+    (bin_dir / "cat").symlink_to("/bin/cat")
     env = os.environ.copy()
     env.update({
         "PATH": str(bin_dir),
@@ -120,6 +121,7 @@ def test_setup_wsl_root_without_sudo(tmp_path):
 
     (bin_dir / "grep").symlink_to("/usr/bin/grep")
     (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+    (bin_dir / "cat").symlink_to("/bin/cat")
     env = os.environ.copy()
     env.update({
         "PATH": str(bin_dir),

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -1,5 +1,5 @@
-import dspy
-import pytest  # noqa: F401
+import pytest
+dspy = pytest.importorskip("dspy")
 import subprocess
 from pathlib import Path
 
@@ -7,7 +7,6 @@ from llm.universal_dspy_wrapper_v2 import (
     LoggedFewShotWrapper,
     _REPO_ROOT,
     is_repo_data_path,
-    _REPO_ROOT,
 )
 
 class DummyModule(dspy.Module):

--- a/tests/test_utf8.py
+++ b/tests/test_utf8.py
@@ -1,8 +1,8 @@
 import json
 import pytest
-from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 
 dspy = pytest.importorskip("dspy")
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 
 def test_logged_fewshot_wrapper_reads_utf8(tmp_path):
     data = {"inputs": {"x": "café"}, "outputs": {"y": "naïve"}}

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,7 +1,7 @@
 import pytest
-from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 
 dspy = pytest.importorskip("dspy")
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 
 class EchoPrediction:
     def __init__(self, text: str) -> None:

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -56,7 +56,8 @@
       "intenseTextStyle": "bold",
       "opacity": 20,
       "useAcrylic": true,
-      "textAntialiasing": "grayscale"
+      "textAntialiasing": "grayscale",
+      "colorScheme": "One Half Dark"
     },
     "list": [
       {


### PR DESCRIPTION
## Summary
- test Linux screenshot environment installers (apt, pacman, brew)
- ensure pacman case doesn't fall back to apt
- make WSL setup tests find `cat`
- define color scheme in Windows Terminal config
- skip DSPy-dependent tests if DSPy isn't installed

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685aa99c79488326a2a9dafe20b88074