### PR TITLE
Fix import ordering in tests

### DIFF
--- a/tests/test_setup_screenshot_env.py
+++ b/tests/test_setup_screenshot_env.py
@@ -1,7 +1,6 @@
 import os
-import subprocess
-import sys
 import shutil
+import subprocess
 from pathlib import Path
 
 import pytest

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -1,13 +1,15 @@
-import pytest
-dspy = pytest.importorskip("dspy")
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from llm.universal_dspy_wrapper_v2 import (
-    LoggedFewShotWrapper,
     _REPO_ROOT,
+    LoggedFewShotWrapper,
     is_repo_data_path,
 )
+
+dspy = pytest.importorskip("dspy")
 
 class DummyModule(dspy.Module):
     def forward(self, value):

--- a/tests/test_utf8.py
+++ b/tests/test_utf8.py
@@ -1,8 +1,10 @@
 import json
+
 import pytest
 
-dspy = pytest.importorskip("dspy")
 from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+
+dspy = pytest.importorskip("dspy")
 
 def test_logged_fewshot_wrapper_reads_utf8(tmp_path):
     data = {"inputs": {"x": "café"}, "outputs": {"y": "naïve"}}

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,7 +1,8 @@
 import pytest
 
-dspy = pytest.importorskip("dspy")
 from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
+
+dspy = pytest.importorskip("dspy")
 
 class EchoPrediction:
     def __init__(self, text: str) -> None:


### PR DESCRIPTION
## Summary
- sort imports with ruff

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685acc414864832695e198809b392609