### PR TITLE
Handle missing tomli_w gracefully

### DIFF
--- a/scripts/thm.py
+++ b/scripts/thm.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 
 try:
@@ -28,10 +29,12 @@ def apply_palette(palette_name: str, repo_root: Path) -> None:
     """Apply ``palette_name`` to Starship and Windows Terminal."""
     try:
         import tomli_w
-    except ModuleNotFoundError as e:
-        raise ModuleNotFoundError(
-            "tomli_w is required; install with 'pip install -e .[cli]'"
-        ) from e
+    except ModuleNotFoundError:
+        print(
+            "tomli_w is required; install with 'pip install -e .[cli]'",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     palette_file = repo_root / "palettes" / f"{palette_name}.toml"
     if not palette_file.exists():

--- a/tests/test_thm.py
+++ b/tests/test_thm.py
@@ -22,6 +22,7 @@ def test_list_palettes_outputs_available_palettes(tmp_path):
 
 
 def test_apply_updates_configs(tmp_path):
+    pytest.importorskip("tomli_w")
     repo_root = Path(__file__).resolve().parents[1]
     script = repo_root / "scripts" / "thm.py"
 
@@ -74,3 +75,30 @@ def test_apply_unknown_palette_errors(tmp_path):
             check=True,
             env=env,
         )
+
+
+def test_apply_missing_tomli_w_exits_with_error(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "thm.py"
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+    shutil.copy(repo_root / "starship.toml", dest / "starship.toml")
+    shutil.copy(
+        repo_root / "windows-terminal" / "settings.json",
+        dest / "windows-terminal" / "settings.json",
+    )
+    for p in (repo_root / "palettes").glob("*.toml"):
+        shutil.copy(p, dest / "palettes" / p.name)
+
+    env = os.environ.copy()
+    env["THM_REPO_ROOT"] = str(dest)
+    result = subprocess.run(
+        [sys.executable, "-S", str(script), "apply", "dracula"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "tomli_w is required" in result.stderr


### PR DESCRIPTION
## Summary
- gracefully handle missing `tomli_w` by printing error and exiting
- skip config update test when `tomli_w` missing
- test CLI behaviour when `tomli_w` is absent

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e1ca3b5c8326b572f4b55f4505e8