### PR TITLE
Improve test setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ winget-packages.lock.json
 # Python cache
 __pycache__/
 node_modules/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ pwsh -File scripts/export-winget.ps1
 
 ## Testing
 
-Before running the Python tests locally, install the required packages:
+Before running the Python tests locally, install this repository in editable
+mode first and then install the rest of the dependencies:
 
 ```bash
+pip install -e .
 pip install -r requirements.txt
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+if importlib.util.find_spec("llm") is None:
+    # Ensure the repository root is on sys.path when running tests directly
+    repo_root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(repo_root))
+    if importlib.util.find_spec("llm") is None:
+        raise ImportError(
+            "The 'llm' package could not be imported. Install this repository with 'pip install -e .' before running tests."
+        )


### PR DESCRIPTION
## Summary
- clarify that running tests requires installing the project in editable mode first
- raise ImportError if tests can't import `llm` even after adjusting `sys.path`

## Testing
- `ruff check tests/conftest.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c07a60ad083269ca98c51ebafeb86