### PR TITLE
Add pytest-xdist to tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
         run: ruff check .
 
       - name: Run tests
-        run: pytest -q
+        run: pytest -n auto
       - name: Run smoke test
-        run: pytest -q tests/test_smoke_test.py
+        run: pytest -n auto tests/test_smoke_test.py
       - name: Run lint
         run: npm run lint
       - name: Validate winget packages
@@ -69,9 +69,9 @@ jobs:
         run: ruff check .
 
       - name: Run tests
-        run: pytest -q
+        run: pytest -n auto
       - name: Run smoke test
-        run: pytest -q tests/test_smoke_test.py
+        run: pytest -n auto tests/test_smoke_test.py
       - name: Run lint
         run: npm run lint
       - name: Validate winget packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,11 @@ requires-python = ">=3.10"
 dependencies = ["dspy==2.6.27"]
 
 [project.optional-dependencies]
-test = ["pytest", "json5"]
+test = [
+    "pytest",
+    "pytest-xdist",
+    "json5",
+]
 cli = ["tomli_w"]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dspy==2.6.27
 pytest
+pytest-xdist
 json5
 ruff
 tomli; python_version < '3.11'


### PR DESCRIPTION
## Summary
- include `pytest-xdist` in optional test dependencies
- parallelize GitHub Actions tests using `pytest -n auto`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f5f7ac5483268e6e620c8b816fb2