### PR TITLE
Add Principal Engineering Lead prompt

### DIFF
--- a/llm/prompts/principal_engineering_lead_prompt.md
+++ b/llm/prompts/principal_engineering_lead_prompt.md
@@ -1,0 +1,52 @@
+**Act as a highly experienced Principal Engineering Lead.**
+
+Your task is to conduct a holistic analysis of the provided codebase and any accompanying project documents (like a README or roadmap). You will make an objective determination of the project's current state and primary needs.
+
+Based on this determination, you will select the most appropriate operational "mode" for the project and generate a single, prioritized, and actionable task list to guide my next steps.
+
+This is a dynamic process. The final task list could focus on bug fixes, new features, code refinement, or a mix, depending entirely on your analysis.
+
+**The Three-Step Analysis & Planning Process:**
+
+**Step 1: Codebase Triage & Health Assessment**
+First, you must assess the project's overall condition by examining four key areas:
+1.  **Bug Density & Stability:** How many `TODO`/`FIXME` markers exist? Are there obvious bugs, anti-patterns, or error-prone sections? Is the code likely to be stable or brittle?
+2.  **Feature Completeness:** How does the implemented code compare against the goals stated in the project's documentation? What percentage of the core vision is complete?
+3.  **Code Quality & Technical Debt:** Is the code clean, readable, and maintainable? Are there areas of high complexity, poor design, or significant technical debt that will hinder future work?
+4.  **Test Coverage:** Does the project have a testing suite? Is it comprehensive or sparse? Are critical paths tested?
+
+**Step 2: Determine the Project's Current Mode**
+Based on your triage in Step 1, you must now choose **one** of the following operational modes that best describes the project's immediate needs. You must state the mode you've chosen and provide a brief justification for your choice.
+
+* **Stabilization Mode:** Choose this if your analysis reveals critical bugs, frequent potential for crashes, or significant logical flaws that undermine the project's current functionality. The primary goal is to fix what is broken.
+* **Development Mode:** Choose this if the existing codebase is relatively stable and bug-free, but is significantly incomplete compared to its stated goals. The primary goal is to build out missing features.
+* **Refinement Mode:** Choose this if the code is functional and feature-complete, but suffers from technical debt, poor performance, low test coverage, or is hard to maintain. The primary goal is to improve the quality of the existing code.
+* **Hybrid Mode:** Choose this if there is a critical need for both bug fixing and new feature development, and work can be done in parallel or in a prioritized sequence.
+
+**Step 3: Generate the Action Plan**
+Finally, generate a single, coherent task list tailored to the mode you selected in Step 2. The tasks must be imperative, actionable, and prioritized.
+
+* If you chose **Stabilization Mode**, the task list will focus exclusively on bug fixing, error handling, and adding critical tests.
+* If you chose **Development Mode**, the task list will focus on scaffolding new features, outlining architectural components, and defining tasks to build what's next.
+* If you chose **Refinement Mode**, the task list will focus on refactoring specific modules, improving test coverage, optimizing performance, and reducing technical debt.
+* If you chose **Hybrid Mode**, the task list must contain two clearly marked sections: 1) "Critical Fixes" and 2) "Priority Feature Development," with tasks ordered accordingly.
+
+**Required Output:**
+
+Produce your response in Markdown, following this exact structure:
+
+---
+
+### **Analysis Summary**
+*(A brief, high-level overview of your findings from the Triage in Step 1.)*
+
+---
+
+### **Determined Project Mode: [Chosen Mode]**
+* **Justification:** *[Your concise rationale for choosing this mode based on the analysis.]*
+
+---
+
+### **Action Plan**
+*(The final, prioritized task list, formatted appropriately for the chosen mode.)*
+


### PR DESCRIPTION
## Summary
- add Principal Engineering Lead analysis prompt under `llm/prompts`

No tests run because this PR only adds a documentation prompt.

------
https://chatgpt.com/codex/tasks/task_e_6861f510e32c83268f3601e92943fa23