### PR TITLE
Add Blacklight theme

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,13 +24,15 @@ def test_windows_terminal_settings():
     assert defaults.get('useAcrylic') is True, 'acrylic not enabled'
     assert 'acrylicOpacity' in defaults, 'acrylic opacity missing'
     assert defaults.get('acrylicOpacity') == 0.85
-    color = defaults.get('colorScheme')
-    if not color:
-        for p in profiles:
-            if 'colorScheme' in p:
-                color = p['colorScheme']
-                break
-    assert color, 'color scheme missing'
+    expected_scheme = 'Blacklight'
+    assert defaults.get('colorScheme') == expected_scheme, 'default color scheme missing'
+
+    for profile in profiles:
+        scheme = profile.get('colorScheme', expected_scheme)
+        assert scheme == expected_scheme, f"profile {profile.get('name')} missing Blacklight scheme"
+
+    schemes = data.get('schemes', [])
+    assert any(s.get('name') == expected_scheme for s in schemes), 'Blacklight scheme not found'
     assert 'actions' in data and data['actions'], "action bindings missing"
 
 

--- a/windows-terminal/settings.base.json
+++ b/windows-terminal/settings.base.json
@@ -56,7 +56,7 @@
         "weight": "normal"
       },
       "acrylicOpacity": 0.85,
-      "colorScheme": "One Half Dark"
+      "colorScheme": "Blacklight"
     },
     "list": [
       {
@@ -64,11 +64,34 @@
         "hidden": false,
         "name": "Ubuntu",
         "source": "Microsoft.WSL",
-        "colorScheme": "Campbell"
+        "colorScheme": "Blacklight"
       }
     ]
   },
   "schemes": [
+    {
+      "name": "Blacklight",
+      "black": "#000000",
+      "red": "#ff66c4",
+      "green": "#b2ff59",
+      "yellow": "#ffff66",
+      "blue": "#66b2ff",
+      "purple": "#d066ff",
+      "cyan": "#66fff2",
+      "white": "#f2f2f2",
+      "brightBlack": "#666666",
+      "brightRed": "#ff66c4",
+      "brightGreen": "#b2ff59",
+      "brightYellow": "#ffff66",
+      "brightBlue": "#66b2ff",
+      "brightPurple": "#d066ff",
+      "brightCyan": "#66fff2",
+      "brightWhite": "#ffffff",
+      "background": "#0d001a",
+      "foreground": "#d0b3ff",
+      "cursorColor": "#ffffff",
+      "selectionBackground": "#301050"
+    },
     {
       "name": "One Half Dark",
       "black": "#282c34",

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -60,7 +60,7 @@
         "weight": "normal"
       },
       "acrylicOpacity": 0.85,
-      "colorScheme": "One Half Dark"
+      "colorScheme": "Blacklight"
     },
     "list": [
       {
@@ -74,11 +74,34 @@
         "hidden": false,
         "name": "Ubuntu",
         "source": "Microsoft.WSL",
-        "colorScheme": "Campbell"
+        "colorScheme": "Blacklight"
       }
     ]
   },
   "schemes": [
+    {
+      "name": "Blacklight",
+      "black": "#000000",
+      "red": "#ff66c4",
+      "green": "#b2ff59",
+      "yellow": "#ffff66",
+      "blue": "#66b2ff",
+      "purple": "#d066ff",
+      "cyan": "#66fff2",
+      "white": "#f2f2f2",
+      "brightBlack": "#666666",
+      "brightRed": "#ff66c4",
+      "brightGreen": "#b2ff59",
+      "brightYellow": "#ffff66",
+      "brightBlue": "#66b2ff",
+      "brightPurple": "#d066ff",
+      "brightCyan": "#66fff2",
+      "brightWhite": "#ffffff",
+      "background": "#0d001a",
+      "foreground": "#d0b3ff",
+      "cursorColor": "#ffffff",
+      "selectionBackground": "#301050"
+    },
     {
       "name": "One Half Dark",
       "black": "#282c34",


### PR DESCRIPTION
## Summary
- add new neon-violet **Blacklight** color scheme
- default Windows Terminal profiles now use Blacklight
- regenerate settings.json
- test that Blacklight scheme exists and is active
- ensure schemes are sorted alphabetically
- assert every profile uses Blacklight

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685dd142e9488326a5d87593139eb793