### PR TITLE
Add test for missing winget packages

### DIFF
--- a/tests/test_validate_winget.py
+++ b/tests/test_validate_winget.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 from pathlib import Path
 import sys
@@ -13,3 +14,18 @@ def test_validate_winget_malformed(tmp_path: Path) -> None:
     )
     assert result.returncode != 0
     assert "Failed to parse" in result.stderr
+
+
+def test_validate_winget_no_packages(tmp_path: Path) -> None:
+    json_file = tmp_path / "no_packages.json"
+    json_file.write_text(
+        json.dumps({"Sources": [{"Name": "TestSource"}]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_winget.py", str(json_file)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "has no packages" in result.stderr


### PR DESCRIPTION
## Summary
- cover validate_winget when a source omits packages

## Testing
- `ruff check .`
- `pytest tests/test_validate_winget.py::test_validate_winget_no_packages -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f5f503d88326ae7b08bfff7b36cb