### PR TITLE
Add check-hooks unit tests

### DIFF
--- a/tests/test_check_hooks.py
+++ b/tests/test_check_hooks.py
@@ -1,0 +1,27 @@
+import shutil
+import subprocess
+from pathlib import Path
+import pytest
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_check_hooks_reports_path(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "core.hooksPath", ".githooks"], cwd=repo, check=True)
+    result = subprocess.run(["bash", "scripts/check-hooks.sh"], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "Git hooks path is set to '.githooks'"
+    assert result.stderr == ""
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_check_hooks_reports_error_when_unset(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    result = subprocess.run(["bash", "scripts/check-hooks.sh"], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert "Git hooks are not configured" in result.stderr


### PR DESCRIPTION
## Summary
- add tests for `check-hooks.sh`
- verify the script shows the path when configured and warns when not set

## Testing
- `ruff check .`
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685dd151d9888326a0d94b3c8b9b7436