### PR TITLE
Update Windows docs for elevated bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ npm run smoke
 
 See the [installation guide](docs/installation.md) for setup instructions.
 After cloning the repository, run `./bootstrap.ps1` from an elevated
-PowerShell prompt. This script cleans up your PATH and enables the local Git
+PowerShell window. Running it with elevation allows
+`scripts/fix-path.ps1` to modify your user PATH and enables the local Git
 hooks automatically. On Windows it invokes `scripts/setup-hooks.ps1` while on
 other platforms it runs `scripts/setup-hooks.sh`.
 For a more detailed overview, see [docs/terminal.md](docs/terminal.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,9 @@ ruff check .
    ./scripts/setup-winget.ps1
    ```
 2. Copy or symlink the files from this repository to your profile directory.
-3. From an elevated PowerShell prompt, run `bootstrap.ps1` to set up your PATH.
+3. From an elevated PowerShell window, run `bootstrap.ps1` to set up your PATH.
+   You must run the script from an **elevated** window so that
+   `scripts/fix-path.ps1` can modify the user PATH.
    Pass `-InstallWinget` to install the core tools automatically. You can also
    add `-InstallWindowsTerminal` to copy the default Windows Terminal settings:
    ```powershell


### PR DESCRIPTION
## Summary
- clarify that `bootstrap.ps1` must run in an elevated PowerShell **window**
  so `fix-path.ps1` can change the user PATH

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c10f4f95c8326811f0ebc1ecf2ae7