### PR TITLE
Add Hyper-V VM helper

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -189,7 +189,13 @@ On Windows Pro editions you can enable Microsoft's virtualization stack:
 Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 ```
 
-Create virtual machines via the **Quick Create** wizard or `New-VM` in PowerShell. Hyper-V is useful for testing scripts in clean environments.
+Create virtual machines via the **Quick Create** wizard or `New-VM` in PowerShell. Use the provided helper script for a quick setup:
+
+```powershell
+./scripts/create-hyperv-vm.ps1 -Name TestVM
+```
+
+Hyper-V is useful for testing scripts in clean environments.
 
 ## ETL automation with n8n
 

--- a/scripts/create-hyperv-vm.ps1
+++ b/scripts/create-hyperv-vm.ps1
@@ -1,0 +1,25 @@
+$ErrorActionPreference = 'Stop'
+
+param(
+    [string] $Name = 'QuickVM',
+    [switch] $QuickCreate,
+    [int] $MemoryGB = 4
+)
+
+if (-not $IsWindows) {
+    return
+}
+
+if (-not (Get-Command New-VM -ErrorAction SilentlyContinue)) {
+    Write-Error 'Hyper-V is required but not installed.'
+    exit 1
+}
+
+if ($QuickCreate) {
+    Start-Process 'virtmgmt.msc' '-quick-create'
+    return
+}
+
+$VhdPath = Join-Path $env:PUBLIC "Documents\\Hyper-V\\$Name.vhdx"
+New-VM -Name $Name -MemoryStartupBytes ($MemoryGB * 1GB) -Generation 2 -SwitchName 'Default Switch' -NewVHDPath $VhdPath -NewVHDSizeBytes 60GB | Out-Null
+

--- a/tests/test_create_hyperv_vm.py
+++ b/tests/test_create_hyperv_vm.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+@pytest.mark.skipif(
+    shutil.which("pwsh") is None and shutil.which("powershell") is None,
+    reason="requires PowerShell",
+)
+def test_create_hyperv_vm_invokes_new_vm(tmp_path: Path) -> None:
+    pwsh = shutil.which("pwsh") or shutil.which("powershell")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "vm.log"
+    create_exe(bin_dir / "New-VM", f"#!/usr/bin/env bash\necho \"$@\" > '{log_file}'\n")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    subprocess.run(
+        [
+            pwsh,
+            "-NoLogo",
+            "-NoProfile",
+            "-Command",
+            (
+                "Set-Variable -Name IsWindows -Value $true -Force; "
+                f"& '{Path('scripts/create-hyperv-vm.ps1')}' -Name TestVM"
+            ),
+        ],
+        check=True,
+        env=env,
+    )
+
+    assert log_file.read_text().strip()
+


### PR DESCRIPTION
## Summary
- add `scripts/create-hyperv-vm.ps1` to automate VM creation
- document the helper in the Hyper-V section of the installation guide
- add a test that verifies the script invokes `New-VM`

## Testing
- `ruff check tests/test_create_hyperv_vm.py`
- `pytest -q tests/test_create_hyperv_vm.py`

------
https://chatgpt.com/codex/tasks/task_e_6865e38f7408832690cdc41ef3c7e440