### PR TITLE
Add merge_profiles duplicate GUID tests

### DIFF
--- a/tests/test_generate_settings.py
+++ b/tests/test_generate_settings.py
@@ -1,6 +1,17 @@
 import subprocess
 import sys
 from pathlib import Path
+import importlib.util
+
+
+def _load_generate_settings():
+    spec = importlib.util.spec_from_file_location(
+        "generate_settings", Path("windows-terminal/generate_settings.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_generated_settings_up_to_date(tmp_path):
@@ -40,4 +51,58 @@ def test_generate_settings_invalid_json(tmp_path: Path) -> None:
     )
     assert result.returncode == 1
     assert f"Failed to parse JSON from {bad_base}" in result.stderr
+
+
+def test_merge_profiles_duplicate_guid() -> None:
+    module = _load_generate_settings()
+    common = {
+        "defaults": {"a": 1},
+        "list": [
+            {"guid": "{1111}", "name": "base", "color": "blue"},
+            {"guid": "{1111}", "name": "base-dup"},
+            {"name": "base-no-guid"},
+        ],
+    }
+    override = {
+        "defaults": {"b": 2},
+        "list": [
+            {"guid": "{1111}", "name": "override"},
+            {"name": "override-no-guid"},
+        ],
+    }
+
+    result = module.merge_profiles(common, override)
+
+    assert result["defaults"] == {"a": 1, "b": 2}
+    assert result["list"] == [
+        {"guid": "{1111}", "name": "override", "color": "blue"},
+        {"guid": "{1111}", "name": "base-dup"},
+        {"name": "base-no-guid"},
+        {"name": "override-no-guid"},
+    ]
+
+
+def test_merge_profiles_override_duplicates() -> None:
+    module = _load_generate_settings()
+    common = {
+        "defaults": {},
+        "list": [
+            {"guid": "{2222}", "name": "base"},
+        ],
+    }
+    override = {
+        "defaults": {},
+        "list": [
+            {"guid": "{2222}", "name": "first"},
+            {"guid": "{2222}", "name": "second"},
+            {"name": "no-guid"},
+        ],
+    }
+
+    result = module.merge_profiles(common, override)
+
+    assert result["list"] == [
+        {"guid": "{2222}", "name": "second"},
+        {"name": "no-guid"},
+    ]
 


### PR DESCRIPTION
## Summary
- add helper to load generate_settings module
- test merge_profiles with duplicate GUIDs
- ensure override duplicates handled correctly

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f5f5fd188326b32f3177b0cd0738