### PR TITLE
Refactor router logic into library

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -1,0 +1,118 @@
+"""LLM routing utilities."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import List
+
+from .backends import (
+    GeminiBackend,
+    GeminiDSPyBackend,
+    OllamaBackend,
+    OllamaDSPyBackend,
+    OpenRouterBackend,
+    OpenRouterDSPyBackend,
+)
+from .ai_router import get_preferred_models
+
+DEFAULT_MODEL = "llama3"
+DEFAULT_PRIMARY_BACKEND = "gemini"
+DEFAULT_FALLBACK_BACKEND = "ollama"
+
+DEFAULT_COMPLEXITY_THRESHOLD = 50
+
+
+def estimate_prompt_complexity(prompt: str) -> int:
+    """Return a basic complexity score for ``prompt``."""
+    return len(prompt.split())
+
+
+def run_gemini(prompt: str, model: str | None = None) -> str:
+    """Return Gemini response for ``prompt``."""
+    backend_cls = GeminiDSPyBackend if GeminiDSPyBackend is not None else GeminiBackend
+    backend = backend_cls(model)  # type: ignore[arg-type]
+    return backend.run(prompt)
+
+
+def run_ollama(prompt: str, model: str) -> str:
+    """Return Ollama response for ``prompt`` using ``model``."""
+    backend_cls = OllamaDSPyBackend if OllamaDSPyBackend is not None else OllamaBackend
+    backend = backend_cls(model)  # type: ignore[arg-type]
+    return backend.run(prompt)
+
+
+def run_openrouter(prompt: str, model: str) -> str:
+    """Return OpenRouter response for ``prompt`` using ``model``."""
+    backend_cls = (
+        OpenRouterDSPyBackend if OpenRouterDSPyBackend is not None else OpenRouterBackend
+    )
+    backend = backend_cls(model)  # type: ignore[arg-type]
+    return backend.run(prompt)
+
+
+def _preferred_backends() -> tuple[str, str | None]:
+    env_primary = os.environ.get("LLM_PRIMARY_BACKEND")
+    env_fallback = os.environ.get("LLM_FALLBACK_BACKEND")
+    if env_primary:
+        return env_primary, env_fallback
+    return get_preferred_models(DEFAULT_PRIMARY_BACKEND, DEFAULT_FALLBACK_BACKEND)
+
+
+def _run_backend(name: str, prompt: str, model: str) -> str:
+    name = name.lower()
+    if name == "gemini":
+        return run_gemini(prompt, model)
+    if name == "ollama":
+        return run_ollama(prompt, model)
+    if name == "openrouter":
+        return run_openrouter(prompt, model)
+    raise ValueError(f"Unknown backend: {name}")
+
+
+def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL) -> str:
+    """Send ``prompt`` using the configured backends."""
+    primary, fallback = _preferred_backends()
+    order: List[str] = []
+
+    env_mode = os.environ.get("LLM_ROUTING_MODE", "auto").lower()
+    if local or env_mode == "local":
+        if fallback:
+            order.append(fallback)
+    else:
+        if env_mode == "remote":
+            order.append(primary)
+            if fallback:
+                order.append(fallback)
+        else:  # auto
+            threshold = int(
+                os.environ.get("LLM_COMPLEXITY_THRESHOLD", DEFAULT_COMPLEXITY_THRESHOLD)
+            )
+            complexity = estimate_prompt_complexity(prompt)
+            if complexity > threshold:
+                order.append(primary)
+                if fallback:
+                    order.append(fallback)
+            else:
+                if fallback:
+                    order.append(fallback)
+                order.append(primary)
+    for backend_name in order:
+        try:
+            return _run_backend(backend_name, prompt, model)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            continue
+    raise RuntimeError("Unable to process prompt")
+
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "DEFAULT_PRIMARY_BACKEND",
+    "DEFAULT_FALLBACK_BACKEND",
+    "DEFAULT_COMPLEXITY_THRESHOLD",
+    "estimate_prompt_complexity",
+    "run_gemini",
+    "run_ollama",
+    "run_openrouter",
+    "send_prompt",
+]

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Simple AI execution planner using ``ai_router``."""
+"""Simple AI execution planner using the router utilities."""
 
 
 from __future__ import annotations
@@ -8,19 +8,19 @@ import argparse
 import subprocess
 from typing import List, Optional
 
-from scripts import ai_router
+from llm import router
 from llm.ai_router import get_preferred_models
 
 
 def plan(goal: str, *, config_path: Optional[str] = None) -> List[str]:
     """Return planning steps for ``goal`` using preferred models."""
     primary, fallback = get_preferred_models(
-        ai_router.DEFAULT_MODEL, ai_router.DEFAULT_MODEL, config_path=config_path
+        router.DEFAULT_MODEL, router.DEFAULT_MODEL, config_path=config_path
     )
     try:
-        text = ai_router.run_gemini(goal, model=primary)
+        text = router.run_gemini(goal, model=primary)
     except (FileNotFoundError, subprocess.CalledProcessError):
-        text = ai_router.run_ollama(goal, model=fallback)
+        text = router.run_ollama(goal, model=fallback)
     return [line.strip() for line in text.splitlines() if line.strip()]
 
 

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -4,109 +4,12 @@
 from __future__ import annotations
 
 import argparse
-import os
 import subprocess
 import sys
 
-from llm.backends import (
-    GeminiBackend,
-    OllamaBackend,
-    OpenRouterBackend,
-    GeminiDSPyBackend,
-    OllamaDSPyBackend,
-    OpenRouterDSPyBackend,
-)
-from llm.ai_router import get_preferred_models
+from llm import router
 
