### PR TITLE
Add tests for OpenRouter backend

### DIFF
--- a/tests/test_openrouter_backend.py
+++ b/tests/test_openrouter_backend.py
@@ -1,0 +1,53 @@
+import pytest
+
+from llm.backends import OpenRouterBackend
+from scripts import ai_router
+
+
+def test_openrouter_backend_returns_string():
+    backend = OpenRouterBackend("m")
+    assert backend.run("p") == "openrouter:p:m"
+
+
+def test_run_openrouter_uses_dspy_backend(monkeypatch):
+    dspy = pytest.importorskip("dspy")  # noqa: F841 - ensure dependency present
+
+    calls = []
+
+    class Dummy:
+        def __init__(self, model):
+            calls.append(("init", model))
+
+        def run(self, prompt: str) -> str:
+            calls.append(("run", prompt))
+            return "dspy"
+
+    class Fail:
+        def __init__(self, *a, **k):
+            raise AssertionError("OpenRouterBackend should not be used")
+
+    monkeypatch.setattr(ai_router, "OpenRouterDSPyBackend", Dummy)
+    monkeypatch.setattr(ai_router, "OpenRouterBackend", Fail)
+
+    out = ai_router.run_openrouter("hi", "model")
+    assert out == "dspy"
+    assert calls == [("init", "model"), ("run", "hi")]
+
+
+def test_run_openrouter_without_dspy(monkeypatch):
+    calls = []
+
+    class Dummy:
+        def __init__(self, model):
+            calls.append(("init", model))
+
+        def run(self, prompt: str) -> str:
+            calls.append(("run", prompt))
+            return "cli"
+
+    monkeypatch.setattr(ai_router, "OpenRouterDSPyBackend", None)
+    monkeypatch.setattr(ai_router, "OpenRouterBackend", Dummy)
+
+    out = ai_router.run_openrouter("yo", "m")
+    assert out == "cli"
+    assert calls == [("init", "m"), ("run", "yo")]


### PR DESCRIPTION
## Summary
- cover OpenRouter backend via new tests
- verify OpenRouterDSPyBackend is used when available
- ensure fallback to OpenRouterBackend when DSPy is unavailable

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864474ff7d88326a065db29d2f0f238