### PR TITLE
Add Nextcloud and Mattermost containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,28 @@ services:
       - GENERIC_TIMEZONE=UTC
       - N8N_PERSONALIZATION_ENABLED=false
 
+  nextcloud:
+    image: nextcloud
+    ports:
+      - "8082:80"
+    volumes:
+      - ./nextcloud:/var/www/html
+
+  mattermost:
+    image: mattermost/mattermost-team-edition
+    ports:
+      - "8065:8065"
+    volumes:
+      - ./mattermost:/mattermost/data
+
+  romm:
+    image: rommapp/romm
+    ports:
+      - "8080:80"
+    volumes:
+      - ./romm:/romm
+
+  neko:
+    image: m1k1o/neko:latest
+    ports:
+      - "8081:8080"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -152,23 +152,30 @@ Launch `ghostty` instead of your default terminal to try it out.
 
 ## Nextcloud server
 
-[Nextcloud](https://nextcloud.com/) provides private file sync and collaborative editing. The quickest way to test it locally is with Docker:
+[Nextcloud](https://nextcloud.com/) provides private file sync and collaborative
+editing. Launch it using the included helper script:
 
 ```bash
-docker run -d --name nextcloud -p 8080:80 nextcloud
+./scripts/run-nextcloud.sh
 ```
 
-Visit `http://localhost:8080` to finish the setup. Customize trusted domains with the `NEXTCLOUD_TRUSTED_DOMAINS` environment variable if you expose it to the network.
+The compose file maps port `8082` to the container's port `80`. Visit
+`http://localhost:8082` to finish the setup. Customize trusted domains with the
+`NEXTCLOUD_TRUSTED_DOMAINS` environment variable if you expose it to the
+network.
 
 ## Mattermost chat
 
-Run an open-source team chat server using Mattermost's Docker image:
+Run an open-source team chat server using the Mattermost service defined in the
+compose file:
 
 ```bash
-docker run -d --name mattermost -p 8065:8065 mattermost/mattermost-team-edition
+./scripts/run-mattermost.sh
 ```
 
-The initial configuration is stored under `~/mattermost/config`. Edit `config.json` to set the site URL and enable integrations.
+The initial configuration is stored under `./mattermost`. Edit `config.json` to
+set the site URL and enable integrations. The server listens on port `8065` by
+default.
 
 ## Hyper-V support
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -33,3 +33,26 @@ To start Neko without the script, run:
 ```bash
 docker compose up neko
 ```
+
+## Nextcloud
+
+Nextcloud provides file sync and collaboration tools. Start it with:
+
+```bash
+./scripts/run-nextcloud.sh
+```
+
+It maps port `8082` to container port `80`. Adjust the value in `docker-compose.yml` if needed.
+
+You can also use `docker compose up nextcloud` directly.
+
+## Mattermost
+
+Mattermost is a self-hosted chat server. Run it via:
+
+```bash
+./scripts/run-mattermost.sh
+```
+
+The service listens on port `8065`. Data is stored under `./mattermost`.
+Use `docker compose up mattermost` to start it manually.

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
 from pathlib import Path
 from typing import List, Optional
 
@@ -37,7 +36,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     steps = ai_exec.plan(args.goal, config_path=args.config)
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
-        send_notification(f"ai-do completed with exit code {exit_code}")
+        send_notification("ai-do completed")
 
     return exit_code
 

--- a/scripts/run-mattermost.sh
+++ b/scripts/run-mattermost.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required but not installed." >&2
+    exit 1
+fi
+
+cd "$repo_root"
+exec docker compose up mattermost "$@"

--- a/scripts/run-nextcloud.sh
+++ b/scripts/run-nextcloud.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required but not installed." >&2
+    exit 1
+fi
+
+cd "$repo_root"
+exec docker compose up nextcloud "$@"


### PR DESCRIPTION
## Summary
- add Nextcloud, Mattermost, RomM and Neko containers to `docker-compose.yml`
- provide launcher scripts for Nextcloud and Mattermost
- document media containers
- update installation instructions
- fix ai_do notification message and remove duplicate import

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68654e40d3bc8326920027d5fb5073e2