### PR TITLE
Add dashboard documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Additional guides:
 - [Media containers](docs/media.md)
 - [Repository navigation](docs/navigation.md)
 - [AI automation tooling](docs/ai-automation.md)
+- [Dashboard concept and API endpoints](docs/dashboard.md)
 
 ## Git hooks
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,15 @@
+# Dashboard Overview
+
+The dashboard is a planned React and Tailwind front end for the Universal Memory Engine (UME). It will visualize memory graphs, display query statistics and provide system health checks.
+
+## API Endpoints
+
+The UME exposes a small set of FastAPI routes that power the dashboard:
+
+- `GET /api/stats` – summary metrics for queries and memory usage
+- `GET /api/graph` – the current memory graph as JSON
+- `POST /api/palette` – apply a color palette
+- `POST /api/prompt` – forward an LLM prompt and return the response
+- `GET /api/health` – simple health check
+
+These endpoints will evolve as the project grows but form the foundation for the web UI.


### PR DESCRIPTION
## Summary
- document concept for a future dashboard and list key API endpoints
- link the dashboard doc from the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865e399fad48326adef8a9d5268fa23