### PR TITLE
Add success test for validate_winget

### DIFF
--- a/tests/test_validate_winget.py
+++ b/tests/test_validate_winget.py
@@ -13,3 +13,17 @@ def test_validate_winget_malformed(tmp_path: Path) -> None:
     )
     assert result.returncode != 0
     assert "Failed to parse" in result.stderr
+
+
+def test_validate_winget_success(tmp_path: Path) -> None:
+    valid_json = tmp_path / "good.json"
+    valid_json.write_text(
+        '{"Sources": [{"Packages": ["foo"]}]}',
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_winget.py", str(valid_json)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- ensure validate_winget.py succeeds with valid JSON

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f5f4520083268eaa1ee92693d219