### PR TITLE
Update Git hook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,19 @@ run it manually:
 ./scripts/setup-hooks.sh
 ```
 
-Once enabled, the `pre-commit` hook automatically exports your current
-`winget` package list to `winget-packages.json` whenever you commit on
-Windows. Be sure to commit the updated file so your package list stays
-in sync. On Linux or WSL the export is skipped unless `winget` is
-available.
+Once enabled, the `pre-commit` hook first runs `winget upgrade --all` and then
+automatically exports your current `winget` package list to
+`winget-packages.json` whenever you commit on Windows. Be sure to commit the
+updated file so your package list stays in sync. On Linux or WSL the export is
+skipped unless `winget` is available.
+
+If the hook is disabled, run the following commands manually to upgrade and
+export your package list:
+
+```powershell
+winget upgrade --all
+pwsh -File scripts/export-winget.ps1
+```
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- document `winget upgrade --all` before exporting packages
- explain how to manually run the command if the Git hook is disabled

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b5685502c832687696ac79f2d9ecf