### PR TITLE
Add Blacklight palette section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ more details.
 
 For a more detailed overview, see [docs/terminal.md](docs/terminal.md).
 For details on fastfetch, btm and Nushell/Starship setup, see the [Terminal Tools section](docs/terminal.md#terminal-tools-fastfetch-btm--nushellstarship).
-For the **One Half Dark** and **Campbell** palettes and the `Alt+M` metrics pane binding used in the screenshots, see [Replicating the Screenshot Environment](docs/terminal.md#replicating-the-screenshot-environment).
+For the **One Half Dark** and **Campbell** palettes and the `Alt+M` metrics pane binding used in the screenshots, see [Replicating the Screenshot Environment](docs/terminal.md#replicating-the-screenshot-environment). For a brief overview of the unified palette and pane shortcuts, check [Blacklight Palette & Shortcuts](docs/terminal.md#blacklight-palette--shortcuts).
 
 
 ## Git hooks

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -164,6 +164,18 @@ source ~/.cache/starship/init.nu
 ```
 Customize the prompt by editing [`starship.toml`](../starship.toml) in this repository.
 
+## Blacklight Palette & Shortcuts
+
+The repository ships a unified **Blacklight** color scheme used by Windows Terminal and the Starship prompt. Run [`install-windows-terminal.ps1`](../scripts/install-windows-terminal.ps1) to copy `windows-terminal/settings.json` into the Windows Terminal *LocalState* folder. Then place [`starship.toml`](../starship.toml) in `~/.config/starship.toml` (or `%USERPROFILE%\.config\starship.toml` on Windows) so both tools share the same colors.
+
+After applying the palette, Windows Terminal defines these shortcuts:
+
+- `Alt+V` – split the current pane vertically.
+- `Alt+H` – split the current pane horizontally.
+- `Alt+M` – open a metrics pane running [`btm`](https://github.com/ClementTsang/bottom).
+
+Use [`setup-screenshot-env.sh`](../scripts/setup-screenshot-env.sh) (or its PowerShell equivalent) to install the helper tools automatically.
+
 
 ## LLM Assets
 


### PR DESCRIPTION
## Summary
- document a unified Blacklight palette and default pane shortcuts in `docs/terminal.md`
- point README to the new section

## Testing
- `pre-commit` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_685f308e40188326a376dfe7a86142d2