### PR TITLE
Add test for windows-terminal settings

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 ruff check .
+python3 windows-terminal/generate_settings.py \
+  windows-terminal/settings.base.json \
+  windows-terminal/settings.json \
+  --common windows-terminal/common-profiles.json
+git add windows-terminal/settings.json
 SCRIPT="scripts/export-winget.ps1"
 OS=$(uname -s)
 case "$OS" in

--- a/tests/test_generate_settings.py
+++ b/tests/test_generate_settings.py
@@ -1,0 +1,23 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_generated_settings_up_to_date(tmp_path):
+    script = Path('windows-terminal/generate_settings.py')
+    base = Path('windows-terminal/settings.base.json')
+    common = Path('windows-terminal/common-profiles.json')
+    output = tmp_path / 'settings.json'
+    subprocess.run([
+        sys.executable,
+        str(script),
+        str(base),
+        str(output),
+        '--common',
+        str(common),
+    ], check=True)
+    expected = Path('windows-terminal/settings.json').read_text(encoding='utf-8')
+    generated = output.read_text(encoding='utf-8')
+    assert generated == expected, (
+        "windows-terminal/settings.json is out of date; run generate_settings.py"
+    )


### PR DESCRIPTION
## Summary
- verify that windows-terminal/generate_settings.py generates settings.json
- regenerate windows-terminal settings before commit via git hook

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d857c0aac832688c9d1ba154f6d49