### PR TITLE
Add LangChain backend option

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -2,6 +2,7 @@ from .base import Backend
 from .gemini import GeminiBackend
 from .ollama import OllamaBackend
 from .openrouter import OpenRouterBackend
+from ..langchain_backend import LangChainBackend
 
 try:  # pragma: no cover - optional dependency
     from .dspy_backends import (
@@ -19,6 +20,7 @@ __all__ = [
     "GeminiBackend",
     "OllamaBackend",
     "OpenRouterBackend",
+    "LangChainBackend",
     "GeminiDSPyBackend",
     "OllamaDSPyBackend",
     "OpenRouterDSPyBackend",

--- a/llm/langchain_backend.py
+++ b/llm/langchain_backend.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from .backends.base import Backend
+
+
+class LangChainBackend(Backend):
+    """Backend that delegates to a LangChain chain."""
+
+    def __init__(self, chain: object) -> None:
+        self.chain = chain
+
+    def run(self, prompt: str) -> str:
+        try:
+            result = self.chain.invoke({"input": prompt})
+        except Exception:
+            result = self.chain.invoke(prompt)
+        if isinstance(result, dict):
+            result = result.get("text") or result.get("output") or result
+        return str(result)

--- a/tests/test_langchain_backend.py
+++ b/tests/test_langchain_backend.py
@@ -1,0 +1,47 @@
+from llm.langchain_backend import LangChainBackend
+import io
+import contextlib
+from scripts import ai_router
+
+
+class DummyChain:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def invoke(self, data):
+        self.calls.append(data)
+        return "out"
+
+
+def test_langchain_backend_invokes_chain():
+    chain = DummyChain()
+    backend = LangChainBackend(chain)
+    result = backend.run("hello")
+    assert result == "out"
+    assert chain.calls == [{"input": "hello"}]
+
+
+def test_cli_backend_option(monkeypatch):
+    def mock_run_langchain(prompt: str) -> str:
+        assert prompt == "cli"
+        return "ok"
+
+    monkeypatch.setattr(ai_router, "run_langchain", mock_run_langchain)
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_router.main(["--backend", "langchain", "cli"])
+    assert rc == 0
+    assert out.getvalue().strip() == "ok"
+
+def test_run_backend_langchain(monkeypatch):
+    calls = []
+
+    def mock_run(prompt: str) -> str:
+        calls.append(prompt)
+        return "done"
+
+    monkeypatch.setattr(ai_router, "run_langchain", mock_run)
+    out = ai_router._run_backend("langchain", "hi", "m")
+    assert out == "done"
+    assert calls == ["hi"]


### PR DESCRIPTION
## Summary
- implement optional `LangChainBackend`
- support `--backend langchain` in `ai_router` CLI
- add tests covering the new backend

## Testing
- `ruff check llm scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864474208188326a0ffb38677bd6c11