### PR TITLE
Add backend registry and dynamic routing

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -1,8 +1,31 @@
+from collections.abc import Callable
+from typing import Dict
+
 from .base import Backend
 from .gemini import GeminiBackend
 from .ollama import OllamaBackend
 from .openrouter import OpenRouterBackend
 from ..langchain_backend import LangChainBackend
+
+_BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
+
+
+def register_backend(name: str, func: Callable[[str, str], str]) -> None:
+    """Register ``func`` to handle ``name``."""
+    _BACKEND_REGISTRY[name.lower()] = func
+
+
+def get_backend(name: str) -> Callable[[str, str], str]:
+    """Return the backend callable registered for ``name``."""
+    key = name.lower()
+    if key not in _BACKEND_REGISTRY:
+        raise ValueError(f"Unknown backend: {name}")
+    return _BACKEND_REGISTRY[key]
+
+
+def clear_registry() -> None:
+    """Remove all registered backends (tests only)."""
+    _BACKEND_REGISTRY.clear()
 
 GeminiDSPyBackendType: type[Backend] | None
 OllamaDSPyBackendType: type[Backend] | None
@@ -32,4 +55,7 @@ __all__ = [
     "GeminiDSPyBackend",
     "OllamaDSPyBackend",
     "OpenRouterDSPyBackend",
+    "register_backend",
+    "get_backend",
+    "clear_registry",
 ]

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -40,7 +40,10 @@ def main(argv: list[str] | None = None) -> int:
         prompt = sys.stdin.read()
 
     try:
-        output = router.send_prompt(prompt, local=args.local, model=args.model)
+        if args.backend:
+            output = router._run_backend(args.backend, prompt, args.model)
+        else:
+            output = router.send_prompt(prompt, local=args.local, model=args.model)
 
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)

--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -6,6 +6,7 @@ import pytest
 
 from scripts import ai_router as cli_ai_router
 from llm import router, ai_router as llm_router
+from llm.backends import register_backend
 
 
 def _set_env(monkeypatch, primary="gemini", fallback="ollama"):
@@ -26,7 +27,9 @@ def test_send_prompt_uses_local_for_simple_prompt(monkeypatch):
         return f"ollama:{prompt}:{model}"
 
     monkeypatch.setattr(router, "run_gemini", fail_run_gemini)
+    register_backend("gemini", router.run_gemini)
     monkeypatch.setattr(router, "run_ollama", mock_run_ollama)
+    register_backend("ollama", router.run_ollama)
 
     out = router.send_prompt("hello", model="g1")
     assert out == "ollama:hello:g1"
@@ -44,7 +47,9 @@ def test_send_prompt_uses_primary_for_complex_prompt(monkeypatch):
         raise AssertionError("ollama should not be called")
 
     monkeypatch.setattr(router, "run_gemini", mock_run_gemini)
+    register_backend("gemini", router.run_gemini)
     monkeypatch.setattr(router, "run_ollama", fail_run_ollama)
+    register_backend("ollama", router.run_ollama)
 
     out = router.send_prompt(long_prompt, model="g1")
     assert out.startswith("gemini:")
@@ -60,7 +65,9 @@ def test_send_prompt_local(monkeypatch):
         return f"ollama:{prompt}:{model}"
 
     monkeypatch.setattr(router, "run_gemini", fail_run_gemini)
+    register_backend("gemini", router.run_gemini)
     monkeypatch.setattr(router, "run_ollama", mock_run_ollama)
+    register_backend("ollama", router.run_ollama)
 
     out = router.send_prompt("yo", local=True, model="o2")
     assert out == "ollama:yo:o2"
@@ -77,7 +84,9 @@ def test_env_forces_remote(monkeypatch):
         raise AssertionError("ollama should not be called")
 
     monkeypatch.setattr(router, "run_gemini", mock_run_gemini)
+    register_backend("gemini", router.run_gemini)
     monkeypatch.setattr(router, "run_ollama", fail_run_ollama)
+    register_backend("ollama", router.run_ollama)
 
     out = router.send_prompt("short", model="g1")
     assert out == "gemini:short:g1"
@@ -94,7 +103,9 @@ def test_env_complexity_threshold(monkeypatch):
         raise AssertionError("ollama should not be called")
 
     monkeypatch.setattr(router, "run_gemini", mock_run_gemini)
