### PR TITLE
Add Git check to setup-hooks

### DIFF
--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Exit early if Git is not installed
+if ! command -v git >/dev/null 2>&1; then
+    echo "git is required" >&2
+    exit 1
+fi
+
 # Configure Git to use local hooks directory if not already set
 current_path=$(git config --get core.hooksPath || true)
 if [[ -z "$current_path" ]]; then


### PR DESCRIPTION
## Summary
- fail fast in `setup-hooks.sh` when Git is missing

## Testing
- `ruff check .`
- `npm run lint`
- `pytest -q`
- `pytest -q tests/test_smoke_test.py`


------
https://chatgpt.com/codex/tasks/task_e_6860e02eda888326a315f71ff5c1c421