### PR TITLE
Add ETL utilities

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -149,3 +149,16 @@ mod.recompile_from_fewshot()
 The wrapper automatically uses the compiled module on the next call. Whenever
 you log new examples, run `snapshot_log_to_fewshot()` and recompile again to
 extend the training set.
+
+## Document Ingestion
+
+`llm.etl` provides helpers to load documents into a ChromaDB persistent store.
+Use the `etl.py` script to process a file or directory in one step:
+
+```bash
+python scripts/etl.py docs/ai-automation.md --persist chroma_db
+python scripts/etl.py ./docs --persist chroma_db
+```
+
+The resulting collection can be registered on a LangGraph with
+`llm.etl.register_retrieval_nodes` for retrieval-augmented generation.

--- a/llm/etl.py
+++ b/llm/etl.py
@@ -1,0 +1,65 @@
+"""Utilities for ingesting documents and registering retrieval nodes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Sequence
+
+
+__all__ = [
+    "partition_document",
+    "store_embeddings",
+    "register_retrieval_nodes",
+]
+
+
+def partition_document(path: Path) -> List[str]:
+    """Return text chunks extracted from ``path`` using ``unstructured``."""
+    try:
+        from unstructured.partition.auto import partition
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "The 'unstructured' package is required for document partitioning"
+        ) from exc
+
+    elements = partition(filename=str(path))
+    chunks = [getattr(el, "text", "") for el in elements if getattr(el, "text", "")]
+    return chunks
+
+
+def store_embeddings(
+    chunks: Sequence[str], *, persist_dir: Path, collection_name: str = "documents"
+):
+    """Store embeddings for ``chunks`` in a ChromaDB collection."""
+    try:
+        import chromadb
+        from chromadb.utils.embedding_functions import (
+            SentenceTransformerEmbeddingFunction,
+        )
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "The 'chromadb' package is required for embedding storage"
+        ) from exc
+
+    client = chromadb.PersistentClient(path=str(persist_dir))
+    embed = SentenceTransformerEmbeddingFunction()
+    collection = client.get_or_create_collection(
+        collection_name, embedding_function=embed
+    )
+    ids = [f"doc-{i}" for i in range(len(chunks))]
+    collection.add(documents=list(chunks), ids=ids)
+    return collection
+
+
+def register_retrieval_nodes(graph, collection, *, node_name: str = "retrieve"):
+    """Register retrieval nodes on ``graph`` for ``collection`` using LangGraph."""
+    try:
+        from langgraph.prebuilt import retrieval
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "The 'langgraph' package is required for retrieval node registration"
+        ) from exc
+
+    retriever = retrieval.ChromaRetriever(collection)
+    graph.add_node(node_name, retriever)
+    return graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ test = [
 cli = ["tomli_w"]
 lmql = ["lmql"]
 guidance = ["guidance"]
+etl = ["unstructured", "chromadb"]
 
 [project.scripts]
 thm = "scripts.thm:main"
@@ -27,6 +28,7 @@ ai = "scripts.ai_cli:send_main"
 ai-plan = "scripts.ai_cli:plan_main"
 ai-do = "scripts.ai_cli:do_main"
 ai-cli = "scripts.ai_cli:main"
+etl = "scripts.etl:main"
 
 
 [tool.setuptools.packages.find]

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Ingest documents into ChromaDB."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List, Optional
+
+from llm import etl
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="File or directory to ingest")
+    parser.add_argument(
+        "--persist",
+        type=Path,
+        default=Path("chroma_db"),
+        help="Chroma persistence directory (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--collection",
+        default="documents",
+        help="Chroma collection name (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    files = [args.path]
+    if args.path.is_dir():
+        files = [p for p in args.path.rglob("*") if p.is_file()]
+
+    chunks: List[str] = []
+    for file in files:
+        chunks.extend(etl.partition_document(file))
+
+    etl.store_embeddings(
+        chunks, persist_dir=args.persist, collection_name=args.collection
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,0 +1,78 @@
+import types
+import sys
+
+from llm import etl
+
+
+def test_partition_document(monkeypatch, tmp_path):
+    file = tmp_path / "doc.txt"
+    file.write_text("dummy")
+
+    class E:
+        def __init__(self, text):
+            self.text = text
+
+    def fake_partition(filename):
+        assert filename == str(file)
+        return [E("a"), E("b")]
+
+    fake_mod = types.SimpleNamespace(partition=fake_partition)
+    monkeypatch.setitem(sys.modules, "unstructured.partition.auto", fake_mod)
+
+    chunks = etl.partition_document(file)
+    assert chunks == ["a", "b"]
+
+
+def test_store_embeddings(monkeypatch, tmp_path):
+    added = {}
+
+    class FakeCollection:
+        def add(self, *, documents, ids):
+            added["docs"] = documents
+            added["ids"] = ids
+
+    class FakeClient:
+        def __init__(self, path):
+            added["path"] = path
+
+        def get_or_create_collection(self, name, embedding_function=None):
+            added["name"] = name
+            added["embed"] = embedding_function
+            return FakeCollection()
+
+    fake_emb_mod = types.SimpleNamespace(
+        SentenceTransformerEmbeddingFunction=lambda: "embed"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "chromadb.utils.embedding_functions",
+        fake_emb_mod,
+    )
+    monkeypatch.setitem(sys.modules, "chromadb.utils", types.SimpleNamespace(embedding_functions=fake_emb_mod))
+    monkeypatch.setitem(sys.modules, "chromadb", types.SimpleNamespace(PersistentClient=FakeClient))
+
+    coll = etl.store_embeddings(["x"], persist_dir=tmp_path, collection_name="c")
+    assert added["path"] == str(tmp_path)
+    assert added["name"] == "c"
+    assert added["docs"] == ["x"]
+    assert added["ids"] == ["doc-0"]
+    assert isinstance(coll, FakeCollection)
+
+
+def test_register_retrieval_nodes(monkeypatch):
+    calls = []
+
+    class Graph:
+        def add_node(self, name, node):
+            calls.append((name, node))
+
+    sentinel = object()
+
+    fake_retrieval = types.SimpleNamespace(ChromaRetriever=lambda c: sentinel)
+    monkeypatch.setitem(sys.modules, "langgraph.prebuilt.retrieval", fake_retrieval)
+    monkeypatch.setitem(sys.modules, "langgraph.prebuilt", types.SimpleNamespace(retrieval=fake_retrieval))
+
+    g = Graph()
+    out = etl.register_retrieval_nodes(g, "coll", node_name="n")
+    assert out is g
+    assert calls == [("n", sentinel)]


### PR DESCRIPTION
## Summary
- add `llm.etl` for document ingestion
- provide CLI wrapper under `scripts/etl.py`
- document ingestion workflow
- include optional dependencies for ETL
- cover the new functions with tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652ea4f2c08326a510b4b37c9d3bb4