### PR TITLE
Add ntfy notifications for AI scripts

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -91,6 +91,9 @@ To run those commands interactively use `ai-do`. Each command is numbered and
 requires a `y` confirmation; pressing `Enter` or `n` skips that command. Output
 is appended to `ai_do.log` by default.
 
+Both `ai-plan` and `ai-do` accept a `--notify` flag to send a notification via
+[`ntfy`](https://ntfy.sh) when the command completes.
+
 ```bash
 ai-do "git add . && git commit -m 'update' && git push" --log my.log
 ```

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -14,11 +14,17 @@ from typing import List, Optional
 from scripts import ai_exec
 
 
+def send_notification(message: str) -> None:
+    """Post a notification via ``ntfy`` if available."""
+    subprocess.run(["ntfy", "send", message], check=False)
+
+
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("goal", help="High level description of the task")
     parser.add_argument("--config")
+    parser.add_argument("--notify", action="store_true", help="Send notification when done")
     parser.add_argument(
         "--log",
         type=Path,
@@ -56,6 +62,8 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(result.stderr, end="", file=sys.stderr)
         if result.returncode and not exit_code:
             exit_code = result.returncode
+    if args.notify:
+        send_notification(f"ai-do completed with exit code {exit_code}")
     return exit_code
 
 

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -13,6 +13,11 @@ from llm import router
 from llm.ai_router import get_preferred_models
 
 
+def send_notification(message: str) -> None:
+    """Post a notification via ``ntfy`` if available."""
+    subprocess.run(["ntfy", "send", message], check=False)
+
+
 def plan(goal: str, *, config_path: Optional[Path] = None) -> List[str]:
     """Return planning steps for ``goal`` using preferred models."""
     primary, fallback = get_preferred_models(
@@ -31,11 +36,14 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("goal")
     parser.add_argument("--config")
+    parser.add_argument("--notify", action="store_true", help="Send notification when done")
     args = parser.parse_args(argv)
     cfg_path = Path(args.config) if args.config else None
     steps = plan(args.goal, config_path=cfg_path)
     for step in steps:
         print(step)
+    if args.notify:
+        send_notification("ai-plan completed")
     return 0
 
 

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -115,3 +115,19 @@ def test_main_confirms_and_sanitizes(monkeypatch, tmp_path):
 
     assert rc == 0
     assert any(prompt.startswith("Run command: echo hi") for prompt in prompts)
+
+
+def test_main_notifies(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [])
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    called = []
+
+    def fake_notify(msg):
+        called.append(msg)
+
+    monkeypatch.setattr(ai_do, "send_notification", fake_notify)
+    log = tmp_path / "log.txt"
+    rc = ai_do.main(["goal", "--log", str(log), "--notify"])
+
+    assert rc == 0
+    assert called == ["ai-do completed with exit code 0"]

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -61,3 +61,16 @@ def test_main_invokes_plan(monkeypatch):
     assert rc == 0
     assert out.getvalue().splitlines() == ["one", "two"]
 
+
+def test_main_notifies(monkeypatch):
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [])
+    called = []
+
+    def fake_notify(msg):
+        called.append(msg)
+
+    monkeypatch.setattr(ai_exec, "send_notification", fake_notify)
+    rc = ai_exec.main(["goal", "--notify"])
+    assert rc == 0
+    assert called == ["ai-plan completed"]
+


### PR DESCRIPTION
## Summary
- support optional notifications via `--notify` for `ai_exec.py` and `ai_do.py`
- document the flag in `docs/ai-automation.md`
- test that notifications are triggered when enabled

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652ea3e3b48326bd8de84618f066c6