### PR TITLE
Add gource rendering helper

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -46,3 +46,16 @@ Mattermost is a self-hosted chat server. Run it via:
 
 The service listens on port `8065`. Data is stored under `./mattermost`.
 Use `docker compose up mattermost` to start it manually.
+
+## Repository visualization
+
+Render an animated commit history using [gource](https://gource.io/). The helper
+script relies on `gource` and `ffmpeg`, and will generate `gource.mp4` in the
+repository root. If `terminalizer` is installed the script also exports a GIF.
+
+```bash
+./scripts/render-gource.sh
+```
+
+Run the script manually when you want to update the video or set up a scheduled
+workflow to automate it.

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -8,7 +8,6 @@ import argparse
 import subprocess
 from pathlib import Path
 from typing import List, Optional
-import subprocess
 
 from scripts import ai_exec
 from scripts.cli_common import execute_steps
@@ -37,8 +36,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification(f"ai-do completed with exit code {exit_code}")
-
+            send_notification("ai-do completed")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 

--- a/scripts/render-gource.sh
+++ b/scripts/render-gource.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+output="${1:-gource.mp4}"
+
+if ! command -v gource >/dev/null 2>&1; then
+    echo "Error: gource is required" >&2
+    exit 1
+fi
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+    echo "Error: ffmpeg is required" >&2
+    exit 1
+fi
+
+# Render the repository history using gource and ffmpeg
+# Terminalizer can be used to convert the resulting video to a GIF
+# if it is available on the system.
+
+gource \
+    --seconds-per-day 0.1 \
+    --auto-skip-seconds 1 \
+    --hide mouse,dirnames,filenames \
+    --output-ppm-stream - \
+    | ffmpeg -y -r 60 -f image2pipe -vcodec ppm -i - \
+        -vcodec libx264 -pix_fmt yuv420p "$output"
+
+if command -v terminalizer >/dev/null 2>&1; then
+    gif_output="${output%.*}.gif"
+    terminalizer render "$output" -o "$gif_output" || \
+        echo "terminalizer failed to create GIF" >&2
+fi


### PR DESCRIPTION
## Summary
- add `scripts/render-gource.sh` to capture repo history
- document how to generate the video in `docs/media.md`
- fix duplicate imports and adjust notification text in `ai_do.py`

## Testing
- `ruff check .`
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865e390206883269d53c31f39518eef