### PR TITLE
Update CI and fix ai_do notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,18 @@ jobs:
       - name: Run tests
         run: pytest -n auto
 
+  extras-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install dependencies with extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[lmql,guidance]' textual -r requirements.txt
+      - name: Run tests with extras
+        run: pytest -n auto
+

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -9,8 +9,6 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
-import subprocess
-
 from scripts import ai_exec
 from scripts.cli_common import execute_steps
 
@@ -37,7 +35,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     steps = ai_exec.plan(args.goal, config_path=args.config)
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
-        send_notification(f"ai-do completed with exit code {exit_code}")
+        if exit_code == 0:
+            send_notification("ai-do completed")
+        else:
+            send_notification(f"ai-do failed with exit code {exit_code}")
 
     return exit_code
 


### PR DESCRIPTION
## Summary
- add a job to run tests with optional extras installed
- fix duplicate subprocess import in `ai_do.py`
- send simpler notification when `ai_do` succeeds

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654e9c3778832681685c9518af0d13