### PR TITLE
Add CI matrix for Python 3.10–3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,14 @@ jobs:
   test:
     name: Test (Ubuntu)
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - uses: actions/setup-node@v4
         with:
@@ -43,11 +46,14 @@ jobs:
   test-windows:
     name: Test (Windows)
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - uses: actions/setup-node@v4
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ dspy==2.6.27
 pytest
 json5
 ruff
+tomli; python_version < '3.11'

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -1,4 +1,7 @@
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
 from pathlib import Path
 
 def test_starship_time_and_git_status_sections():


### PR DESCRIPTION
## Summary
- test workflow against Python 3.10, 3.11 and 3.12
- install `tomli` for Python 3.10
- make starship tests compatible with Python 3.10

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8576bff88326a1edc412ff0aaa12