### PR TITLE
Add basic Streamlit web UI

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -48,6 +48,19 @@ By default the tool picks the backend automatically based on the prompt length.
 Set `LLM_ROUTING_MODE` to `remote` or `local` to force the behavior, or tweak
 `LLM_COMPLEXITY_THRESHOLD` to adjust when the prompt is considered complex.
 
+## Streamlit Web UI
+
+A lightweight web interface built with [Streamlit](https://streamlit.io/) exposes
+the same prompt routing and palette controls. Launch it from the repository
+root:
+
+```bash
+streamlit run ui/web_app.py --server.headless true
+```
+
+Use **Send** to route prompts via `ai_router.send_prompt` and **Apply** to call
+`thm.apply_palette`.
+
 ## LLM Configuration
 
 `get_preferred_models()` reads model names from a JSON file. By default the

--- a/llm/router.py
+++ b/llm/router.py
@@ -85,9 +85,11 @@ def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL)
             if fallback:
                 order.append(fallback)
         else:  # auto
-            threshold = int(
-                os.environ.get("LLM_COMPLEXITY_THRESHOLD", DEFAULT_COMPLEXITY_THRESHOLD)
-            )
+            threshold_str = os.environ.get("LLM_COMPLEXITY_THRESHOLD")
+            try:
+                threshold = int(threshold_str) if threshold_str else DEFAULT_COMPLEXITY_THRESHOLD
+            except ValueError:  # pragma: no cover - invalid env value
+                threshold = DEFAULT_COMPLEXITY_THRESHOLD
             complexity = estimate_prompt_complexity(prompt)
             if complexity > threshold:
                 order.append(primary)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ json5
 ruff
 tomli; python_version < '3.11'
 tomli_w
+streamlit

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -8,8 +8,61 @@ import subprocess
 import sys
 
 from llm import router
+from llm.backends import (
+    GeminiBackend,
+    OllamaBackend,
+    OpenRouterBackend,
+    GeminiDSPyBackend,
+    OllamaDSPyBackend,
+    OpenRouterDSPyBackend,
+    LangChainBackend,
+)
 
 DEFAULT_MODEL = router.DEFAULT_MODEL
+DEFAULT_PRIMARY_BACKEND = router.DEFAULT_PRIMARY_BACKEND
+DEFAULT_FALLBACK_BACKEND = router.DEFAULT_FALLBACK_BACKEND
+DEFAULT_COMPLEXITY_THRESHOLD = router.DEFAULT_COMPLEXITY_THRESHOLD
+
+
+run_gemini = router.run_gemini
+run_ollama = router.run_ollama
+
+def run_openrouter(prompt: str, model: str) -> str:
+    """Return OpenRouter response for ``prompt`` using ``model``."""
+    backend_cls = (
+        OpenRouterDSPyBackend if OpenRouterDSPyBackend is not None else OpenRouterBackend
+    )
+    backend = backend_cls(model)  # type: ignore[arg-type]
+    return backend.run(prompt)
+
+
+def create_default_chain() -> object:
+    """Return a simple LangChain chain."""
+    try:  # pragma: no cover - optional dependency
+        from langchain_openai import ChatOpenAI
+        from langchain_core.prompts import ChatPromptTemplate
+        from langchain_core.output_parsers import StrOutputParser
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("langchain is required for the langchain backend") from exc
+
+    prompt = ChatPromptTemplate.from_messages([("human", "{input}")])
+    return prompt | ChatOpenAI() | StrOutputParser()
+
+
+def run_langchain(prompt: str) -> str:
+    """Return response using a LangChain chain."""
+    backend = LangChainBackend(create_default_chain())
+    return backend.run(prompt)
+
+def _run_backend(name: str, prompt: str, model: str) -> str:
+    """Delegate to ``router._run_backend`` with LangChain support."""
+    if name.lower() == "langchain":
+        return run_langchain(prompt)
+    return router._run_backend(name, prompt, model)
+
+def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL) -> str:
+    """Proxy to ``router.send_prompt`` so tests can monkeypatch it."""
+    return router.send_prompt(prompt, local=local, model=model)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -40,7 +93,10 @@ def main(argv: list[str] | None = None) -> int:
         prompt = sys.stdin.read()
 
     try:
