### PR TITLE
Fix SuperClaude backend registration

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -8,6 +8,7 @@ import importlib
 import pkgutil
 
 from .base import Backend
+from .superclaude import SuperClaudeBackend
 
 
 _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
@@ -28,6 +29,7 @@ __all__ = [
     "OpenRouterDSPyBackend",
     "LMQLBackend",
     "GuidanceBackend",
+    "SuperClaudeBackend",
 ]
 
 

--- a/llm/router.py
+++ b/llm/router.py
@@ -16,6 +16,7 @@ from .backends import (
 
     get_backend,
 )
+from llm.backends import SuperClaudeBackend, register_backend
 from .ai_router import get_preferred_models
 from .langchain_backend import LangChainBackend
 


### PR DESCRIPTION
## Summary
- import SuperClaude backend into router
- expose `SuperClaudeBackend` through `llm.backends`

## Testing
- `ruff check llm/router.py`
- `pytest tests/test_ai_router.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e926fd1c8326b1985d8ada490f2c