### PR TITLE
Add palette tests and fix backend registry

### DIFF
--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -282,6 +282,7 @@ def test_send_prompt_prefers_dspy(monkeypatch):
     monkeypatch.setattr(router, "GeminiDSPyBackend", Dummy)
     monkeypatch.setattr(router, "GeminiBackend", FailBackend)
     monkeypatch.setattr(router, "run_ollama", fail_ollama)
+    register_backend("gemini", router.run_gemini)
     register_backend("ollama", router.run_ollama)
 
     out = router.send_prompt("msg", model="m")

--- a/tests/test_apply_palette.py
+++ b/tests/test_apply_palette.py
@@ -1,0 +1,35 @@
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scripts.thm import apply_palette
+
+
+@pytest.mark.usefixtures("tmp_path")
+def test_apply_palette_updates_configs(tmp_path: Path) -> None:
+    pytest.importorskip("tomli_w")
+    repo_root = Path(__file__).resolve().parents[1]
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+
+    shutil.copy(repo_root / "starship.toml", dest / "starship.toml")
+    shutil.copy(repo_root / "windows-terminal" / "settings.json", dest / "windows-terminal" / "settings.json")
+    for p in (repo_root / "palettes").glob("*.toml"):
+        shutil.copy(p, dest / "palettes" / p.name)
+
+    apply_palette("dracula", dest)
+
+    import tomllib
+
+    data = tomllib.loads((dest / "starship.toml").read_text())
+    assert data.get("palette") == "dracula"
+    assert "dracula" in data.get("palettes", {})
+
+    wt_data = json.loads((dest / "windows-terminal" / "settings.json").read_text())
+    assert wt_data.get("profiles", {}).get("defaults", {}).get("colorScheme") == "Dracula"
+    assert all(p.get("colorScheme") == "Dracula" for p in wt_data.get("profiles", {}).get("list", []))
+    assert any(s.get("name") == "Dracula" for s in wt_data.get("schemes", []))


### PR DESCRIPTION
## Summary
- add direct tests for applying palettes
- extend settings generation tests
- ensure backend registry uses patched run_gemini in tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68652eb609e08326a7f6088f5e0d0bc4