### PR TITLE
Update starship config

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -1,9 +1,12 @@
+add_newline = false
 format = """
-$directory$git_branch$git_state$git_status$fill$time
-$character"""
+[┌─](bold purple)$directory$git_branch$git_state$git_status$fill$time
+[└─](bold purple)$character
+"""
 
 [git_status]
 disabled = false
+stashed = "📦"
 
 [git_branch]
 disabled = false

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -5,11 +5,13 @@ def test_starship_time_and_git_status_sections():
     data = tomllib.loads(Path('starship.toml').read_text())
     assert 'time' in data, '[time] section missing'
     assert 'git_status' in data, '[git_status] section missing'
+    assert data['git_status'].get('stashed') == "📦", 'stashed icon mismatch'
     assert 'git_branch' in data, '[git_branch] section missing'
     assert 'git_state' in data, '[git_state] section missing'
 
 def test_starship_multiline_format():
     data = tomllib.loads(Path('starship.toml').read_text())
-    expected = "$directory$git_branch$git_state$git_status$fill$time\n$character"
+    expected = "[┌─](bold purple)$directory$git_branch$git_state$git_status$fill$time\n[└─](bold purple)$character\n"
     assert data.get('format') == expected, 'prompt format mismatch'
+    assert data.get('add_newline') is False, 'add_newline should be false'
 


### PR DESCRIPTION
## Summary
- change starship prompt to recommended two-line format
- customize git status stashed icon
- check new starship options in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685acc46a26083268751350d9805d882