### PR TITLE
Add textual dependency

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,6 +21,13 @@ Install the Python development tools including `ruff`:
 pip install -e . -r requirements.txt
 ```
 
+If you want to try the Textual-based UI prototype, install the
+optional dependency:
+
+```bash
+pip install textual
+```
+
 Run `ruff` to check the code style:
 
 ```bash

--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -7,6 +7,26 @@ from .ollama import OllamaBackend
 from .openrouter import OpenRouterBackend
 from ..langchain_backend import LangChainBackend
 
+_BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
+
+
+def register_backend(name: str, func: Callable[[str, str], str]) -> None:
+    """Register ``func`` to handle ``name``."""
+    _BACKEND_REGISTRY[name.lower()] = func
+
+
+def get_backend(name: str) -> Callable[[str, str], str]:
+    """Return the backend callable registered for ``name``."""
+    key = name.lower()
+    if key not in _BACKEND_REGISTRY:
+        raise ValueError(f"Unknown backend: {name}")
+    return _BACKEND_REGISTRY[key]
+
+
+def clear_registry() -> None:
+    """Remove all registered backends (tests only)."""
+    _BACKEND_REGISTRY.clear()
+
 LMQLBackendType: type[Backend] | None
 GuidanceBackendType: type[Backend] | None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ruff
 tomli; python_version < '3.11'
 tomli_w
 streamlit
+textual

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+from pathlib import Path
 from typing import List, Optional
 
 from llm import router

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -52,7 +52,11 @@ def create_default_chain() -> object:
 
 
 def run_langchain(prompt: str) -> str:
-    """Return response using a LangChain chain."""
+    """Return response using a LangChain chain if available."""
+    if not os.environ.get("OPENAI_API_KEY"):
+        # Fallback to the standard routing logic when no API key is set.
+        return router.send_prompt(prompt, model=DEFAULT_MODEL)
+
     backend = LangChainBackend(create_default_chain())
     return backend.run(prompt)
 


### PR DESCRIPTION
## Summary
- include textual in requirements
- mention textual installation in docs
- re-add backend registry
- fix lint errors
- fallback to default routing when LangChain isn't configured

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68648f9363588326bd7f51cfaab8ce7d