-        output = router.send_prompt(prompt, local=args.local, model=args.model)
+        if args.backend:
+            output = _run_backend(args.backend, prompt, args.model)
+        else:
+            output = send_prompt(prompt, local=args.local, model=args.model)
 
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)
@@ -54,3 +110,24 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "DEFAULT_PRIMARY_BACKEND",
+    "DEFAULT_FALLBACK_BACKEND",
+    "DEFAULT_COMPLEXITY_THRESHOLD",
+    "run_gemini",
+    "run_ollama",
+    "run_openrouter",
+    "run_langchain",
+    "create_default_chain",
+    "_run_backend",
+    "send_prompt",
+    "main",
+    "GeminiBackend",
+    "OllamaBackend",
+    "OpenRouterBackend",
+    "GeminiDSPyBackend",
+    "OllamaDSPyBackend",
+    "OpenRouterDSPyBackend",
+]

--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -105,7 +105,7 @@ def test_invalid_complexity_threshold(monkeypatch):
     monkeypatch.setenv("LLM_COMPLEXITY_THRESHOLD", "invalid")
 
 
-    long_prompt = " ".join(["word"] * (ai_router.DEFAULT_COMPLEXITY_THRESHOLD + 1))
+    long_prompt = " ".join(["word"] * (router.DEFAULT_COMPLEXITY_THRESHOLD + 1))
 
     def mock_run_gemini(prompt, model=None):
         return f"gemini:{prompt}:{model}"
@@ -114,10 +114,10 @@ def test_invalid_complexity_threshold(monkeypatch):
 
         raise AssertionError("ollama should not be called")
 
-    monkeypatch.setattr(ai_router, "run_gemini", mock_run_gemini)
-    monkeypatch.setattr(ai_router, "run_ollama", fail_run_ollama)
+    monkeypatch.setattr(router, "run_gemini", mock_run_gemini)
+    monkeypatch.setattr(router, "run_ollama", fail_run_ollama)
 
-    out = ai_router.send_prompt(long_prompt, model="g1")
+    out = router.send_prompt(long_prompt, model="g1")
     assert out.startswith("gemini:")
 
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,33 @@
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def test_streamlit_app_starts(tmp_path):
+    script = Path('ui/web_app.py')
+    log = tmp_path / 'out.txt'
+    with log.open('w') as log_file:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                '-m',
+                'streamlit',
+                'run',
+                str(script),
+                '--server.headless',
+                'true',
+                '--server.port',
+                '0',
+            ],
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            time.sleep(5)
+        finally:
+            proc.terminate()
+            proc.wait(timeout=10)
+    output = log.read_text(encoding='utf-8')
+    assert 'Streamlit app' in output or 'You can now view' in output
+

--- a/ui/web_app.py
+++ b/ui/web_app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from scripts.ai_router import send_prompt
+from scripts.thm import apply_palette, PALETTES_DIR, REPO_ROOT
+
+
+st.title("LLM Router")
+
+prompt = st.text_area("Prompt")
+if st.button("Send"):
+    if prompt:
+        result = send_prompt(prompt)
+        st.write(result)
+
+st.header("Apply Palette")
+options = [p.stem for p in PALETTES_DIR.glob("*.toml")]
+palette = st.selectbox("Palette", options)
+if st.button("Apply"):
+    if palette:
+        apply_palette(palette, REPO_ROOT)
+        st.success(f"Applied {palette}")
+


### PR DESCRIPTION
## Summary
- add a Streamlit-based interface for prompt routing and palette management
- document how to launch the Streamlit UI
- include a minimal test that verifies the app starts
- require Streamlit in requirements
- fix routing helpers for LangChain and restore compatibility with tests

## Testing
- `ruff check scripts/ai_router.py llm/router.py tests/test_ai_router.py tests/test_langchain_backend.py tests/test_openrouter_backend.py ui/web_app.py tests/test_web_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686453c5d5788326a6bf6e7b517be9a9