### PR TITLE
Fix ai_exec imports and add backend registry

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -7,6 +7,26 @@ from .ollama import OllamaBackend
 from .openrouter import OpenRouterBackend
 from ..langchain_backend import LangChainBackend
 
+_BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
+
+
+def register_backend(name: str, func: Callable[[str, str], str]) -> None:
+    """Register ``func`` to handle ``name``."""
+    _BACKEND_REGISTRY[name.lower()] = func
+
+
+def get_backend(name: str) -> Callable[[str, str], str]:
+    """Return the backend callable registered for ``name``."""
+    key = name.lower()
+    if key not in _BACKEND_REGISTRY:
+        raise ValueError(f"Unknown backend: {name}")
+    return _BACKEND_REGISTRY[key]
+
+
+def clear_registry() -> None:
+    """Remove all registered backends (tests only)."""
+    _BACKEND_REGISTRY.clear()
+
 LMQLBackendType: type[Backend] | None
 GuidanceBackendType: type[Backend] | None
 

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 from typing import List, Optional
+from pathlib import Path
 
 from llm import router
 from llm.ai_router import get_preferred_models


### PR DESCRIPTION
## Summary
- add missing `Path` import in `ai_exec.py`
- implement backend registry functions in `llm.backends`
- use a dummy API key for LangChain to avoid network calls in tests
- route explicit LangChain backend requests through `send_prompt`

## Testing
- `ruff check scripts/ai_router.py scripts/ai_exec.py llm/backends/__init__.py`
- `mypy scripts/ai_router.py scripts/ai_exec.py llm/backends/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648f9096dc83269a749eae51b7f95b