### PR TITLE
Implement backend registry

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from typing import Dict
 
 from .base import Backend
 from .gemini import GeminiBackend
@@ -39,6 +38,23 @@ OllamaDSPyBackend: type[Backend] | None = OllamaDSPyBackendType
 OpenRouterDSPyBackend: type[Backend] | None = OpenRouterDSPyBackendType
 LMQLBackend: type[Backend] | None = LMQLBackendType
 GuidanceBackend: type[Backend] | None = GuidanceBackendType
+
+_REGISTRY: dict[str, Callable[[str, str], str]] = {}
+
+
+def register_backend(name: str, func: Callable[[str, str], str]) -> None:
+    """Register ``func`` under ``name``."""
+    _REGISTRY[name] = func
+
+
+def get_backend(name: str) -> Callable[[str, str], str]:
+    """Return the backend function registered as ``name``."""
+    return _REGISTRY[name]
+
+
+def clear_registry() -> None:
+    """Clear all registered backends."""
+    _REGISTRY.clear()
 
 __all__ = [
     "Backend",

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 from typing import List, Optional
+from pathlib import Path
 
 from llm import router
 from llm.ai_router import get_preferred_models


### PR DESCRIPTION
## Summary
- clean unused imports in `llm/backends`
- implement simple backend registry
- expose registry helpers via `__all__`
- fix missing `Path` import in `scripts/ai_exec.py`
- avoid OpenAI dependency in langchain tests

## Testing
- `ruff check llm/backends/__init__.py scripts/ai_router.py`
- `mypy llm/backends/__init__.py scripts/ai_router.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648f91de488326a23151d35040273a