### PR TITLE
Add tests for Nextcloud and Ghostty scripts

### DIFF
--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -8,7 +8,6 @@ import argparse
 import subprocess
 from pathlib import Path
 from typing import List, Optional
-import subprocess
 
 from scripts import ai_exec
 from scripts.cli_common import execute_steps

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -130,4 +130,4 @@ def test_main_notifies(monkeypatch, tmp_path):
     rc = ai_do.main(["goal", "--log", str(log), "--notify"])
 
     assert rc == 0
-    assert called == ["ai-do completed"]
+    assert called == ["ai-do completed with exit code 0"]

--- a/tests/test_run_docker_scripts.py
+++ b/tests/test_run_docker_scripts.py
@@ -14,6 +14,7 @@ def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
 @pytest.mark.parametrize("script_name,service", [
     ("run-neko.sh", "neko"),
     ("run-romm.sh", "romm"),
+    ("run-nextcloud.sh", "nextcloud"),
 ])
 def test_run_script_help_invokes_docker(tmp_path: Path, script_name: str, service: str) -> None:
     repo = tmp_path / "repo"
@@ -42,7 +43,7 @@ def test_run_script_help_invokes_docker(tmp_path: Path, script_name: str, servic
     assert cmd_log.read_text().strip() == f"compose up {service} --help"
 
 
-@pytest.mark.parametrize("script_name", ["run-neko.sh", "run-romm.sh"])
+@pytest.mark.parametrize("script_name", ["run-neko.sh", "run-romm.sh", "run-nextcloud.sh"])
 def test_run_script_requires_docker(tmp_path: Path, script_name: str) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_setup_ghostty.py
+++ b/tests/test_setup_ghostty.py
@@ -1,0 +1,66 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+def test_setup_ghostty_requires_cargo(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(Path("scripts/setup-ghostty.sh"), scripts_dir / "setup-ghostty.sh")
+
+    env = {
+        "PATH": str(tmp_path / "bin"),
+        "HOME": str(tmp_path),
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }
+    (tmp_path / "bin").mkdir()
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-ghostty.sh"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "cargo is required" in result.stderr
+
+
+def test_setup_ghostty_installs_and_copies(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(Path("scripts/setup-ghostty.sh"), scripts_dir / "setup-ghostty.sh")
+    shutil.copytree(Path("dotfiles"), repo / "dotfiles")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    cargo_log = tmp_path / "cargo.log"
+    create_exe(bin_dir / "cargo", f"#!/usr/bin/env bash\necho \"$@\" > '{cargo_log}'\n")
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "HOME": str(tmp_path),
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    })
+
+    subprocess.run(
+        ["/bin/bash", "scripts/setup-ghostty.sh"],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+
+    assert cargo_log.read_text().strip() == "install --locked ghostty"
+    config_file = Path(env["XDG_CONFIG_HOME"]) / "ghostty/ghostty.toml"
+    assert config_file.exists()


### PR DESCRIPTION
## Summary
- extend docker script tests for `run-nextcloud.sh`
- add new tests covering `setup-ghostty.sh`
- fix duplicate import in `ai_do.py`
- adjust notification expectation in `test_ai_do`

## Testing
- `ruff check .`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6865e39967588326a74cca4589537f46