### PR TITLE
Fix path truncation logic

### DIFF
--- a/scripts/fix-path.ps1
+++ b/scripts/fix-path.ps1
@@ -38,17 +38,9 @@ if ($userProfile) {
 
 $joinedPath = $unique -join ';'
 $newPath = $joinedPath
-$originalCount = $unique.Count
-if ($newPath.Length -gt 1023) {
-    Write-Warning "PATH length exceeds 1023 characters and will be truncated."
-    $removed = $newPath.Substring(1023)
-    Write-Verbose "Removed portion: $removed" -Verbose
-    $newPath = $newPath.Substring(0, 1023)
 
-}
-$finalCount = ($newPath -split ';').Count
-if ($finalCount -lt $originalCount) {
-    Write-Warning 'Some PATH entries were dropped due to size limitations.'
+if ($newPath.Length -gt 32000) {
+    Write-Warning "PATH length exceeds 32k characters and may not be fully persisted on Windows."
 }
 
 [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')


### PR DESCRIPTION
## Summary
- remove old PATH truncation from `fix-path.ps1`
- warn only for very large PATH values
- update tests for new behavior and add extra long PATH check

## Testing
- `ruff check .`
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d858037fc8326a080b219d49c178a