### PR TITLE
Handle missing dspy import

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -15,8 +15,14 @@ from pathlib import Path
 from typing import Callable, List, Type
 import warnings
 
-import dspy
-from dspy.teleprompt import LabeledFewShot
+try:
+    import dspy
+    from dspy.teleprompt import LabeledFewShot
+except ImportError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "The 'dspy' package is required to use LoggedFewShotWrapper; install it "
+        "via 'pip install dspy-ai'"
+    ) from exc
 
 try:
     _REPO_ROOT = Path(

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -2,13 +2,14 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from llm.universal_dspy_wrapper_v2 import (
+
+dspy = pytest.importorskip("dspy")
+
+from llm.universal_dspy_wrapper_v2 import (  # noqa: E402 - imported after importorskip
     _REPO_ROOT,
     LoggedFewShotWrapper,
     is_repo_data_path,
 )
-
-dspy = pytest.importorskip("dspy")
 
 class DummyModule(dspy.Module):
     def forward(self, value):


### PR DESCRIPTION
## Summary
- guard `dspy` import in universal wrapper
- ensure dspy is present before loading wrapper tests

## Testing
- `ruff check llm/universal_dspy_wrapper_v2.py tests/test_universal_dspy_wrapper_v2.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c10f15f54832688cf403c3d4365bd