### PR TITLE
Add PowerShell wrapper for WSL setup

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -24,7 +24,11 @@ if ($InstallWSL -and $IsWindows) {
     & "$PSScriptRoot/scripts/install-wsl.ps1"
 }
 
-if ($SetupWSL -and (Get-Command bash -ErrorAction SilentlyContinue)) {
-    & bash "$PSScriptRoot/scripts/setup-wsl.sh"
+if ($SetupWSL) {
+    if ($IsWindows) {
+        & "$PSScriptRoot/scripts/setup-wsl.ps1"
+    } elseif (Get-Command bash -ErrorAction SilentlyContinue) {
+        & bash "$PSScriptRoot/scripts/setup-wsl.sh"
+    }
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,10 +41,10 @@ ruff check .
    You must run the script from an **elevated** window so that
    `scripts/fix-path.ps1` can modify the user PATH.
    Pass `-InstallWinget` to install the core tools automatically. You can also
-   add `-InstallWindowsTerminal` to copy the default Windows Terminal settings
-   and `-InstallWSL` to enable WSL:
+   add `-InstallWindowsTerminal` to copy the default Windows Terminal settings,
+   `-InstallWSL` to enable WSL, and `-SetupWSL` to configure the Ubuntu instance:
    ```powershell
-   ./bootstrap.ps1 -InstallWinget -InstallWindowsTerminal -InstallWSL
+   ./bootstrap.ps1 -InstallWinget -InstallWindowsTerminal -InstallWSL -SetupWSL
    ```
    The script calls `scripts/fix-path.ps1` to clean up duplicate entries and ensure your `bin` directory is included.
    If `$Env:USERPROFILE` isn't defined (e.g. on Linux), it falls back to `$HOME`.
@@ -63,7 +63,8 @@ You can also pass `-InstallWSL` to `bootstrap.ps1` to run the same command.
 
 Run the provided script from the repository root to install the basic tools on
 a fresh Ubuntu/WSL instance. The script uses `apt-get` and may prompt for your
-password. You can call it directly or pass `-SetupWSL` to `bootstrap.ps1`:
+password. Invoke it directly inside WSL or pass `-SetupWSL` to `bootstrap.ps1`
+from Windows to run it via `wsl.exe`:
 
 ```bash
 sudo bash scripts/setup-wsl.sh

--- a/scripts/setup-wsl.ps1
+++ b/scripts/setup-wsl.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    & bash (Join-Path $PSScriptRoot 'setup-wsl.sh')
+    return
+}
+
+if (-not (Get-Command wsl -ErrorAction SilentlyContinue)) {
+    Write-Error 'wsl.exe is required but not installed.'
+    exit 1
+}
+
+$script = Join-Path $PSScriptRoot 'setup-wsl.sh'
+& wsl.exe bash $script

--- a/tests/test_setup_wsl_ps1.py
+++ b/tests/test_setup_wsl_ps1.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+@pytest.mark.skipif(
+    shutil.which("pwsh") is None and shutil.which("powershell") is None,
+    reason="requires PowerShell",
+)
+def test_setup_wsl_ps1_invokes_wsl(tmp_path: Path) -> None:
+    pwsh = shutil.which("pwsh") or shutil.which("powershell")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "wsl.log"
+    create_exe(bin_dir / "wsl", f"#!/usr/bin/env bash\necho \"$@\" > '{log_file}'\n")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    subprocess.run(
+        [
+            pwsh,
+            "-NoLogo",
+            "-NoProfile",
+            "-Command",
+            (
+                "Set-Variable -Name IsWindows -Value $true -Force; "
+                f"& '{Path('scripts/setup-wsl.ps1')}'"
+            ),
+        ],
+        check=True,
+        env=env,
+    )
+
+    args = log_file.read_text().strip().split()
+    assert args and args[0] == "bash"
+    assert args[1].replace('\\', '/').endswith('scripts/setup-wsl.sh')


### PR DESCRIPTION
## Summary
- support running `setup-wsl.sh` from Windows with new `setup-wsl.ps1`
- call the wrapper from `bootstrap.ps1` when `-SetupWSL` is used on Windows
- document this option in the installation guide
- add test for the new PowerShell wrapper

## Testing
- `ruff check .`
- `pytest -q`
- `pytest -q tests/test_smoke_test.py`
- `npm run lint`
- `python scripts/validate_winget.py`

------
https://chatgpt.com/codex/tasks/task_e_685d857a2bfc83268ad09787b8764d4d