### PR TITLE
Add starship status segment

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -1,6 +1,6 @@
 add_newline = false
 format = """
-[┌─](bold purple)$directory$git_branch$git_state$git_status$fill$time
+[┌─](bold purple)$directory$git_branch$git_state$git_status$status$fill$time
 [└─](bold purple)$character
 """
 
@@ -17,3 +17,6 @@ disabled = false
 [time]
 disabled = false
 format = "[$time]($style) "
+
+[status]
+disabled = false

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -8,10 +8,12 @@ def test_starship_time_and_git_status_sections():
     assert data['git_status'].get('stashed') == "📦", 'stashed icon mismatch'
     assert 'git_branch' in data, '[git_branch] section missing'
     assert 'git_state' in data, '[git_state] section missing'
+    assert 'status' in data, '[status] section missing'
+    assert data['status'].get('disabled') is False, '[status] should be enabled'
 
 def test_starship_multiline_format():
     data = tomllib.loads(Path('starship.toml').read_text())
-    expected = "[┌─](bold purple)$directory$git_branch$git_state$git_status$fill$time\n[└─](bold purple)$character\n"
+    expected = "[┌─](bold purple)$directory$git_branch$git_state$git_status$status$fill$time\n[└─](bold purple)$character\n"
     assert data.get('format') == expected, 'prompt format mismatch'
     assert data.get('add_newline') is False, 'add_newline should be false'
 


### PR DESCRIPTION
## Summary
- enable `status` in starship config
- update starship test coverage

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b566a7b44832690cbcfcb697027a8