### PR TITLE
Handle invalid JSON in generate_settings

### DIFF
--- a/tests/test_generate_settings.py
+++ b/tests/test_generate_settings.py
@@ -21,3 +21,23 @@ def test_generated_settings_up_to_date(tmp_path):
     assert generated == expected, (
         "windows-terminal/settings.json is out of date; run generate_settings.py"
     )
+
+
+def test_generate_settings_invalid_json(tmp_path: Path) -> None:
+    script = Path("windows-terminal/generate_settings.py")
+    bad_base = tmp_path / "bad.json"
+    bad_base.write_text("{ invalid json", encoding="utf-8")
+    output = tmp_path / "out.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            str(bad_base),
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert f"Failed to parse JSON from {bad_base}" in result.stderr
+

--- a/windows-terminal/generate_settings.py
+++ b/windows-terminal/generate_settings.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """Generate Windows Terminal settings from a base file and common profiles."""
 import json
+import sys
 from pathlib import Path
 import argparse
 
 
 def load_json(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as ex:
+        print(f"Failed to parse JSON from {path}: {ex}", file=sys.stderr)
+        sys.exit(1)
 
 
 def merge_profiles(common: dict, override: dict) -> dict:


### PR DESCRIPTION
## Summary
- add graceful JSON parsing to Windows Terminal settings generator
- test error handling for malformed JSON

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e1c7c9508326aeb4f8a9da2011fb