### PR TITLE
Add PowerShell hook setup

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -3,7 +3,11 @@ param(
 )
 
 & "$PSScriptRoot/scripts/fix-path.ps1"
-& bash "$PSScriptRoot/scripts/setup-hooks.sh"
+if (Get-Command bash -ErrorAction SilentlyContinue) {
+    & bash "$PSScriptRoot/scripts/setup-hooks.sh"
+} else {
+    & "$PSScriptRoot/scripts/setup-hooks.ps1"
+}
 
 if ($InstallWinget -and $IsWindows) {
     & "$PSScriptRoot/scripts/setup-winget.ps1"

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -1,0 +1,15 @@
+# Configure Git to use local hooks directory if not already set.
+$ErrorActionPreference = 'Stop'
+
+try {
+    $currentPath = git config --get core.hooksPath 2>$null
+} catch {
+    $currentPath = $null
+}
+
+if (-not $currentPath) {
+    git config core.hooksPath .githooks
+    Write-Host "Git hooks enabled using .githooks"
+} else {
+    Write-Host "Git hooks already configured at '$currentPath'"
+}


### PR DESCRIPTION
## Summary
- provide `setup-hooks.ps1` to configure git hooks when Bash isn't available
- call the new script from `bootstrap.ps1` as a fallback

## Testing
- `ruff check .`
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b567853888326908048aa4023b679