### PR TITLE
Refine winget validation error handling

### DIFF
--- a/scripts/validate_winget.py
+++ b/scripts/validate_winget.py
@@ -17,7 +17,10 @@ def validate(path: Path) -> bool:
     """
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except Exception as exc:  # noqa: BLE001
+    except FileNotFoundError:
+        print(f"{path} not found", file=sys.stderr)
+        return False
+    except json.JSONDecodeError as exc:
         print(f"Failed to parse {path}: {exc}", file=sys.stderr)
         return False
 


### PR DESCRIPTION
## Summary
- handle `FileNotFoundError` and `JSONDecodeError` separately in `validate_winget.py`
- drop the broad `except Exception` clause

## Testing
- `ruff check .`
- `pytest tests/test_validate_winget.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860e02ef16c8326804097990e866338