### PR TITLE
Add smoke test npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ You can then run the test suite to verify the configuration:
 pytest
 ```
 
-Finally, run the smoke test script to verify the basic commands:
+Finally, run the smoke test to verify the basic commands:
 
 ```bash
-pwsh -File scripts/smoke_test.ps1
+npm run smoke
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "echo \"No JS tests\"",
-    "lint": "eslint . --ext .js"
+    "lint": "eslint . --ext .js",
+    "smoke": "pwsh -File scripts/smoke_test.ps1"
   },
   "devDependencies": {
     "eslint": "^9.29.0"


### PR DESCRIPTION
## Summary
- enable running the smoke test via npm
- document running `npm run smoke` in quickstart

## Testing
- `pip install dspy`
- `pip install -e .`
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_685c07b842fc8326b64c63b4bf9fc853