### PR TITLE
Fix duplicate function definition

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,12 +21,6 @@ def load_json(path: Path):
         return json5.loads(text)
 
 
-def find_binding(actions: list[dict], key: str) -> dict | None:
-    """Return the binding dict matching ``key`` if present."""
-    for action in actions:
-        if action.get("keys") == key:
-            return action
-    return None
 
 
 def test_windows_terminal_settings():


### PR DESCRIPTION
## Summary
- remove the redundant `find_binding` function from `tests/test_config.py`

## Testing
- `ruff check tests/test_config.py`
- `pytest tests/test_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685f3083c8e483268bf9da4083c52113