### PR TITLE
Add AI executor utility

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -40,3 +40,23 @@ ai "Write a Python script"
 # Run the prompt against the locally installed model
 ai --local "Translate text"
 ```
+
+## Shell Command Planning
+
+`scripts/ai_exec.py` converts high level requests into shell commands using the
+same backend as the `ai` helper. Each command is printed before execution and
+requires an explicit `y` confirmation; pressing `Enter` or `n` skips that
+command.
+
+Examples:
+
+```bash
+# Build and install dependencies
+python scripts/ai_exec.py "create a venv and install requirements"
+
+# Commit and push changes using the local model
+python scripts/ai_exec.py "git add . && git commit -m 'update' && git push" --local
+```
+
+This interactive review makes the workflow safer by ensuring you see and approve
+every command before it runs.

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Plan and execute shell commands using the configured LLM backend."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from typing import Iterable
+
+from scripts import ai_router
+
+
+PLAN_TEMPLATE = """\
+Plan the shell commands needed to accomplish this task:
+{instruction}
+Return one command per line with no explanations.
+"""
+
+
+def plan_commands(instruction: str, *, local: bool = False, model: str = ai_router.DEFAULT_MODEL) -> list[str]:
+    """Return a list of shell commands for ``instruction``."""
+    prompt = PLAN_TEMPLATE.format(instruction=instruction)
+    output = ai_router.send_prompt(prompt, local=local, model=model)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def confirm(cmd: str) -> bool:
+    """Return ``True`` if the user confirms running ``cmd``."""
+    resp = input(f"Run '{cmd}'? [y/N]: ")
+    return resp.strip().lower().startswith("y")
+
+
+def run_commands(commands: Iterable[str]) -> int:
+    """Run each command after confirmation. Return the last return code."""
+    rc = 0
+    for cmd in commands:
+        print(cmd)
+        if confirm(cmd):
+            completed = subprocess.run(cmd, shell=True)
+            rc = completed.returncode
+            if rc != 0:
+                break
+    return rc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("instruction", help="Task description for the planner")
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Use local model via Ollama instead of Gemini",
+    )
+    parser.add_argument(
+        "--model",
+        default=ai_router.DEFAULT_MODEL,
+        help="Model name for planning (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    commands = plan_commands(args.instruction, local=args.local, model=args.model)
+    return run_commands(commands)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -1,0 +1,55 @@
+import io
+import contextlib
+
+from scripts import ai_exec
+
+
+def test_plans_and_runs_commands(monkeypatch):
+    def fake_send(prompt, *, local=False, model=ai_exec.ai_router.DEFAULT_MODEL):
+        assert "task" in prompt.lower()
+        return "echo 1\necho 2"
+
+    runs = []
+
+    def fake_run(cmd, shell=True):
+        runs.append(cmd)
+        class R:
+            returncode = 0
+        return R()
+
+    inputs = iter(["y", "n"])
+    monkeypatch.setattr(ai_exec.ai_router, "send_prompt", fake_send)
+    monkeypatch.setattr(ai_exec.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_exec.main(["do something", "--model", "m", "--local"])
+
+    assert rc == 0
+    assert runs == ["echo 1"]
+    lines = out.getvalue().splitlines()
+    assert "echo 1" in lines
+    assert "echo 2" in lines
+
+
+def test_stops_on_command_failure(monkeypatch):
+    monkeypatch.setattr(
+        ai_exec.ai_router,
+        "send_prompt",
+        lambda *_args, **_kwargs: "bad 1\necho 2",
+    )
+
+    runs = []
+    def fake_run(cmd, shell=True):
+        runs.append(cmd)
+        class R:
+            returncode = 1 if len(runs) == 1 else 0
+        return R()
+
+    monkeypatch.setattr(ai_exec.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    rc = ai_exec.main(["task"])
+    assert rc == 1
+    assert runs == ["bad 1"]


### PR DESCRIPTION
## Summary
- add `scripts/ai_exec.py` for planning and executing shell commands via the LLM backend with per-command confirmation
- document command planning workflow in `docs/ai-automation.md`
- test planning and confirmation logic with mocked subprocesses
- clarify docs and add failure stopping tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68630b29aca8832683dcfe30cf011f6b