### PR TITLE
Update AI automation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Run `ruff` to lint the Python code:
 ruff check .
 ```
 
+The installation also provides an `ai` command for routing prompts to your chosen
+model:
+
+```bash
+# Send the prompt to the remote provider
+ai "Write a Python script"
+
+# Force evaluation with your local model
+ai --local "Translate text"
+```
+
 Next, install the Git hooks so `pre-commit` runs automatically:
 
 ```powershell

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -23,4 +23,20 @@ Lint the codebase with `ruff`:
 ruff check .
 ```
 
-`dspy` (version 2.6.27) powers the local LLM wrapper found in `llm/`, while `pytest` runs the test suite.
+
+`dspy` (version 2.6.27) powers the local LLM wrapper found in `llm/`, while
+`pytest` runs the test suite.
+
+## LLM Routing CLI
+
+Use the `ai` command to route prompts to your configured language model. By
+default the tool sends the request to your remote provider, but passing
+`--local` forces evaluation with the local LLM instead.
+
+```bash
+# Send the prompt to the provider configured in your environment
+ai "Write a Python script"
+
+# Run the prompt against the locally installed model
+ai --local "Translate text"
+```


### PR DESCRIPTION
## Summary
- add LLM routing CLI section to ai-automation docs
- document using the `ai` command in the README quickstart

## Testing
- no tests run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68628c6db9d88326b05a7292e3e707e5