### PR TITLE
Raise ImportError if DSPy missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Key directories:
 ## Quickstart
 
 Install the required Python packages (including test utilities such as
-`pytest` and `json5`). The optional `dspy` dependency enables the full
-test suite but tests that rely on it will be skipped if the package is
-missing:
+`pytest` and `json5`). The optional `dspy` dependency (install via
+`pip install dspy-ai`) enables the full test suite and is required for
+`llm.LoggedFewShotWrapper`. Tests that rely on it will be skipped if the
+package is missing:
 
 ```bash
 pip install -e .[cli] -r requirements.txt

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from pathlib import Path
 
 try:  # pragma: no cover - optional dependency
     from .universal_dspy_wrapper_v2 import LoggedFewShotWrapper, is_repo_data_path
-except ImportError:  # dspy not installed
-    LoggedFewShotWrapper = None  # type: ignore[assignment]
-    is_repo_data_path = None  # type: ignore[assignment]
+except ImportError as exc:  # dspy not installed
+    def _missing(name: str, _exc: Exception = exc):
+        raise ImportError(
+            "The 'dspy' package is required to use "
+            f"{name}; install it via 'pip install dspy-ai'"
+        ) from _exc
+
+    class LoggedFewShotWrapper:  # type: ignore[assignment]
+        def __init__(self, *args, **kwargs) -> None:
+            _missing("LoggedFewShotWrapper")
+
+    def is_repo_data_path(path: str | Path) -> bool:  # type: ignore[assignment]
+        _missing("is_repo_data_path")
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .ai_router import get_preferred_models as _get_preferred_models  # noqa: F401
@@ -21,9 +32,5 @@ def __getattr__(name: str):
         return _get_preferred_models
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-__all__ = [
-    name
-    for name in ["LoggedFewShotWrapper", "is_repo_data_path", "get_preferred_models"]
-    if name == "get_preferred_models" or locals().get(name) is not None
-]
+__all__ = ["LoggedFewShotWrapper", "is_repo_data_path", "get_preferred_models"]
 


### PR DESCRIPTION
## Summary
- raise `ImportError` placeholders in `llm.__init__` when `dspy` isn't installed
- document how to install optional `dspy` dependency for `LoggedFewShotWrapper`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68644722b39c8326adfb2715d8f1292d