### PR TITLE
Update Terminal defaults and tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,8 @@ def test_windows_terminal_settings():
     assert len(profiles) > 0, "no profiles configured"
     defaults = data['profiles'].get('defaults', {})
     assert defaults.get('useAcrylic') is True, 'acrylic not enabled'
-    assert 'opacity' in defaults, 'acrylic opacity missing'
+    assert 'acrylicOpacity' in defaults, 'acrylic opacity missing'
+    assert defaults.get('acrylicOpacity') == 0.85
     color = defaults.get('colorScheme')
     if not color:
         for p in profiles:
@@ -47,11 +48,13 @@ def test_windows_terminal_split_bindings():
     assert binding_v, 'Alt+V binding missing'
     assert binding_v.get('command', {}).get('action') == 'splitPane'
     assert binding_v.get('command', {}).get('split') == 'vertical'
+    assert binding_v.get('command', {}).get('profile') == '{1857054d-df21-5f4a-bd44-865a14a14d59}'
 
     binding_h = find_binding('alt+h')
     assert binding_h, 'Alt+H binding missing'
     assert binding_h.get('command', {}).get('action') == 'splitPane'
     assert binding_h.get('command', {}).get('split') == 'horizontal'
+    assert binding_h.get('command', {}).get('profile') == '{574e775e-4f2a-5b96-ac1e-a2962a402336}'
 
 
 

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -20,14 +20,16 @@
     {
       "command": {
         "action": "splitPane",
-        "split": "vertical"
+        "split": "vertical",
+        "profile": "{1857054d-df21-5f4a-bd44-865a14a14d59}"
       },
       "keys": "alt+v"
     },
     {
       "command": {
         "action": "splitPane",
-        "split": "horizontal"
+        "split": "horizontal",
+        "profile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}"
       },
       "keys": "alt+h"
     }
@@ -50,11 +52,11 @@
     "defaults": {
       "compatibility.input.forceVT": true,
       "font": {
-        "face": "CascaydiaCove Nerd Font",
+        "face": "CaskaydiaCove Nerd Font",
         "weight": "normal"
       },
       "intenseTextStyle": "bold",
-      "opacity": 20,
+      "acrylicOpacity": 0.85,
       "useAcrylic": true,
       "textAntialiasing": "grayscale",
       "colorScheme": "One Half Dark"


### PR DESCRIPTION
## Summary
- adjust starter Windows Terminal settings
- update split-pane bindings to specify profiles
- replace opacity with acrylicOpacity
- update tests to match new config

## Testing
- `npm run lint`
- `pytest tests/test_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685acc4534888326bb1002a3aee662db