### PR TITLE
Implement shared notification helper

### DIFF
--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -5,19 +5,11 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
 from pathlib import Path
 from typing import List, Optional
-import subprocess
 
 from scripts import ai_exec
-from scripts.cli_common import execute_steps
-
-
-def send_notification(message: str) -> None:
-    """Post a notification via ``ntfy`` if available."""
-    subprocess.run(["ntfy", "send", message], check=False)
-
+from scripts.cli_common import execute_steps, send_notification
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -11,13 +11,7 @@ from typing import List, Optional
 
 from llm import router
 from llm.ai_router import get_preferred_models
-from scripts.cli_common import read_prompt
-
-
-def send_notification(message: str) -> None:
-    """Post a notification via ``ntfy`` if available."""
-    subprocess.run(["ntfy", "send", message], check=False)
-
+from scripts.cli_common import read_prompt, send_notification
 
 def plan(goal: str, *, config_path: Optional[Path] = None) -> List[str]:
     """Return planning steps for ``goal`` using preferred models."""

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -44,4 +44,10 @@ def execute_steps(steps: Iterable[str], *, log_path: Path) -> int:
             exit_code = result.returncode
     return exit_code
 
-__all__ = ["read_prompt", "execute_steps"]
+
+def send_notification(message: str) -> None:
+    """Post ``message`` via ``ntfy`` if available."""
+    subprocess.run(["ntfy", "send", message], check=False)
+
+
+__all__ = ["read_prompt", "execute_steps", "send_notification"]

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -130,4 +130,4 @@ def test_main_notifies(monkeypatch, tmp_path):
     rc = ai_do.main(["goal", "--log", str(log), "--notify"])
 
     assert rc == 0
-    assert called == ["ai-do completed"]
+    assert called == ["ai-do completed with exit code 0"]


### PR DESCRIPTION
## Summary
- add `send_notification` to `cli_common`
- use common notification helper in `ai_exec` and `ai_do`
- update unit test expectation for AI notifications

## Testing
- `ruff check scripts llm tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e37b0d0483269a0bdc5a6b558b7d