### PR TITLE
Add interactive command runner test

### DIFF
--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Execute shell commands with interactive confirmation."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from typing import Iterable
+
+
+def confirm(cmd: str) -> bool:
+    """Return ``True`` if the user confirms running ``cmd``."""
+    resp = input(f"Run '{cmd}'? [y/N]: ")
+    return resp.strip().lower().startswith("y")
+
+
+def run_commands(commands: Iterable[str]) -> int:
+    """Run each command after confirmation. Return the last exit code."""
+    rc = 0
+    for cmd in commands:
+        print(cmd)
+        if confirm(cmd):
+            completed = subprocess.run(cmd, shell=True)
+            rc = completed.returncode
+            if rc != 0:
+                break
+    return rc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("commands", nargs="+", help="Shell commands to run")
+    args = parser.parse_args(argv)
+    return run_commands(args.commands)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -1,0 +1,45 @@
+import io
+import contextlib
+import subprocess
+
+from scripts import ai_do
+
+
+def test_run_commands_respects_user_input(monkeypatch):
+    runs = []
+
+    def fake_run(cmd, shell=True):
+        runs.append(cmd)
+        class R:
+            returncode = 0
+        return R()
+
+    inputs = iter(["y", "n"])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_do.run_commands(["echo 1", "echo 2"])
+
+    assert rc == 0
+    assert runs == ["echo 1"]
+    lines = out.getvalue().splitlines()
+    assert "echo 1" in lines
+    assert "echo 2" in lines
+
+
+def test_run_commands_stops_on_failure(monkeypatch):
+    runs = []
+    def fake_run(cmd, shell=True):
+        runs.append(cmd)
+        class R:
+            returncode = 1 if len(runs) == 1 else 0
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    rc = ai_do.run_commands(["bad", "ok"])
+    assert rc == 1
+    assert runs == ["bad"]

--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -2,7 +2,6 @@ import io
 import json
 import contextlib
 import subprocess
-import json
 
 import sys
 


### PR DESCRIPTION
## Summary
- add `ai_do` script for confirming and running shell commands
- test interactive execution logic in `test_ai_do.py`
- clean up duplicate import in existing router tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68633812a3108326b93ef4abf6183b66