### PR TITLE
Add Starship blacklight palette and tests

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -4,12 +4,37 @@ format = """
 [└─](bold purple)$character
 """
 
-[git_status]
-disabled = false
-stashed = "📦"
+palette = "blacklight"
+
+[palettes.blacklight]
+black = "#282c34"
+red = "#e06c75"
+green = "#98c379"
+yellow = "#e5c07b"
+blue = "#61afef"
+purple = "#c678dd"
+cyan = "#56b6c2"
+white = "#dcdfe4"
+bright_black = "#282c34"
+bright_red = "#e06c75"
+bright_green = "#98c379"
+bright_yellow = "#e5c07b"
+bright_blue = "#61afef"
+bright_purple = "#c678dd"
+bright_cyan = "#56b6c2"
+bright_white = "#dcdfe4"
+
+[directory]
+style = "fg:blue"
 
 [git_branch]
 disabled = false
+style = "fg:purple"
+
+[git_status]
+disabled = false
+stashed = "📦"
+style = "fg:red"
 
 [git_state]
 disabled = false
@@ -17,6 +42,7 @@ disabled = false
 [time]
 disabled = false
 format = "[$time]($style) "
+style = "fg:yellow"
 
 [status]
 disabled = false

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -14,9 +14,40 @@ def test_starship_time_and_git_status_sections():
     assert 'status' in data, '[status] section missing'
     assert data['status'].get('disabled') is False, '[status] should be enabled'
 
+    assert 'directory' in data, '[directory] section missing'
+    assert data['directory'].get('style') == 'fg:blue', 'directory style mismatch'
+    assert data['git_branch'].get('style') == 'fg:purple', 'git_branch style mismatch'
+    assert data['git_status'].get('style') == 'fg:red', 'git_status style mismatch'
+    assert data['time'].get('style') == 'fg:yellow', 'time style mismatch'
+
 def test_starship_multiline_format():
     data = tomllib.loads(Path('starship.toml').read_text())
     expected = "[┌─](bold purple)$directory$git_branch$git_state$git_status$status$fill$time\n[└─](bold purple)$character\n"
     assert data.get('format') == expected, 'prompt format mismatch'
     assert data.get('add_newline') is False, 'add_newline should be false'
+
+def test_starship_palette():
+    data = tomllib.loads(Path('starship.toml').read_text())
+    assert data.get('palette') == 'blacklight', 'palette not set to blacklight'
+    palette = data.get('palettes', {}).get('blacklight', {})
+    expected_colors = {
+        'black': '#282c34',
+        'red': '#e06c75',
+        'green': '#98c379',
+        'yellow': '#e5c07b',
+        'blue': '#61afef',
+        'purple': '#c678dd',
+        'cyan': '#56b6c2',
+        'white': '#dcdfe4',
+        'bright_black': '#282c34',
+        'bright_red': '#e06c75',
+        'bright_green': '#98c379',
+        'bright_yellow': '#e5c07b',
+        'bright_blue': '#61afef',
+        'bright_purple': '#c678dd',
+        'bright_cyan': '#56b6c2',
+        'bright_white': '#dcdfe4',
+    }
+    for name, value in expected_colors.items():
+        assert palette.get(name) == value, f'{name} color mismatch'
 


### PR DESCRIPTION
## Summary
- add `blacklight` palette to `starship.toml`
- use palette in directory, git and time styles
- verify palette and styles in tests
- cover all colors in the palette tests

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685dd147d0a883268abe1c20d5046699