### PR TITLE
Enhance hook setup scripts

### DIFF
--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -1,6 +1,22 @@
 # Configure Git to use local hooks directory if not already set.
 $ErrorActionPreference = 'Stop'
 
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Error 'git is required'
+    exit 1
+}
+
+try {
+    $insideRepo = git rev-parse --is-inside-work-tree 2>$null
+} catch {
+    $insideRepo = $null
+}
+
+if ($insideRepo -ne 'true') {
+    Write-Error 'This script must be run inside a Git repository.'
+    exit 1
+}
+
 try {
     $currentPath = git config --get core.hooksPath 2>$null
 } catch {

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -7,6 +7,12 @@ if ! command -v git >/dev/null 2>&1; then
     exit 1
 fi
 
+# Verify that we are inside a Git repository
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: this script must be run inside a Git repository" >&2
+    exit 1
+fi
+
 # Configure Git to use local hooks directory if not already set
 current_path=$(git config --get core.hooksPath || true)
 if [[ -z "$current_path" ]]; then

--- a/tests/test_setup_hooks.py
+++ b/tests/test_setup_hooks.py
@@ -43,3 +43,36 @@ def test_setup_hooks_sh_sets_core_hooks_path(tmp_path):
         check=True,
     )
     assert result.stdout.strip() == ".githooks"
+
+
+@pytest.mark.skipif(
+    shutil.which("pwsh") is None and shutil.which("powershell") is None,
+    reason="requires PowerShell",
+)
+def test_setup_hooks_ps1_requires_git_repo(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+    pwsh = shutil.which("pwsh") or shutil.which("powershell")
+    result = subprocess.run(
+        [pwsh, "-NoLogo", "-NoProfile", "-File", "scripts/setup-hooks.ps1"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Git repository" in result.stderr
+
+
+def test_setup_hooks_sh_requires_git_repo(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+    result = subprocess.run(
+        ["bash", "scripts/setup-hooks.sh"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Git repository" in result.stderr


### PR DESCRIPTION
## Summary
- require a git repo when running `setup-hooks.sh`
- add the same check for PowerShell
- test that both scripts fail outside a repo

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e1c996ac832688b527db807daf9a