### PR TITLE
Handle missing config files in thm

### DIFF
--- a/scripts/thm.py
+++ b/scripts/thm.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 
 try:
@@ -41,6 +42,9 @@ def apply_palette(palette_name: str, repo_root: Path) -> None:
 
     # Update starship.toml
     starship = repo_root / "starship.toml"
+    if not starship.exists():
+        print(f"Error: {starship} not found", file=sys.stderr)
+        raise SystemExit(1)
     data = tomllib.loads(starship.read_text(encoding="utf-8"))
     data["palette"] = palette_name
     palettes = data.setdefault("palettes", {})
@@ -49,6 +53,9 @@ def apply_palette(palette_name: str, repo_root: Path) -> None:
 
     # Update Windows Terminal settings
     wt_settings = repo_root / "windows-terminal" / "settings.json"
+    if not wt_settings.exists():
+        print(f"Error: {wt_settings} not found", file=sys.stderr)
+        raise SystemExit(1)
     wt_data = json.loads(wt_settings.read_text(encoding="utf-8"))
     scheme_name = palette_name.replace("-", " ").title()
     mapping = {

--- a/tests/test_thm.py
+++ b/tests/test_thm.py
@@ -74,3 +74,55 @@ def test_apply_unknown_palette_errors(tmp_path):
             check=True,
             env=env,
         )
+
+
+def test_apply_missing_starship_errors(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "thm.py"
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+
+    # Only copy windows-terminal settings
+    shutil.copy(
+        repo_root / "windows-terminal" / "settings.json",
+        dest / "windows-terminal" / "settings.json",
+    )
+    for p in (repo_root / "palettes").glob("*.toml"):
+        shutil.copy(p, dest / "palettes" / p.name)
+
+    env = os.environ.copy()
+    env["THM_REPO_ROOT"] = str(dest)
+    result = subprocess.run(
+        [sys.executable, str(script), "apply", "dracula"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "starship.toml" in result.stderr
+
+
+def test_apply_missing_wt_settings_errors(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "thm.py"
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+
+    shutil.copy(repo_root / "starship.toml", dest / "starship.toml")
+    for p in (repo_root / "palettes").glob("*.toml"):
+        shutil.copy(p, dest / "palettes" / p.name)
+
+    env = os.environ.copy()
+    env["THM_REPO_ROOT"] = str(dest)
+    result = subprocess.run(
+        [sys.executable, str(script), "apply", "dracula"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "windows-terminal" in result.stderr or "settings.json" in result.stderr


### PR DESCRIPTION
## Summary
- fail early if starship.toml or Windows Terminal settings.json are missing
- test missing files in `thm` CLI

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e1c88d84832684f609cc5795efbb