### PR TITLE
Fix quoting in setup-wsl.ps1

### DIFF
--- a/scripts/setup-wsl.ps1
+++ b/scripts/setup-wsl.ps1
@@ -11,4 +11,4 @@ if (-not (Get-Command wsl -ErrorAction SilentlyContinue)) {
 }
 
 $script = Join-Path $PSScriptRoot 'setup-wsl.sh'
-& wsl.exe bash $script
+& wsl.exe bash "`"$script`""


### PR DESCRIPTION
## Summary
- quote the script path when invoking `wsl.exe`

## Testing
- `ruff check .`
- `pytest -q`
- `pytest -q tests/test_smoke_test.py`
- `npm run lint`
- `python scripts/validate_winget.py`


------
https://chatgpt.com/codex/tasks/task_e_6860e02d2cdc8326b781050ab172f328