### PR TITLE
Validate THM palette key

### DIFF
--- a/scripts/thm.py
+++ b/scripts/thm.py
@@ -37,7 +37,12 @@ def apply_palette(palette_name: str, repo_root: Path) -> None:
     if not palette_file.exists():
         raise FileNotFoundError(f"Palette '{palette_name}' not found")
 
-    colors = load_palette(palette_file)[palette_name]
+    palettes = load_palette(palette_file)
+    if palette_name not in palettes:
+        raise ValueError(
+            f"Palette file '{palette_file}' does not contain key '{palette_name}'"
+        )
+    colors = palettes[palette_name]
 
     # Update starship.toml
     starship = repo_root / "starship.toml"

--- a/tests/test_thm.py
+++ b/tests/test_thm.py
@@ -74,3 +74,27 @@ def test_apply_unknown_palette_errors(tmp_path):
             check=True,
             env=env,
         )
+
+
+def test_apply_missing_key_errors(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "thm.py"
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+    shutil.copy(repo_root / "starship.toml", dest / "starship.toml")
+    shutil.copy(
+        repo_root / "windows-terminal" / "settings.json",
+        dest / "windows-terminal" / "settings.json",
+    )
+    (dest / "palettes" / "missing.toml").write_text("[wrong]\nfoo='bar'\n")
+
+    env = os.environ.copy()
+    env["THM_REPO_ROOT"] = str(dest)
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.run(
+            [sys.executable, str(script), "apply", "missing"],
+            check=True,
+            env=env,
+        )


### PR DESCRIPTION
## Summary
- check palette TOML has the expected key in `thm.py`
- raise a helpful error when the palette key is missing
- test missing key behaviour

## Testing
- `ruff check .`
- `npm run lint`
- `pytest -q`
- `pytest -q tests/test_smoke_test.py`
- `python scripts/validate_winget.py`


------
https://chatgpt.com/codex/tasks/task_e_6861e1c922f083269ccd898849e08a81