### PR TITLE
Add Textual UI prototype

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -181,6 +181,19 @@ Use [`setup-screenshot-env.sh`](../scripts/setup-screenshot-env.sh) (or its Powe
 
 The `llm` directory collects prompts and other files related to language models.
 Place custom prompts under `llm/prompts/` and organize subfolders as needed.
+
+## Textual UI Prototype
+
+A lightweight interface using [Textual](https://textual.textualize.io/) lives
+under `ui/textual_app.py`. Launch it with:
+
+```bash
+python -m ui.textual_app
+```
+
+Use **Send** to route prompts via `ai_router.send_prompt` and **Apply** to call
+`thm.apply_palette`. Palette names are loaded from the `palettes/` directory and
+responses or status messages show directly in the terminal window.
 ---
 
 ## Cloning & Managing Dotfiles

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Prototype UI package."""

--- a/ui/textual_app.py
+++ b/ui/textual_app.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.widgets import Input, Button, Static, Select
+from textual.containers import Vertical
+
+from scripts.ai_router import send_prompt
+from scripts.thm import apply_palette, PALETTES_DIR, REPO_ROOT
+
+
+class TerminalUI(App):
+    """Minimal Textual interface for prompt sending and palette application."""
+
+    CSS_PATH = None
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - simple UI
+        palettes = [(p.stem, p.stem) for p in PALETTES_DIR.glob("*.toml")]
+        yield Vertical(
+            Static("Send Prompt"),
+            Input(placeholder="Enter prompt", id="prompt"),
+            Button("Send", id="send"),
+            Static(id="response"),
+            Static("Apply Palette"),
+            Select(palettes, id="palette"),
+            Button("Apply", id="apply"),
+            Static(id="status"),
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:  # pragma: no cover
+        if event.button.id == "send":
+            prompt = self.query_one("#prompt", Input).value
+            if prompt:
+                result = send_prompt(prompt)
+                self.query_one("#response", Static).update(result)
+        elif event.button.id == "apply":
+            palette = self.query_one("#palette", Select).value
+            if palette:
+                apply_palette(palette, REPO_ROOT)
+                self.query_one("#status", Static).update(f"Applied {palette}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    TerminalUI().run()


### PR DESCRIPTION
## Summary
- prototype Textual UI to send prompts and apply terminal palettes
- document how to launch the prototype in terminal.md

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864473ee9948326b106b0058deafe56