-DEFAULT_MODEL = "llama3"
-DEFAULT_PRIMARY_BACKEND = "gemini"
-DEFAULT_FALLBACK_BACKEND = "ollama"
-
-DEFAULT_COMPLEXITY_THRESHOLD = 50
-
-
-def estimate_prompt_complexity(prompt: str) -> int:
-    """Return a basic complexity score for ``prompt``."""
-    return len(prompt.split())
-
-
-def run_gemini(prompt: str, model: str | None = None) -> str:
-    """Return Gemini response for ``prompt``."""
-    backend_cls = GeminiDSPyBackend if GeminiDSPyBackend is not None else GeminiBackend
-    backend = backend_cls(model)  # type: ignore[arg-type]
-    return backend.run(prompt)
-
-
-def run_ollama(prompt: str, model: str) -> str:
-    """Return Ollama response for ``prompt`` using ``model``."""
-    backend_cls = OllamaDSPyBackend if OllamaDSPyBackend is not None else OllamaBackend
-    backend = backend_cls(model)  # type: ignore[arg-type]
-    return backend.run(prompt)
-
-
-def run_openrouter(prompt: str, model: str) -> str:
-    """Return OpenRouter response for ``prompt`` using ``model``."""
-    backend_cls = (
-        OpenRouterDSPyBackend if OpenRouterDSPyBackend is not None else OpenRouterBackend
-    )
-    backend = backend_cls(model)  # type: ignore[arg-type]
-    return backend.run(prompt)
-
-
-def _preferred_backends() -> tuple[str, str | None]:
-    env_primary = os.environ.get("LLM_PRIMARY_BACKEND")
-    env_fallback = os.environ.get("LLM_FALLBACK_BACKEND")
-    if env_primary:
-        return env_primary, env_fallback
-    return get_preferred_models(
-        DEFAULT_PRIMARY_BACKEND, DEFAULT_FALLBACK_BACKEND
-    )
-
-
-def _run_backend(name: str, prompt: str, model: str) -> str:
-    name = name.lower()
-    if name == "gemini":
-        return run_gemini(prompt, model)
-    if name == "ollama":
-        return run_ollama(prompt, model)
-    if name == "openrouter":
-        return run_openrouter(prompt, model)
-    raise ValueError(f"Unknown backend: {name}")
-
-
-def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL) -> str:
-    """Send ``prompt`` using the configured backends."""
-    primary, fallback = _preferred_backends()
-    order: list[str] = []
-
-    env_mode = os.environ.get("LLM_ROUTING_MODE", "auto").lower()
-    if local or env_mode == "local":
-        if fallback:
-            order.append(fallback)
-    else:
-        if env_mode == "remote":
-            order.append(primary)
-            if fallback:
-                order.append(fallback)
-        else:  # auto
-            threshold = int(
-                os.environ.get("LLM_COMPLEXITY_THRESHOLD", DEFAULT_COMPLEXITY_THRESHOLD)
-            )
-            complexity = estimate_prompt_complexity(prompt)
-            if complexity > threshold:
-                order.append(primary)
-                if fallback:
-                    order.append(fallback)
-            else:
-                if fallback:
-                    order.append(fallback)
-                order.append(primary)
-    for backend_name in order:
-        try:
-            return _run_backend(backend_name, prompt, model)
-        except (FileNotFoundError, subprocess.CalledProcessError):
-            continue
-    raise RuntimeError("Unable to process prompt")
+DEFAULT_MODEL = router.DEFAULT_MODEL
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -115,7 +18,6 @@ def main(argv: list[str] | None = None) -> int:
         "prompt",
         help="Prompt to send to the model or '-' to read from STDIN",
     )
-
     parser.add_argument(
         "--local",
         action="store_true",
@@ -132,9 +34,8 @@ def main(argv: list[str] | None = None) -> int:
     if prompt == "-":
         prompt = sys.stdin.read()
 
-
     try:
-        output = send_prompt(prompt, local=args.local, model=args.model)
+        output = router.send_prompt(prompt, local=args.local, model=args.model)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)
         return 1

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -16,8 +16,8 @@ def test_plan_uses_primary(monkeypatch):
     def fail_ollama(prompt, model):
         raise AssertionError("ollama should not be called")
 
-    monkeypatch.setattr(ai_exec.ai_router, "run_gemini", fake_gemini)
-    monkeypatch.setattr(ai_exec.ai_router, "run_ollama", fail_ollama)
+    monkeypatch.setattr(ai_exec.router, "run_gemini", fake_gemini)
+    monkeypatch.setattr(ai_exec.router, "run_ollama", fail_ollama)
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
 
     steps = ai_exec.plan("goal")
@@ -36,8 +36,8 @@ def test_plan_falls_back(monkeypatch):
         calls.append(("ollama", prompt, model))
         return "fallback"
 
-    monkeypatch.setattr(ai_exec.ai_router, "run_gemini", failing_gemini)
-    monkeypatch.setattr(ai_exec.ai_router, "run_ollama", fake_ollama)
+    monkeypatch.setattr(ai_exec.router, "run_gemini", failing_gemini)
+    monkeypatch.setattr(ai_exec.router, "run_ollama", fake_ollama)
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
 
     steps = ai_exec.plan("goal")


### PR DESCRIPTION
## Summary
- extract routing functionality from the CLI into `llm/router.py`
- update `scripts/ai_router.py` to a thin wrapper around the new router
- adjust `scripts/ai_exec.py` to use `llm.router`
- update tests to target the router library

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686447351ee883268b5094a10ae72757