### PR TITLE
Add robust complexity threshold parsing

### DIFF
--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -74,6 +74,16 @@ def _run_backend(name: str, prompt: str, model: str) -> str:
     raise ValueError(f"Unknown backend: {name}")
 
 
+def _get_threshold(env_val: str | None) -> int:
+    """Return the complexity threshold parsed from ``env_val``."""
+    if env_val is None:
+        return DEFAULT_COMPLEXITY_THRESHOLD
+    try:
+        return int(env_val)
+    except ValueError:
+        return DEFAULT_COMPLEXITY_THRESHOLD
+
+
 def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL) -> str:
     """Send ``prompt`` using the configured backends."""
     primary, fallback = _preferred_backends()
@@ -89,9 +99,7 @@ def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL)
             if fallback:
                 order.append(fallback)
         else:  # auto
-            threshold = int(
-                os.environ.get("LLM_COMPLEXITY_THRESHOLD", DEFAULT_COMPLEXITY_THRESHOLD)
-            )
+            threshold = _get_threshold(os.environ.get("LLM_COMPLEXITY_THRESHOLD"))
             complexity = estimate_prompt_complexity(prompt)
             if complexity > threshold:
                 order.append(primary)

--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -100,6 +100,25 @@ def test_env_complexity_threshold(monkeypatch):
     assert out == "gemini:two words:g1"
 
 
+def test_env_complexity_threshold_invalid(monkeypatch):
+    _set_env(monkeypatch, "gemini", "ollama")
+    monkeypatch.setenv("LLM_COMPLEXITY_THRESHOLD", "x")
+
+    long_prompt = " ".join(["word"] * (ai_router.DEFAULT_COMPLEXITY_THRESHOLD + 1))
+
+    def mock_run_gemini(prompt, model=None):
+        return f"gemini:{prompt}:{model}"
+
+    def fail_run_ollama(prompt, model):
+        raise AssertionError("ollama should not be called")
+
+    monkeypatch.setattr(ai_router, "run_gemini", mock_run_gemini)
+    monkeypatch.setattr(ai_router, "run_ollama", fail_run_ollama)
+
+    out = ai_router.send_prompt(long_prompt, model="g1")
+    assert out.startswith("gemini:")
+
+
 def test_cli_invokes_send_prompt(monkeypatch):
     def mock_send_prompt(prompt, *, local=False, model=ai_router.DEFAULT_MODEL):
         assert prompt == "cli"


### PR DESCRIPTION
## Summary
- add helper `_get_threshold` to safely parse complexity threshold from the environment
- use `_get_threshold` when computing routing complexity
- test fallback to default threshold with invalid env var

## Testing
- `ruff check .`
- `pytest tests/test_ai_router.py::test_env_complexity_threshold_invalid -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644721e3d4832689e47fa71b5be8ce