### PR TITLE
Update docs on stdin usage

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -41,7 +41,7 @@ ai "Write a Python script"
 ai --local "Translate text"
 
 # Read a prompt from standard input
-echo "Summarize" | ai --stdin
+echo "Summarize" | ai -
 ```
 
 By default the tool picks the backend automatically based on the prompt length.


### PR DESCRIPTION
## Summary
- update AI automation docs to prefer `ai -` when reading from STDIN

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_686453c171c8832689520b1e3a6dc51c