### PR TITLE
Add RomM & Neko compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  romm:
+    image: ghcr.io/rommapp/romm:latest
+    container_name: romm
+    ports:
+      - "8080:80"
+    volumes:
+      - ./romm:/romm
+    restart: unless-stopped
+
+  neko:
+    image: m1k1o/neko:firefox
+    container_name: neko
+    ports:
+      - "8081:8080"
+    environment:
+      - NEKO_SCREEN=1920x1080@30
+    shm_size: "2gb"
+    restart: unless-stopped

--- a/docs/media.md
+++ b/docs/media.md
@@ -1,0 +1,35 @@
+# Media Containers
+
+This repository includes optional Docker setups for media-related tools.
+
+## RomM
+
+RomM is a self-hosted game library manager. Start it with the helper script:
+
+```bash
+./scripts/run-romm.sh
+```
+
+The web interface is available on [localhost:8080](http://localhost:8080). Data is stored under `./romm`.
+
+You can also launch it directly with:
+
+```bash
+docker compose up romm
+```
+
+## Neko
+
+Neko provides browser streaming via Docker. Launch it with the helper script:
+
+```bash
+./scripts/run-neko.sh
+```
+
+It listens on port `8081` by default. Adjust the mapping in `docker-compose.yml` if you need a different port.
+
+To start Neko without the script, run:
+
+```bash
+docker compose up neko
+```

--- a/llm/router.py
+++ b/llm/router.py
@@ -75,6 +75,15 @@ def _preferred_backends() -> tuple[str, str | None]:
 
 
 def _run_backend(name: str, prompt: str, model: str) -> str:
+    """Run ``name`` backend with ``prompt`` and ``model``.
+
+    Prefer dynamically patched ``run_<name>`` functions if present so tests can
+    monkeypatch the module without re-registering backends. Fall back to the
+    backend registry otherwise.
+    """
+    attr = globals().get(f"run_{name.lower()}")
+    if callable(attr):
+        return attr(prompt, model)
     func = get_backend(name)
     return func(prompt, model)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = ["dspy==2.6.27"]
 test = [
     "pytest",
     "pytest-xdist",
+    "pytest-asyncio",
     "json5",
     "mypy",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dspy==2.6.27
 pytest
 pytest-xdist
+pytest-asyncio
 json5
 ruff
 tomli; python_version < '3.11'

--- a/scripts/run-neko.sh
+++ b/scripts/run-neko.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required but not installed." >&2
+    exit 1
+fi
+
+cd "$repo_root"
+exec docker compose up neko "$@"

--- a/scripts/run-romm.sh
+++ b/scripts/run-romm.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required but not installed." >&2
+    exit 1
+fi
+
+cd "$repo_root"
+exec docker compose up romm "$@"


### PR DESCRIPTION
## Summary
- provide a docker-compose.yml with RomM and Neko services
- add helper scripts `run-romm.sh` and `run-neko.sh`
- document usage in `docs/media.md`
- include pytest-asyncio to support async tests
- ensure router backends respect monkeypatching

## Testing
- `ruff check .`
- `mypy llm scripts`
- `pytest -n auto`
- `npm run lint`
- `python scripts/validate_winget.py`


------
https://chatgpt.com/codex/tasks/task_e_68652ea6e7508326b4c7cb442a5b0fdf