### PR TITLE
Add retrieval example and improve tests

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -163,4 +163,18 @@ docker-compose up -d
 
 Open <http://localhost:5678> in your browser and choose **Import from File** to load `n8n/flows/mcp-ai_exec.json`. The workflow contains a single **Execute Command** node that calls `scripts/ai_exec.py`.
 
+## LangGraph Retrieval Example
+
+`scripts/rag_example.py` demonstrates how to build a simple retrieval graph. First ingest a document into ChromaDB:
+
+```bash
+python scripts/etl.py examples/rag_example.txt --persist examples/chroma --collection demo
+```
+
+Then query the collection using the retrieval graph:
+
+```bash
+python scripts/rag_example.py "small document" --persist examples/chroma --collection demo
+```
+
 

--- a/examples/rag_example.txt
+++ b/examples/rag_example.txt
@@ -1,0 +1,1 @@
+This is a small document for retrieval testing.

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -9,8 +9,6 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
-import subprocess
-
 from scripts import ai_exec
 from scripts.cli_common import execute_steps
 

--- a/scripts/rag_example.py
+++ b/scripts/rag_example.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Minimal retrieval example using LangGraph."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Optional
+
+from llm import etl
+
+
+def build_graph(collection: Any):
+    """Return a compiled retrieval graph for ``collection``."""
+    from langgraph.graph import StateGraph
+
+    g = StateGraph(dict)
+    etl.register_retrieval_nodes(g, collection)
+    g.set_entry_point("retrieve")
+    return g.compile()
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query", help="Search query")
+    parser.add_argument(
+        "--persist",
+        type=Path,
+        default=Path("chroma_db"),
+        help="Chroma persistence directory (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--collection",
+        default="documents",
+        help="Chroma collection name (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    import chromadb
+
+    client = chromadb.PersistentClient(path=str(args.persist))
+    collection = client.get_or_create_collection(args.collection)
+    app = build_graph(collection)
+    result = app.invoke({"query": args.query})
+    print(result["text"])
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())
+

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -130,4 +130,4 @@ def test_main_notifies(monkeypatch, tmp_path):
     rc = ai_do.main(["goal", "--log", str(log), "--notify"])
 
     assert rc == 0
-    assert called == ["ai-do completed"]
+    assert called == ["ai-do completed with exit code 0"]

--- a/tests/test_rag_example.py
+++ b/tests/test_rag_example.py
@@ -1,0 +1,96 @@
+import sys
+import types
+import io
+import contextlib
+
+from scripts import rag_example
+
+
+def test_build_graph(monkeypatch):
+    outputs = []
+
+    class Graph:
+        def __init__(self, *a, **k):
+            self.nodes = {}
+            self.entry = None
+
+        def add_node(self, name, node):
+            self.nodes[name] = node
+
+        def set_entry_point(self, name):
+            self.entry = name
+
+        def compile(self):
+            graph = self
+
+            class App:
+                def invoke(self, state):
+                    return graph.nodes[graph.entry](state)
+
+            return App()
+
+    def fake_stategraph(*a, **k):
+        return Graph()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "langgraph.graph",
+        types.SimpleNamespace(StateGraph=fake_stategraph),
+    )
+
+    def fake_register(graph, collection, *, node_name="retrieve"):
+        def run(state):
+            outputs.append(state)
+            return {"text": "retrieved"}
+
+        graph.add_node(node_name, run)
+        return graph
+
+    monkeypatch.setattr(rag_example.etl, "register_retrieval_nodes", fake_register)
+
+    app = rag_example.build_graph("coll")
+    result = app.invoke({"query": "hello"})
+    assert result == {"text": "retrieved"}
+    assert outputs == [{"query": "hello"}]
+
+
+def test_main_prints_text(monkeypatch, tmp_path):
+    out = io.StringIO()
+    captured = []
+
+    class FakeCollection:
+        pass
+
+    class FakeClient:
+        def __init__(self, path):
+            captured.append(f"path:{path}")
+
+        def get_or_create_collection(self, name):
+            captured.append(f"name:{name}")
+            return FakeCollection()
+
+    def fake_build_graph(collection):
+        assert isinstance(collection, FakeCollection)
+
+        class App:
+            def invoke(self, state):
+                captured.append(state)
+                return {"text": "ok"}
+
+        return App()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "chromadb",
+        types.SimpleNamespace(PersistentClient=FakeClient),
+    )
+    monkeypatch.setattr(rag_example, "build_graph", fake_build_graph)
+
+    with contextlib.redirect_stdout(out):
+        rc = rag_example.main(
+            ["hi", "--persist", str(tmp_path), "--collection", "demo"]
+        )
+
+    assert rc == 0
+    assert out.getvalue().strip() == "ok"
+    assert captured == [f"path:{tmp_path}", "name:demo", {"query": "hi"}]


### PR DESCRIPTION
## Summary
- add minimal LangGraph retrieval example
- document ingestion and query workflow
- include simple sample text
- restore exit code in ai_do notification
- verify rag example CLI outputs text

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68654e99daf48326a01b92c251cd3c1d