### PR TITLE
Fix ai_do success message and missing import

### DIFF
--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import subprocess
 from pathlib import Path
 from typing import List, Optional
 
@@ -35,7 +36,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed")
+            send_notification(f"ai-do completed with exit code {exit_code}")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 


### PR DESCRIPTION
## Summary
- ensure `subprocess` module is imported in `ai_do`
- notify with exit code when `ai_do` completes successfully

## Testing
- `ruff check scripts/ai_do.py`
- `pytest tests/test_ai_do.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6865ddedef1c8326b657639907701ffe