### PR TITLE
Fix skipping dspy tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Key directories:
 ## Quickstart
 
 Install the required Python packages (including test utilities such as
-`pytest` and `json5`):
+`pytest` and `json5`). The optional `dspy` dependency enables the full
+test suite but tests that rely on it will be skipped if the package is
+missing:
 
 ```bash
 pip install -e . -r requirements.txt
@@ -100,6 +102,8 @@ mode first and then install the rest of the dependencies:
 ```bash
 pip install -e .
 pip install -r requirements.txt
+# Optional: install `dspy` to run the complete suite
+pip install dspy-ai
 ```
 
 Then invoke `pytest`:

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,15 @@
+# Running the Tests
+
+The suite relies on `pytest` and `json5`. Some tests also require the optional
+[`dspy`](https://pypi.org/project/dspy-ai/) package. Those tests will be skipped
+if `dspy` isn't installed.
+
+Install dependencies and run the tests with:
+
+```bash
+pip install -e .
+pip install -r requirements.txt
+# optional: install dspy for the full suite
+pip install dspy-ai
+pytest
+```

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,14 +2,6 @@ import json
 from pathlib import Path
 import pytest
 
-
-def find_binding(actions: list[dict], key: str):
-    """Return the first binding in ``actions`` matching ``key``."""
-    for action in actions:
-        if action.get("keys") == key:
-            return action
-    return None
-
 json5 = pytest.importorskip("json5")
 
 

--- a/tests/test_utf8.py
+++ b/tests/test_utf8.py
@@ -1,9 +1,10 @@
 import json
 
 import pytest
-from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 
 dspy = pytest.importorskip("dspy")
+
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper  # noqa: E402
 
 def test_logged_fewshot_wrapper_reads_utf8(tmp_path):
     data = {"inputs": {"x": "café"}, "outputs": {"y": "naïve"}}

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,7 +1,8 @@
 import pytest
-from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper
 
 dspy = pytest.importorskip("dspy")
+
+from llm.universal_dspy_wrapper_v2 import LoggedFewShotWrapper  # noqa: E402
 
 class EchoPrediction:
     def __init__(self, text: str) -> None:

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -45,7 +45,6 @@
       "command": {
         "action": "closePane"
       },
-
       "keys": "ctrl+shift+w"
     }
   ],


### PR DESCRIPTION
## Summary
- skip `dspy` tests early so the suite runs without the package
- update README about optional `dspy`
- remove duplicate helper from test_config
- refresh generated terminal settings
- mention optional dspy in the new tests/README

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f3094d90c83269cfd48c738240e02