+    register_backend("gemini", router.run_gemini)
     monkeypatch.setattr(router, "run_ollama", fail_run_ollama)
+    register_backend("ollama", router.run_ollama)
 
     out = router.send_prompt("two words", model="g1")
     assert out == "gemini:two words:g1"
@@ -105,7 +116,9 @@ def test_invalid_complexity_threshold(monkeypatch):
     monkeypatch.setenv("LLM_COMPLEXITY_THRESHOLD", "invalid")
 
 
-    long_prompt = " ".join(["word"] * (ai_router.DEFAULT_COMPLEXITY_THRESHOLD + 1))
+    long_prompt = " ".join([
+        "word",
+    ] * (router.DEFAULT_COMPLEXITY_THRESHOLD + 1))
 
     def mock_run_gemini(prompt, model=None):
         return f"gemini:{prompt}:{model}"
@@ -114,10 +127,11 @@ def test_invalid_complexity_threshold(monkeypatch):
 
         raise AssertionError("ollama should not be called")
 
-    monkeypatch.setattr(ai_router, "run_gemini", mock_run_gemini)
-    monkeypatch.setattr(ai_router, "run_ollama", fail_run_ollama)
-
-    out = ai_router.send_prompt(long_prompt, model="g1")
+    monkeypatch.setattr(router, "run_gemini", mock_run_gemini)
+    register_backend("gemini", router.run_gemini)
+    monkeypatch.setattr(router, "run_ollama", fail_run_ollama)
+    register_backend("ollama", router.run_ollama)
+    out = router.send_prompt(long_prompt, model="g1")
     assert out.startswith("gemini:")
 
 
@@ -214,6 +228,7 @@ def test_send_prompt_prefers_dspy(monkeypatch):
     monkeypatch.setattr(router, "GeminiDSPyBackend", Dummy)
     monkeypatch.setattr(router, "GeminiBackend", FailBackend)
     monkeypatch.setattr(router, "run_ollama", fail_ollama)
+    register_backend("ollama", router.run_ollama)
 
     out = router.send_prompt("msg", model="m")
     assert out == "dspy:msg:m"

--- a/tests/test_langchain_backend.py
+++ b/tests/test_langchain_backend.py
@@ -2,6 +2,8 @@ from llm.langchain_backend import LangChainBackend
 import io
 import contextlib
 from scripts import ai_router
+from llm.backends import register_backend
+from llm import router
 
 
 class DummyChain:
@@ -22,11 +24,11 @@ def test_langchain_backend_invokes_chain():
 
 
 def test_cli_backend_option(monkeypatch):
-    def mock_run_langchain(prompt: str) -> str:
+    def mock_run_langchain(prompt: str, model: str) -> str:
         assert prompt == "cli"
         return "ok"
 
-    monkeypatch.setattr(ai_router, "run_langchain", mock_run_langchain)
+    register_backend("langchain", mock_run_langchain)
 
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
@@ -37,11 +39,11 @@ def test_cli_backend_option(monkeypatch):
 def test_run_backend_langchain(monkeypatch):
     calls = []
 
-    def mock_run(prompt: str) -> str:
+    def mock_run(prompt: str, model: str) -> str:
         calls.append(prompt)
         return "done"
 
-    monkeypatch.setattr(ai_router, "run_langchain", mock_run)
-    out = ai_router._run_backend("langchain", "hi", "m")
+    register_backend("langchain", mock_run)
+    out = router._run_backend("langchain", "hi", "m")
     assert out == "done"
     assert calls == ["hi"]

--- a/tests/test_openrouter_backend.py
+++ b/tests/test_openrouter_backend.py
@@ -1,7 +1,7 @@
 import pytest
 
 from llm.backends import OpenRouterBackend
-from scripts import ai_router
+from llm import router as ai_router
 
 
 def test_openrouter_backend_returns_string():


### PR DESCRIPTION
## Summary
- allow registering backends dynamically
- have router `_run_backend` resolve backends via the registry
- update CLI to use `_run_backend` when a backend is explicitly requested
- adjust tests to register dummy backends

## Testing
- `ruff check llm/backends/__init__.py llm/router.py scripts/ai_router.py tests/test_ai_router.py tests/test_langchain_backend.py tests/test_openrouter_backend.py`
- `ruff check tests/test_ai_router.py tests/test_langchain_backend.py tests/test_openrouter_backend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686453c461308326bd8c2ee8563fb542