### PR TITLE
Fix import duplicate

### DIFF
--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -8,7 +8,6 @@ import argparse
 import subprocess
 from pathlib import Path
 from typing import List, Optional
-from pathlib import Path
 
 from llm import router
 from llm.ai_router import get_preferred_models


### PR DESCRIPTION
## Summary
- clean up duplicate import in `ai_exec`

## Testing
- `ruff check scripts/ai_exec.py`
- `pytest tests/test_ai_exec.py -q` *(fails: NameError: Dict not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68652ad4b32083268ea7faf85d8f9d08