### PR TITLE
Update bootstrap flags

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,5 +1,7 @@
 param(
-    [switch] $InstallWinget
+    [switch] $InstallWinget,
+    [switch] $InstallWindowsTerminal,
+    [switch] $SetupWSL
 )
 
 & "$PSScriptRoot/scripts/fix-path.ps1"
@@ -11,5 +13,13 @@ if (Get-Command bash -ErrorAction SilentlyContinue) {
 
 if ($InstallWinget -and $IsWindows) {
     & "$PSScriptRoot/scripts/setup-winget.ps1"
+}
+
+if ($InstallWindowsTerminal -and $IsWindows) {
+    & "$PSScriptRoot/scripts/install-windows-terminal.ps1"
+}
+
+if ($SetupWSL -and (Get-Command bash -ErrorAction SilentlyContinue)) {
+    & bash "$PSScriptRoot/scripts/setup-wsl.sh"
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,9 +38,10 @@ ruff check .
    ```
 2. Copy or symlink the files from this repository to your profile directory.
 3. From an elevated PowerShell prompt, run `bootstrap.ps1` to set up your PATH.
-   Pass `-InstallWinget` to install the core tools automatically:
+   Pass `-InstallWinget` to install the core tools automatically. You can also
+   add `-InstallWindowsTerminal` to copy the default Windows Terminal settings:
    ```powershell
-   ./bootstrap.ps1 -InstallWinget
+   ./bootstrap.ps1 -InstallWinget -InstallWindowsTerminal
    ```
    The script calls `scripts/fix-path.ps1` to clean up duplicate entries and ensure your `bin` directory is included.
    If `$Env:USERPROFILE` isn't defined (e.g. on Linux), it falls back to `$HOME`.
@@ -50,10 +51,14 @@ ruff check .
 
 Run the provided script from the repository root to install the basic tools on
 a fresh Ubuntu/WSL instance. The script uses `apt-get` and may prompt for your
-password:
+password. You can call it directly or pass `-SetupWSL` to `bootstrap.ps1`:
 
 ```bash
 sudo bash scripts/setup-wsl.sh
+```
+
+```powershell
+./bootstrap.ps1 -SetupWSL
 ```
 
 ## Linux / macOS


### PR DESCRIPTION
## Summary
- allow bootstrap.ps1 to set up WSL tools or install Windows Terminal settings
- document new optional flags in installation guide

## Testing
- `npm run lint`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c07b012b08326b90f46f44f2d0d80