### PR TITLE
Handle case insensitive paths in universal wrapper

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import os
 import re
 
 import shutil
@@ -41,7 +42,8 @@ except (subprocess.CalledProcessError, FileNotFoundError) as exc:
     _REPO_ROOT = Path.cwd()
 
 _PATH_REGEX = re.compile(
-    rf"^(?P<root>{re.escape(_REPO_ROOT.as_posix())})/.+(?P<data>[^/]+\.(?:ya?ml|json))$"
+    rf"^(?P<root>{re.escape(_REPO_ROOT.as_posix())})/.+(?P<data>[^/]+\.(?:ya?ml|json))$",
+    re.IGNORECASE if os.name == "nt" else 0,
 )
 
 

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+import os
 
 import pytest
 
@@ -51,6 +52,24 @@ def test_is_repo_data_path_windows_and_posix():
 
     assert is_repo_data_path(posix_path)
     assert is_repo_data_path(windows_path)
+
+
+def test_is_repo_data_path_mixed_case(monkeypatch):
+    """Paths should be case-insensitive on Windows."""
+    mixed = Path(f"{_REPO_ROOT.as_posix().upper()}/FiLe.JsOn")
+
+    if os.name == "nt":
+        assert is_repo_data_path(mixed)
+    else:
+        assert not is_repo_data_path(mixed)
+
+        import importlib
+        import sys
+
+        monkeypatch.setattr("os.name", "nt", raising=False)
+        sys.modules.pop("llm.universal_dspy_wrapper_v2", None)
+        module = importlib.import_module("llm.universal_dspy_wrapper_v2")
+        assert module.is_repo_data_path(mixed)
 
 
 def test_repo_root_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- allow case-insensitive path matching in `universal_dspy_wrapper_v2`
- test mixed-case paths on Windows
- simplify path normalization

## Testing
- `ruff check llm/universal_dspy_wrapper_v2.py tests/test_universal_dspy_wrapper_v2.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860e02de8b88326a60f1caefefb7bf1