### PR TITLE
Add test for invalid LLM_COMPLEXITY_THRESHOLD

### DIFF
--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -89,9 +89,11 @@ def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL)
             if fallback:
                 order.append(fallback)
         else:  # auto
-            threshold = int(
-                os.environ.get("LLM_COMPLEXITY_THRESHOLD", DEFAULT_COMPLEXITY_THRESHOLD)
-            )
+            raw_threshold = os.environ.get("LLM_COMPLEXITY_THRESHOLD")
+            try:
+                threshold = int(raw_threshold) if raw_threshold is not None else DEFAULT_COMPLEXITY_THRESHOLD
+            except ValueError:
+                threshold = DEFAULT_COMPLEXITY_THRESHOLD
             complexity = estimate_prompt_complexity(prompt)
             if complexity > threshold:
                 order.append(primary)

--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -100,6 +100,25 @@ def test_env_complexity_threshold(monkeypatch):
     assert out == "gemini:two words:g1"
 
 
+def test_invalid_complexity_threshold(monkeypatch):
+    _set_env(monkeypatch, "gemini", "ollama")
+    monkeypatch.setenv("LLM_COMPLEXITY_THRESHOLD", "invalid")
+
+    long_prompt = " ".join(["word"] * (ai_router.DEFAULT_COMPLEXITY_THRESHOLD + 1))
+
+    def mock_run_gemini(prompt, model=None):
+        return f"gemini:{prompt}:{model}"
+
+    def fail_run_ollama(prompt, model):  # pragma: no cover - ensure unused
+        raise AssertionError("ollama should not be called")
+
+    monkeypatch.setattr(ai_router, "run_gemini", mock_run_gemini)
+    monkeypatch.setattr(ai_router, "run_ollama", fail_run_ollama)
+
+    out = ai_router.send_prompt(long_prompt, model="g1")
+    assert out.startswith("gemini:")
+
+
 def test_cli_invokes_send_prompt(monkeypatch):
     def mock_send_prompt(prompt, *, local=False, model=ai_router.DEFAULT_MODEL):
         assert prompt == "cli"


### PR DESCRIPTION
## Summary
- fallback to the default complexity threshold when the `LLM_COMPLEXITY_THRESHOLD` env var is invalid
- test this behaviour in `tests/test_ai_router.py`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644750cb94832698f308d68711a1a0