### PR TITLE
Add Windows winget setup script

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,2 +1,10 @@
+param(
+    [switch] $InstallWinget
+)
+
 & "$PSScriptRoot/scripts/fix-path.ps1"
+
+if ($InstallWinget -and $IsWindows) {
+    & "$PSScriptRoot/scripts/setup-winget.ps1"
+}
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,14 +15,18 @@ Alternatively, download the official installer from [nodejs.org](https://nodejs.
 
 ## Windows
 
-1. Install packages using `winget`:
+1. Install packages using `winget`. You can either import the full package list
+   or run the provided helper script for the essentials:
    ```powershell
    winget import winget-packages.json
+   # Or install just the core tools
+   ./scripts/setup-winget.ps1
    ```
 2. Copy or symlink the files from this repository to your profile directory.
-3. From an elevated PowerShell prompt, run `bootstrap.ps1` to set up your PATH:
+3. From an elevated PowerShell prompt, run `bootstrap.ps1` to set up your PATH.
+   Pass `-InstallWinget` to install the core tools automatically:
    ```powershell
-   ./bootstrap.ps1
+   ./bootstrap.ps1 -InstallWinget
    ```
    The script calls `scripts/fix-path.ps1` to clean up duplicate entries and ensure your `bin` directory is included.
    If `$Env:USERPROFILE` isn't defined (e.g. on Linux), it falls back to `$HOME`.

--- a/scripts/setup-winget.ps1
+++ b/scripts/setup-winget.ps1
@@ -1,0 +1,25 @@
+# Install basic command-line tools on Windows using winget.
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    return
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Error 'winget is required but not installed.'
+    exit 1
+}
+
+$packages = @(
+    @{ Id = 'ajeetdsouza.zoxide' },
+    @{ Id = 'junegunn.fzf' },
+    @{ Id = 'sharkdp.bat' },
+    @{ Id = 'dandavison.delta' },
+    @{ Id = 'Starship.Starship' },
+    @{ Id = 'Microsoft.WindowsTerminal' },
+    @{ Id = 'Microsoft.OpenSSH.Preview' }
+)
+
+foreach ($pkg in $packages) {
+    winget install --id $pkg.Id -e --accept-source-agreements --accept-package-agreements
+}


### PR DESCRIPTION
## Summary
- add script to install common CLI tools on Windows with winget
- make bootstrap optional call with `-InstallWinget`
- document how to use this optional flag in Windows setup instructions

## Testing
- `pytest -q`
- `npm run lint`
- `python scripts/validate_winget.py`


------
https://chatgpt.com/codex/tasks/task_e_685acc5aa1a48326818c58a7a2859ca7