### PR TITLE
Add mypy configuration and integrate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e . -r requirements.txt
+          pip install mypy
           npm ci
       - name: Run ruff
         run: ruff check .
+
+      - name: Run mypy
+        run: mypy llm scripts
 
       - name: Run tests
         run: pytest -n auto
@@ -64,9 +68,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e . -r requirements.txt
+          pip install mypy
           npm ci
       - name: Run ruff
         run: ruff check .
+
+      - name: Run mypy
+        run: mypy llm scripts
 
       - name: Run tests
         run: pytest -n auto

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+LoggedFewShotWrapperType: type[Any] | None
+is_repo_data_path_fn: Callable[[str | Path], bool] | None
 
 try:  # pragma: no cover - optional dependency
-    from .universal_dspy_wrapper_v2 import LoggedFewShotWrapper, is_repo_data_path
+    from .universal_dspy_wrapper_v2 import (
+        LoggedFewShotWrapper as LoggedFewShotWrapperType,
+        is_repo_data_path as is_repo_data_path_fn,
+    )
 except ImportError:  # dspy not installed
-    LoggedFewShotWrapper = None  # type: ignore[assignment]
-    is_repo_data_path = None  # type: ignore[assignment]
+    LoggedFewShotWrapperType = None
+    is_repo_data_path_fn = None
+
+LoggedFewShotWrapper: type[Any] | None = LoggedFewShotWrapperType
+is_repo_data_path: Callable[[str | Path], bool] | None = is_repo_data_path_fn
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .ai_router import get_preferred_models as _get_preferred_models  # noqa: F401

--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -3,16 +3,24 @@ from .gemini import GeminiBackend
 from .ollama import OllamaBackend
 from .openrouter import OpenRouterBackend
 
+GeminiDSPyBackendType: type[Backend] | None
+OllamaDSPyBackendType: type[Backend] | None
+OpenRouterDSPyBackendType: type[Backend] | None
+
 try:  # pragma: no cover - optional dependency
     from .dspy_backends import (
-        GeminiDSPyBackend,
-        OllamaDSPyBackend,
-        OpenRouterDSPyBackend,
+        GeminiDSPyBackend as GeminiDSPyBackendType,
+        OllamaDSPyBackend as OllamaDSPyBackendType,
+        OpenRouterDSPyBackend as OpenRouterDSPyBackendType,
     )
 except Exception:  # pragma: no cover - dspy missing
-    GeminiDSPyBackend = None
-    OllamaDSPyBackend = None
-    OpenRouterDSPyBackend = None
+    GeminiDSPyBackendType = None
+    OllamaDSPyBackendType = None
+    OpenRouterDSPyBackendType = None
+
+GeminiDSPyBackend: type[Backend] | None = GeminiDSPyBackendType
+OllamaDSPyBackend: type[Backend] | None = OllamaDSPyBackendType
+OpenRouterDSPyBackend: type[Backend] | None = OpenRouterDSPyBackendType
 
 __all__ = [
     "Backend",

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+python_version = 3.10
+ignore_missing_imports = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+strict_equality = true
+
+[mypy.llm.*]
+strict = true
+
+[mypy.scripts.*]
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ test = [
     "pytest",
     "pytest-xdist",
     "json5",
+    "mypy",
 ]
 cli = ["tomli_w"]
 

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+from pathlib import Path
 from typing import List, Optional
 
 from scripts import ai_router
@@ -15,12 +16,14 @@ from llm.ai_router import get_preferred_models
 def plan(goal: str, *, config_path: Optional[str] = None) -> List[str]:
     """Return planning steps for ``goal`` using preferred models."""
     primary, fallback = get_preferred_models(
-        ai_router.DEFAULT_MODEL, ai_router.DEFAULT_MODEL, config_path=config_path
+        ai_router.DEFAULT_MODEL,
+        ai_router.DEFAULT_MODEL,
+        config_path=Path(config_path) if config_path else None,
     )
     try:
         text = ai_router.run_gemini(goal, model=primary)
     except (FileNotFoundError, subprocess.CalledProcessError):
-        text = ai_router.run_ollama(goal, model=fallback)
+        text = ai_router.run_ollama(goal, model=fallback or ai_router.DEFAULT_MODEL)
     return [line.strip() for line in text.splitlines() if line.strip()]
 
 

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 
 from llm.backends import (
+    Backend,
     GeminiBackend,
     OllamaBackend,
     OpenRouterBackend,
@@ -32,24 +33,34 @@ def estimate_prompt_complexity(prompt: str) -> int:
 
 def run_gemini(prompt: str, model: str | None = None) -> str:
     """Return Gemini response for ``prompt``."""
-    backend_cls = GeminiDSPyBackend if GeminiDSPyBackend is not None else GeminiBackend
-    backend = backend_cls(model)  # type: ignore[arg-type]
+    backend_cls: type[Backend]
+    if GeminiDSPyBackend is not None:
+        backend_cls = GeminiDSPyBackend
+    else:
+        backend_cls = GeminiBackend
+    backend = backend_cls(model)  # type: ignore[call-arg]
     return backend.run(prompt)
 
 
 def run_ollama(prompt: str, model: str) -> str:
     """Return Ollama response for ``prompt`` using ``model``."""
-    backend_cls = OllamaDSPyBackend if OllamaDSPyBackend is not None else OllamaBackend
-    backend = backend_cls(model)  # type: ignore[arg-type]
+    backend_cls: type[Backend]
+    if OllamaDSPyBackend is not None:
+        backend_cls = OllamaDSPyBackend
+    else:
+        backend_cls = OllamaBackend
+    backend = backend_cls(model)  # type: ignore[call-arg]
     return backend.run(prompt)
 
 
 def run_openrouter(prompt: str, model: str) -> str:
     """Return OpenRouter response for ``prompt`` using ``model``."""
-    backend_cls = (
-        OpenRouterDSPyBackend if OpenRouterDSPyBackend is not None else OpenRouterBackend
-    )
-    backend = backend_cls(model)  # type: ignore[arg-type]
+    backend_cls: type[Backend]
+    if OpenRouterDSPyBackend is not None:
+        backend_cls = OpenRouterDSPyBackend
+    else:
+        backend_cls = OpenRouterBackend
+    backend = backend_cls(model)  # type: ignore[call-arg]
     return backend.run(prompt)
 
 


### PR DESCRIPTION
## Summary
- add `mypy.ini` enabling strict checks for `llm/` and `scripts/`
- install and run `mypy` in CI
- include `mypy` in optional test dependencies
- adjust code to satisfy `mypy` strict mode

## Testing
- `ruff check .`
- `pytest -q`
- `npm run lint`
- `mypy llm scripts`

------
https://chatgpt.com/codex/tasks/task_e_6864475187c883268bd6851e7a6f1f67