### PR TITLE
Fix LangChain backend import

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Dict
 
 from .base import Backend
 from .gemini import GeminiBackend

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -18,6 +18,7 @@ from llm.backends import (
     OllamaDSPyBackend,
     OpenRouterDSPyBackend,
 )
+from llm.langchain_backend import LangChainBackend
 
 DEFAULT_MODEL = router.DEFAULT_MODEL
 DEFAULT_PRIMARY_BACKEND = router.DEFAULT_PRIMARY_BACKEND


### PR DESCRIPTION
## Summary
- import `LangChainBackend` in `ai_router`
- fix missing `Dict` import in `llm.backends`

## Testing
- `ruff check scripts/ai_router.py`
- `pytest tests/test_langchain_backend.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68652ad381748326ad46dceaff6063dc