### PR TITLE
Improve ai_do safety

### DIFF
--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -16,7 +16,7 @@ def test_main_runs_and_logs(monkeypatch, tmp_path):
     calls = []
 
     def fake_run(cmd, *, shell, capture_output, text):
-        assert shell and capture_output and text
+        assert not shell and capture_output and text
         calls.append(cmd)
 
         class Result:
@@ -29,7 +29,7 @@ def test_main_runs_and_logs(monkeypatch, tmp_path):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    inputs = iter(["y", "n"])
+    inputs = iter(["y", "y", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     log = tmp_path / "log.txt"
@@ -38,7 +38,7 @@ def test_main_runs_and_logs(monkeypatch, tmp_path):
         rc = ai_do.main(["goal", "--log", str(log)])
 
     assert rc == 0
-    assert calls == ["cmd1"]
+    assert calls == [["cmd1"]]
     assert "$ cmd1" in log.read_text()
 
 
@@ -70,11 +70,48 @@ def test_main_returns_failure(monkeypatch, tmp_path):
             self.stderr = "err"
             self.returncode = 1
 
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: Result())
-    monkeypatch.setattr("builtins.input", lambda _: "y")
+    def fake_run(cmd, *, shell, capture_output, text):
+        assert not shell and capture_output and text
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    inputs = iter(["y", "y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     log = tmp_path / "log.txt"
     rc = ai_do.main(["goal", "--log", str(log)])
 
     assert rc == 1
     assert "(exit 1)" in log.read_text()
+
+
+def test_main_confirms_and_sanitizes(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["echo hi"])
+
+    prompts = []
+    inputs = iter(["y", "y"])
+
+    def fake_input(prompt):
+        prompts.append(prompt)
+        return next(inputs)
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        assert cmd == ["echo", "hi"]
+        assert not shell and capture_output and text
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    log = tmp_path / "log.txt"
+    rc = ai_do.main(["goal", "--log", str(log)])
+
+    assert rc == 0
+    assert any(prompt.startswith("Run command: echo hi") for prompt in prompts)


### PR DESCRIPTION
## Summary
- add confirmation prompt before executing commands
- parse commands with shlex and avoid using shell when possible
- expand tests for ai_do to cover new logic

## Testing
- `ruff check .`
- `pytest -n auto`
- `pytest -n auto tests/test_smoke_test.py`
- `npm run lint`
- `python scripts/validate_winget.py`


------
https://chatgpt.com/codex/tasks/task_e_6864472518388326bf7f8d3bc62bdfd1