### PR TITLE
Add command palette and plan overlay

### DIFF
--- a/tests/test_textual_ui.py
+++ b/tests/test_textual_ui.py
@@ -1,6 +1,8 @@
 import pytest
 pytest.importorskip("textual")
 from textual.widgets import Static, Input, Select  # noqa: E402 - imported after importorskip
+from textual.command import CommandPalette
+from ui.textual_app import PlanOverlay
 
 from ui.textual_app import TerminalUI
 
@@ -42,4 +44,24 @@ async def test_palette_application(monkeypatch):
 
         assert calls == ["dracula"]
         assert str(app.query_one("#status", Static).renderable) == "Applied dracula"
+
+
+@pytest.mark.asyncio
+async def test_command_palette_hotkey():
+    app = TerminalUI()
+    async with app.run_test() as pilot:
+        await pilot.press("ctrl+p")
+        await pilot.pause(0.05)
+        assert any(isinstance(s, CommandPalette) for s in app.screen_stack)
+
+
+@pytest.mark.asyncio
+async def test_plan_overlay_timeout():
+    app = TerminalUI()
+    async with app.run_test() as pilot:
+        overlay = PlanOverlay(["step"], timeout=0.1)
+        app.push_screen(overlay)
+        assert overlay in app.screen_stack
+        await pilot.pause(0.2)
+        assert overlay not in app.screen_stack
 

--- a/ui/textual_app.py
+++ b/ui/textual_app.py
@@ -1,18 +1,54 @@
 from __future__ import annotations
 
 from textual.app import App, ComposeResult
-from textual.widgets import Input, Button, Static, Select
+from textual.command import CommandPalette
 from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, ProgressBar, Select, Static
 
 from llm.router import send_prompt
 from scripts.thm import apply_palette, PALETTES_DIR, REPO_ROOT
+
+
+class PlanOverlay(ModalScreen[bool]):
+    """Overlay that displays planned shell steps and auto-accepts."""
+
+    def __init__(self, steps: list[str], timeout: float = 3) -> None:
+        super().__init__()
+        self.steps = steps
+        self.timeout = timeout
+        self._remaining = int(timeout * 10)
+
+    BINDINGS = [("y", "accept", "Accept"), ("n", "decline", "Decline")]
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - simple UI
+        yield Static("\n".join(self.steps), id="plan")
+        yield ProgressBar(total=self._remaining, id="timer", show_eta=False)
+
+    def on_mount(self) -> None:
+        self.set_interval(0.1, self._tick)
+
+    def _tick(self) -> None:
+        self._remaining -= 1
+        self.query_one("#timer", ProgressBar).advance(1)
+        if self._remaining <= 0:
+            self.action_accept()
+
+    def action_accept(self) -> None:
+        self.dismiss(True)
+
+    def action_decline(self) -> None:
+        self.dismiss(False)
 
 
 class TerminalUI(App):
     """Minimal Textual interface for prompt sending and palette application."""
 
     CSS_PATH = None
-    BINDINGS = [("q", "quit", "Quit")]
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("ctrl+p", "command_palette", "Command Palette"),
+    ]
 
     def compose(self) -> ComposeResult:  # pragma: no cover - simple UI
         palettes = [(p.stem, p.stem) for p in PALETTES_DIR.glob("*.toml")]
@@ -35,9 +71,13 @@ class TerminalUI(App):
                 self.query_one("#response", Static).update(result)
         elif event.button.id == "apply":
             palette = self.query_one("#palette", Select).value
-            if palette:
+            if isinstance(palette, str):
                 apply_palette(palette, REPO_ROOT)
                 self.query_one("#status", Static).update(f"Applied {palette}")
+
+    def show_plan(self, steps: list[str], timeout: float = 3) -> None:
+        """Display a plan overlay with an auto-accept timer."""
+        self.push_screen(PlanOverlay(steps, timeout))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual launch


### PR DESCRIPTION
## Summary
- allow opening command palette with Ctrl+P
- implement PlanOverlay with progress bar
- expose `show_plan` helper
- test command palette hotkey and overlay timeout

## Testing
- `ruff check ui/textual_app.py`
- `mypy ui/textual_app.py`
- `ruff check tests/test_textual_ui.py`
- `mypy tests/test_textual_ui.py`
- `pytest -k textual_ui -q`

------
https://chatgpt.com/codex/tasks/task_e_68654e4055948326bcf10249888783db