### PR TITLE
Fix ruff lint error and document contributing steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,15 @@ Then invoke `pytest`:
 pytest
 ```
 
+## Contributing
+
+Run `ruff` before committing to ensure the Python code is lint-free:
+
+```bash
+ruff check .
+```
+
+After fixing any lint errors, rerun the command and verify that it reports zero
+issues. The `pre-commit` hook runs the same command automatically.
+
 Licensed under the [Apache 2.0](LICENSE) license.

--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -2,7 +2,6 @@ import io
 import json
 import contextlib
 import subprocess
-import json
 
 import sys
 


### PR DESCRIPTION
## Summary
- remove duplicate `json` import
- add a Contributing section mentioning Ruff

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863381348a4832695a5267357411c15