### PR TITLE
Remove redundant keybindings

### DIFF
--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -9,7 +9,8 @@
         "monitor": "any",
         "name": "_quake"
       },
-      "id": "User.globalSummon.90584B03"
+      "id": "User.globalSummon.90584B03",
+      "keys": "ctrl+;"
     },
     {
       "command": {
@@ -37,12 +38,6 @@
   "copyFormatting": "none",
   "copyOnSelect": false,
   "defaultProfile": "{1857054d-df21-5f4a-bd44-865a14a14d59}",
-  "keybindings": [
-    {
-      "id": "User.globalSummon.90584B03",
-      "keys": "ctrl+;"
-    }
-  ],
   "newTabMenu": [
     {
       "type": "remainingProfiles"


### PR DESCRIPTION
## Summary
- drop the `keybindings` array from Windows Terminal settings
- keep globalSummon bound to `ctrl+;` via the `actions` array

## Testing
- `ruff check .`
- `npm run lint`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c07a5b88c8326a3d35c74285bf475