### PR TITLE
Pin dspy version

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -23,4 +23,4 @@ Lint the codebase with `ruff`:
 ruff check .
 ```
 
-`dspy` powers the local LLM wrapper found in `llm/`, while `pytest` runs the test suite.
+`dspy` (version 2.6.27) powers the local LLM wrapper found in `llm/`, while `pytest` runs the test suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Local LLM utilities"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["dspy"]
+dependencies = ["dspy==2.6.27"]
 
 [project.optional-dependencies]
 test = ["pytest", "json5"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dspy
+dspy==2.6.27
 pytest
 json5
 ruff


### PR DESCRIPTION
## Summary
- pin dspy to version 2.6.27 in `pyproject.toml` and `requirements.txt`
- document the pinned version in `docs/ai-automation.md`

## Testing
- `pip install -e . -r requirements.txt`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c10f1aa1883268b023742e3a8974c