### PR TITLE
Add n8n workflow and compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  n8n:
+    image: n8nio/n8n
+    ports:
+      - "5678:5678"
+    volumes:
+      - ./n8n:/home/node/.n8n
+      - ./n8n/flows:/flows
+    environment:
+      - GENERIC_TIMEZONE=UTC
+      - N8N_PERSONALIZATION_ENABLED=false

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -149,3 +149,14 @@ mod.recompile_from_fewshot()
 The wrapper automatically uses the compiled module on the next call. Whenever
 you log new examples, run `snapshot_log_to_fewshot()` and recompile again to
 extend the training set.
+
+## n8n Integration
+
+An example workflow for the [n8n](https://n8n.io/) automation platform lives in `n8n/flows/`. Start the service with Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+Open <http://localhost:5678> in your browser and choose **Import from File** to load `n8n/flows/mcp-ai_exec.json`. The workflow contains a single **Execute Command** node that calls `scripts/ai_exec.py`.
+

--- a/llm/router.py
+++ b/llm/router.py
@@ -75,6 +75,13 @@ def _preferred_backends() -> tuple[str, str | None]:
 
 
 def _run_backend(name: str, prompt: str, model: str) -> str:
+    """Return response for ``prompt`` using backend ``name``."""
+    if name.lower() == "gemini":
+        return run_gemini(prompt, model)
+    if name.lower() == "ollama":
+        return run_ollama(prompt, model)
+    if name.lower() == "openrouter":
+        return run_openrouter(prompt, model)
     func = get_backend(name)
     return func(prompt, model)
 

--- a/n8n/flows/mcp-ai_exec.json
+++ b/n8n/flows/mcp-ai_exec.json
@@ -1,0 +1,30 @@
+{
+  "name": "MCP ai_exec",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1",
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "command": "python scripts/ai_exec.py \"echo hello\""
+      },
+      "id": "2",
+      "name": "ai_exec",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [460, 300]
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [ { "node": "ai_exec", "type": "main", "index": 0 } ]
+      ]
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dspy==2.6.27
 pytest
 pytest-xdist
+pytest-asyncio
 json5
 ruff
 tomli; python_version < '3.11'


### PR DESCRIPTION
## Summary
- provide `docker-compose.yml` with an n8n service
- include a minimal n8n workflow calling `ai_exec`
- document how to start n8n and import the workflow
- fix backend routing to honor patched implementations
- install `pytest-asyncio` so async tests run

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652ea5d4d08326b2f354c521e0861e