### PR TITLE
Add preferred model config docs and tests

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -40,3 +40,19 @@ ai "Write a Python script"
 # Run the prompt against the locally installed model
 ai --local "Translate text"
 ```
+
+## LLM Configuration
+
+`get_preferred_models()` reads model names from a JSON file. By default the
+project looks for `llm/llm_config.json` in the repository root, but you can set
+`LLM_CONFIG_PATH` to specify another location or pass a path when calling the
+function.
+
+Example configuration:
+
+```json
+{
+  "primary_model": "gpt-4",
+  "fallback_model": "gpt-3.5-turbo"
+}
+```

--- a/tests/test_preferred_models.py
+++ b/tests/test_preferred_models.py
@@ -1,0 +1,27 @@
+import json
+
+from llm.ai_router import get_preferred_models
+
+
+def test_defaults_returned_when_config_missing(tmp_path):
+    path = tmp_path / "missing.json"
+    primary, fallback = get_preferred_models("p", "f", config_path=path)
+    assert primary == "p"
+    assert fallback == "f"
+
+
+def test_reading_from_config(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"primary_model": "x", "fallback_model": "y"}))
+    primary, fallback = get_preferred_models("p", "f", config_path=cfg)
+    assert primary == "x"
+    assert fallback == "y"
+
+
+def test_env_var_overrides_default(tmp_path, monkeypatch):
+    cfg = tmp_path / "env.json"
+    cfg.write_text(json.dumps({"primary_model": "m1", "fallback_model": "m2"}))
+    monkeypatch.setenv("LLM_CONFIG_PATH", str(cfg))
+    primary, fallback = get_preferred_models("p", "f")
+    assert primary == "m1"
+    assert fallback == "m2"


### PR DESCRIPTION
## Summary
- document the JSON format for configuring preferred LLM models
- test `get_preferred_models()` for defaults, file loading and env override

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630b27777883269496f34c9b4a6e65