### PR TITLE
Refactor repo root lookup

### DIFF
--- a/llm/ai_router.py
+++ b/llm/ai_router.py
@@ -4,31 +4,15 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import warnings
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
-
-def _repo_root() -> Path:
-    try:
-        return Path(
-            subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                check=True,
-                capture_output=True,
-                text=True,
-            ).stdout.strip()
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:  # pragma: no cover
-        warnings.warn(
-            f"Git repo root detection failed: {exc}. Falling back to current working directory.",
-            RuntimeWarning,
-        )
-        return Path.cwd()
+from .utils import get_repo_root
 
 
-_DEFAULT_CONFIG = _repo_root() / "llm" / "llm_config.json"
+
+_DEFAULT_CONFIG = get_repo_root() / "llm" / "llm_config.json"
 
 
 def _load_config(path: Path) -> dict[str, Any]:

--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -11,10 +11,10 @@ import os
 import re
 
 import shutil
-import subprocess
 from pathlib import Path
 from typing import Callable, List, Type
-import warnings
+
+from .utils import get_repo_root
 
 try:
     import dspy
@@ -25,21 +25,7 @@ except ImportError as exc:  # pragma: no cover - import guard
         "via 'pip install dspy-ai'"
     ) from exc
 
-try:
-    _REPO_ROOT = Path(
-        subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-    )
-except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-    warnings.warn(
-        f"Git repo root detection failed: {exc}. Falling back to current working directory.",
-        RuntimeWarning,
-    )
-    _REPO_ROOT = Path.cwd()
+_REPO_ROOT = get_repo_root()
 
 _PATH_REGEX = re.compile(
     rf"^(?P<root>{re.escape(_REPO_ROOT.as_posix())})/.+(?P<data>[^/]+\.(?:ya?ml|json))$",

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -1,0 +1,28 @@
+"""Utility helpers for the llm package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import warnings
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def get_repo_root() -> Path:
+    """Return the repository root or ``Path.cwd()`` if detection fails."""
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+        )
+        return Path(out.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:  # pragma: no cover - fall back
+        warnings.warn(
+            f"Git repo root detection failed: {exc}. Falling back to current working directory.",
+            RuntimeWarning,
+        )
+        return Path.cwd()
+
+
+__all__ = ["get_repo_root"]


### PR DESCRIPTION
## Summary
- centralize repo root detection in `llm.utils.get_repo_root`
- use the helper in `ai_router` and `universal_dspy_wrapper_v2`
- simplify tests by relying on the helper
- cache the repo root to avoid repeated git calls

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68644731016c832692dcde9e5f4e1042