### PR TITLE
Add subprocess tests for docker scripts

### DIFF
--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -9,8 +9,6 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
-import subprocess
-
 from scripts import ai_exec
 from scripts.cli_common import execute_steps
 

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -130,4 +130,4 @@ def test_main_notifies(monkeypatch, tmp_path):
     rc = ai_do.main(["goal", "--log", str(log), "--notify"])
 
     assert rc == 0
-    assert called == ["ai-do completed"]
+    assert called == ["ai-do completed with exit code 0"]

--- a/tests/test_run_docker_scripts.py
+++ b/tests/test_run_docker_scripts.py
@@ -1,0 +1,65 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+@pytest.mark.parametrize("script_name,service", [
+    ("run-neko.sh", "neko"),
+    ("run-romm.sh", "romm"),
+])
+def test_run_script_help_invokes_docker(tmp_path: Path, script_name: str, service: str) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(Path("scripts") / script_name, scripts_dir / script_name)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    cmd_log = tmp_path / "docker_cmd.log"
+    create_exe(
+        bin_dir / "docker",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{cmd_log}'\n",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    subprocess.run([
+        "/bin/bash",
+        f"scripts/{script_name}",
+        "--help",
+    ], cwd=repo, env=env, check=True)
+
+    assert cmd_log.read_text().strip() == f"compose up {service} --help"
+
+
+@pytest.mark.parametrize("script_name", ["run-neko.sh", "run-romm.sh"])
+def test_run_script_requires_docker(tmp_path: Path, script_name: str) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(Path("scripts") / script_name, scripts_dir / script_name)
+
+    env = {"PATH": str(tmp_path / "bin")}
+    (tmp_path / "bin").mkdir()
+
+    result = subprocess.run(
+        ["/bin/bash", f"scripts/{script_name}"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "docker is required" in result.stderr


### PR DESCRIPTION
## Summary
- add tests for run-neko and run-romm shell scripts
- update ai_do send_notification test to match current script
- fix duplicate import in `scripts/ai_do.py`

## Testing
- `ruff check .`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68654e9c8f8483269c37c20d0ba37bca