### PR TITLE
Update README with PATH cleanup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ npm run smoke
 
 See the [installation guide](docs/installation.md) for setup instructions.
 After cloning the repository, run `./bootstrap.ps1` from an elevated
-PowerShell prompt. This script cleans up your PATH and enables the local Git
-hooks automatically. On Windows it invokes `scripts/setup-hooks.ps1` while on
-other platforms it runs `scripts/setup-hooks.sh`.
+PowerShell prompt. The script runs `scripts/fix-path.ps1` to deduplicate and
+persist your PATH, which is necessary because a user PATH can easily exceed the
+1024‑character limit. It also enables the local Git hooks automatically. On
+Windows it invokes `scripts/setup-hooks.ps1` while on other platforms it runs
+`scripts/setup-hooks.sh`.
 For a more detailed overview, see [docs/terminal.md](docs/terminal.md).
 For details on fastfetch, btm and Nushell/Starship setup, see the [Terminal Tools section](docs/terminal.md#terminal-tools-fastfetch-btm--nushellstarship).
 


### PR DESCRIPTION
## Summary
- document that `bootstrap.ps1` calls `fix-path.ps1` to clean up the PATH
- mention why this is required when the PATH exceeds 1024 characters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c11196324832695a76f5aa96f6034