### PR TITLE
Initialize git hooks automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ Install the required Python packages (including test utilities such as
 pip install -e . -r requirements.txt
 ```
 
-Next, install the Git hooks so `pre-commit` runs automatically:
+Next, run the bootstrap script to enable the Git hooks and clean up your PATH:
 
-```bash
-./scripts/setup-hooks.sh
+```powershell
+./bootstrap.ps1
 ```
+
+`bootstrap.ps1` calls `scripts/setup-hooks.sh` automatically so `pre-commit`
+runs on each commit.
 
 You can then run the test suite to verify the configuration:
 
@@ -35,9 +38,9 @@ pytest
 
 
 See the [installation guide](docs/installation.md) for setup instructions.
-After cloning the repository, run `./scripts/setup-hooks.sh` to enable the
-local Git hooks.  Then execute `scripts/fix-path.ps1` from an elevated
-PowerShell prompt to ensure your PATH is configured correctly.
+After cloning the repository, run `./bootstrap.ps1` from an elevated
+PowerShell prompt. This script cleans up your PATH and enables the local Git
+hooks automatically.
 For a more detailed overview, see [docs/terminal.md](docs/terminal.md).
 For details on fastfetch, btm and Nushell/Starship setup, see the [Terminal Tools section](docs/terminal.md#terminal-tools-fastfetch-btm--nushellstarship).
 
@@ -45,7 +48,9 @@ For details on fastfetch, btm and Nushell/Starship setup, see the [Terminal Tool
 ## Git hooks
 
 Run `scripts/setup-hooks.sh` to enable the local hooks automatically
-(equivalent to running `git config core.hooksPath .githooks`):
+(equivalent to running `git config core.hooksPath .githooks`). The
+`bootstrap.ps1` script invokes this for you, so you usually don't need to
+run it manually:
 
 ```bash
 ./scripts/setup-hooks.sh

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,2 +1,3 @@
 & "$PSScriptRoot/scripts/fix-path.ps1"
+& bash "$PSScriptRoot/scripts/setup-hooks.sh"
 

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Configure Git to use local hooks directory
-git config core.hooksPath .githooks
-
-echo "Git hooks enabled using .githooks"
+# Configure Git to use local hooks directory if not already set
+current_path=$(git config --get core.hooksPath || true)
+if [[ -z "$current_path" ]]; then
+    git config core.hooksPath .githooks
+    echo "Git hooks enabled using .githooks"
+else
+    echo "Git hooks already configured at '$current_path'"
+fi


### PR DESCRIPTION
## Summary
- avoid overwriting existing Git hooks path in `setup-hooks.sh`
- call `setup-hooks.sh` from `bootstrap.ps1` so hooks activate on first run
- document the new bootstrap behaviour in `README.md`

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685acc64383483268ab67ff04c4b1a5a