### PR TITLE
Add planning CLI entry and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ ai "Write a Python script"
 
 # Force evaluation with your local model
 ai --local "Translate text"
+
+# Generate a step-by-step plan
+ai-plan "Refactor the codebase"
 ```
 
 Next, install the Git hooks so `pre-commit` runs automatically:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ cli = ["tomli_w"]
 [project.scripts]
 thm = "scripts.thm:main"
 ai = "scripts.ai_router:main"
+ai-plan = "scripts.ai_exec:main"
 
 
 [tool.setuptools.packages.find]

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Simple AI execution planner using ``ai_router``."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from typing import List, Optional
+
+from scripts import ai_router
+from llm.ai_router import get_preferred_models
+
+
+def plan(goal: str, *, config_path: Optional[str] = None) -> List[str]:
+    """Return planning steps for ``goal`` using preferred models."""
+    primary, fallback = get_preferred_models(
+        ai_router.DEFAULT_MODEL, ai_router.DEFAULT_MODEL, config_path=config_path
+    )
+    try:
+        text = ai_router.run_gemini(goal, model=primary)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        text = ai_router.run_ollama(goal, model=fallback)
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("goal")
+    parser.add_argument("--config")
+    args = parser.parse_args(argv)
+    steps = plan(args.goal, config_path=args.config)
+    for step in steps:
+        print(step)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Route prompts to Gemini or Ollama."""
 
-
 from __future__ import annotations
 
 import argparse
@@ -52,7 +51,10 @@ def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL)
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("prompt", help="Prompt to send to the model")
+    parser.add_argument(
+        "prompt",
+        help="Prompt to send to the model or '-' to read from STDIN",
+    )
     parser.add_argument(
         "--local",
         action="store_true",
@@ -62,12 +64,15 @@ def main(argv: list[str] | None = None) -> int:
         "--model",
         default=DEFAULT_MODEL,
         help="Model name for Ollama (default: %(default)s)",
-
     )
     args = parser.parse_args(argv)
 
+    prompt = args.prompt
+    if prompt == "-":
+        prompt = sys.stdin.read()
+
     try:
-        output = send_prompt(args.prompt, local=args.local, model=args.model)
+        output = send_prompt(prompt, local=args.local, model=args.model)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -79,5 +84,4 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-
     raise SystemExit(main())

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -1,0 +1,61 @@
+import subprocess
+import io
+import contextlib
+
+from scripts import ai_exec
+
+
+def test_plan_uses_primary(monkeypatch):
+    calls = []
+
+    def fake_gemini(prompt, model=None):
+        calls.append(("gemini", prompt, model))
+        return "step1\nstep2"
+
+    def fail_ollama(prompt, model):
+        raise AssertionError("ollama should not be called")
+
+    monkeypatch.setattr(ai_exec.ai_router, "run_gemini", fake_gemini)
+    monkeypatch.setattr(ai_exec.ai_router, "run_ollama", fail_ollama)
+    monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
+
+    steps = ai_exec.plan("goal")
+    assert steps == ["step1", "step2"]
+    assert calls == [("gemini", "goal", "g")]
+
+
+def test_plan_falls_back(monkeypatch):
+    calls = []
+
+    def failing_gemini(prompt, model=None):
+        calls.append(("gemini", prompt, model))
+        raise subprocess.CalledProcessError(1, ["gemini"])
+
+    def fake_ollama(prompt, model):
+        calls.append(("ollama", prompt, model))
+        return "fallback"
+
+    monkeypatch.setattr(ai_exec.ai_router, "run_gemini", failing_gemini)
+    monkeypatch.setattr(ai_exec.ai_router, "run_ollama", fake_ollama)
+    monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
+
+    steps = ai_exec.plan("goal")
+    assert steps == ["fallback"]
+    assert calls == [
+        ("gemini", "goal", "g"),
+        ("ollama", "goal", "o"),
+    ]
+
+
+def test_main_invokes_plan(monkeypatch):
+    def mock_plan(goal: str, *, config_path=None):
+        assert goal == "goal"
+        assert config_path == "cfg.json"
+        return ["one", "two"]
+
+    monkeypatch.setattr(ai_exec, "plan", mock_plan)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_exec.main(["goal", "--config", "cfg.json"])
+    assert rc == 0
+    assert out.getvalue().splitlines() == ["one", "two"]

--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -1,8 +1,11 @@
 import io
 import contextlib
 import subprocess
+import json
+import sys
 
 from scripts import ai_router
+from llm import ai_router as llm_router
 
 
 def test_send_prompt_calls_gemini(monkeypatch):
@@ -61,3 +64,33 @@ def test_cli_invokes_send_prompt(monkeypatch):
     assert rc == 0
     assert out.getvalue().strip() == "ok"
 
+
+def test_cli_reads_stdin(monkeypatch):
+    def mock_send_prompt(prompt, *, local=False, model=ai_router.DEFAULT_MODEL):
+        assert prompt == "from-stdin"
+        assert local is False
+        assert model == ai_router.DEFAULT_MODEL
+        return "done"
+
+    monkeypatch.setattr(ai_router, "send_prompt", mock_send_prompt)
+    out = io.StringIO()
+    stdin = io.StringIO("from-stdin")
+    monkeypatch.setattr(sys, "stdin", stdin)
+    with contextlib.redirect_stdout(out):
+        rc = ai_router.main(["-"])
+    assert rc == 0
+    assert out.getvalue() == "done\n"
+
+
+def test_get_preferred_models_config_override(tmp_path, monkeypatch):
+    cfg = {"primary_model": "p", "fallback_model": "f"}
+    config_file = tmp_path / "cfg.json"
+    config_file.write_text(json.dumps(cfg))
+    primary, fallback = llm_router.get_preferred_models("d1", "d2", config_path=config_file)
+    assert (primary, fallback) == ("p", "f")
+
+    config_file2 = tmp_path / "env.json"
+    config_file2.write_text(json.dumps({"primary_model": "envp"}))
+    monkeypatch.setenv("LLM_CONFIG_PATH", str(config_file2))
+    primary2, fallback2 = llm_router.get_preferred_models("d3", "fb")
+    assert (primary2, fallback2) == ("envp", "fb")


### PR DESCRIPTION
## Summary
- register `ai-plan` entry point for AI planner
- document `ai-plan` command usage
- test `ai_exec.main` invocation

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68630b2c90c88326b4b705d420e305b0