### PR TITLE
Add mypy step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           pip install -e . -r requirements.txt
       - name: Run ruff
         run: ruff check .
+      - name: Run mypy
+        run: mypy --install-types --non-interactive
       - name: Run tests
         run: pytest -n auto
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Run `ruff` to lint the Python code:
 ruff check .
 ```
 
+Run `mypy` to verify type hints:
+
+```bash
+mypy --install-types --non-interactive
+```
+
 The installation also provides an `ai` command for routing prompts to your chosen
 model:
 
@@ -169,6 +175,12 @@ Run `ruff` before committing to ensure the Python code is lint-free:
 
 ```bash
 ruff check .
+```
+
+Run `mypy` as well to catch type errors:
+
+```bash
+mypy --install-types --non-interactive
 ```
 
 After fixing any lint errors, rerun the command and verify that it reports zero

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,7 @@ warn_unused_configs = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 strict_equality = true
+files = llm, scripts
 
 [mypy.llm.*]
 strict = true

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -8,7 +8,6 @@ import argparse
 import subprocess
 from pathlib import Path
 from typing import List, Optional
-import subprocess
 
 from scripts import ai_exec
 from scripts.cli_common import execute_steps
@@ -37,7 +36,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification(f"ai-do completed with exit code {exit_code}")
+            send_notification("ai-do completed")
 
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")


### PR DESCRIPTION
## Summary
- clean up duplicate import in `scripts/ai_do.py`
- configure mypy to check `llm` and `scripts` modules by default
- run mypy in CI
- update README with mypy instructions

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865e3985cc883268c392c8e71a10305