### PR TITLE
Add Windows Terminal config tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ def load_json(path: Path):
 def test_windows_terminal_settings():
     data = load_json(Path('windows-terminal') / 'settings.json')
     assert data.get('defaultProfile'), 'default profile missing'
+    assert data['defaultProfile'] == '{1857054d-df21-5f4a-bd44-865a14a14d59}'
     assert 'profiles' in data
     profiles = data['profiles'].get('list', [])
     assert len(profiles) > 0, "no profiles configured"
@@ -55,6 +56,10 @@ def test_windows_terminal_split_bindings():
     assert binding_h.get('command', {}).get('action') == 'splitPane'
     assert binding_h.get('command', {}).get('split') == 'horizontal'
     assert binding_h.get('command', {}).get('profile') == '{574e775e-4f2a-5b96-ac1e-a2962a402336}'
+
+    binding_close = find_binding('ctrl+shift+w')
+    assert binding_close, 'Ctrl+Shift+W binding missing'
+    assert binding_close.get('command', {}).get('action') == 'closePane'
 
 
 

--- a/windows-terminal/settings.base.json
+++ b/windows-terminal/settings.base.json
@@ -33,6 +33,12 @@
         "profile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}"
       },
       "keys": "alt+h"
+    },
+    {
+      "command": {
+        "action": "closePane"
+      },
+      "keys": "ctrl+shift+w"
     }
   ],
   "copyFormatting": "none",

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -33,6 +33,12 @@
         "profile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}"
       },
       "keys": "alt+h"
+    },
+    {
+      "command": {
+        "action": "closePane"
+      },
+      "keys": "ctrl+shift+w"
     }
   ],
   "copyFormatting": "none",


### PR DESCRIPTION
## Summary
- verify default profile uses the Ubuntu GUID
- ensure ctrl+shift+w closes the active pane
- include closePane binding in Windows Terminal settings

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dcd3f92548326bca8d6e58682c900