### PR TITLE
Add n8n flow generator

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -6,16 +6,8 @@ import os
 import subprocess
 from typing import List
 
-from .backends import (
-    GeminiBackend,  # noqa: F401 - re-exported for tests
-    GeminiDSPyBackend,  # noqa: F401 - re-exported for tests
-    OllamaBackend,  # noqa: F401 - re-exported for tests
-    OllamaDSPyBackend,  # noqa: F401 - re-exported for tests
-    OpenRouterBackend,  # noqa: F401 - re-exported for tests
-    OpenRouterDSPyBackend,  # noqa: F401 - re-exported for tests
-
-    get_backend,
-)
+from .backends import register_backend, get_backend
+from .backends.superclaude import SuperClaudeBackend  # noqa: F401 - tests
 from .ai_router import get_preferred_models
 from .langchain_backend import LangChainBackend
 
@@ -35,7 +27,7 @@ def run_gemini(prompt: str, model: str | None = None) -> str:
     """Return Gemini response for ``prompt`` using registered backend."""
 
     func = get_backend("gemini")
-    return func(prompt, model)
+    return func(prompt, model or "")
 
 
 def run_ollama(prompt: str, model: str) -> str:

--- a/n8n/flows/generated-example.json
+++ b/n8n/flows/generated-example.json
@@ -1,0 +1,34 @@
+{
+  "name": "Generated Example",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1",
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {"name": "hello", "value": "world"}
+          ]
+        }
+      },
+      "id": "2",
+      "name": "Set",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [460, 300]
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [ { "node": "Set", "type": "main", "index": 0 } ]
+      ]
+    }
+  }
+}

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,8 +29,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed")
-
+            send_notification(f"ai-do completed with exit code {exit_code}")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 

--- a/scripts/n8n_generate.py
+++ b/scripts/n8n_generate.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Generate n8n workflow JSON using the LLM router."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Optional
+
+from llm import router
+from scripts.cli_common import read_prompt
+
+DEFAULT_PROMPT = (
+    "Create a basic n8n workflow JSON with a Start node and a Set node."
+)
+
+
+def generate(prompt: str) -> dict:
+    """Return parsed workflow JSON for ``prompt``."""
+    text = router.send_prompt(prompt)
+    return json.loads(text)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "prompt",
+        nargs="?",
+        default=DEFAULT_PROMPT,
+        help="Prompt describing the workflow or '-' to read from STDIN",
+    )
+    parser.add_argument("-o", "--output", type=Path, help="Write JSON to this file")
+    args = parser.parse_args(argv)
+
+    prompt = read_prompt(args.prompt)
+    data = generate(prompt)
+    output = json.dumps(data, indent=2)
+
+    if args.output:
+        Path(args.output).write_text(output)
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_n8n_flow.py
+++ b/tests/test_n8n_flow.py
@@ -1,6 +1,9 @@
 import json
 from pathlib import Path
 
+from scripts import n8n_generate
+from llm import router
+
 
 def test_mcp_node_present():
     data = json.loads(Path('n8n/flows/mcp-ai_exec.json').read_text())
@@ -11,4 +14,11 @@ def test_mcp_node_present():
     assert start_main and start_main[0][0]['node'] == 'mcp'
     mcp_main = conns.get('mcp', {}).get('main', [])
     assert mcp_main and mcp_main[0][0]['node'] == 'ai_exec'
+
+
+def test_generate_returns_valid_json(monkeypatch):
+    sample = Path('n8n/flows/generated-example.json').read_text()
+    monkeypatch.setattr(router, 'send_prompt', lambda p: sample)
+    data = n8n_generate.generate('dummy')
+    assert 'nodes' in data and isinstance(data['nodes'], list)
 


### PR DESCRIPTION
## Summary
- fix router imports and notification text
- add `scripts/n8n_generate.py` for LLM-based n8n workflow generation
- provide `generated-example.json` sample workflow
- validate generated workflow in tests

## Testing
- `ruff check llm/router.py scripts/ai_do.py scripts/n8n_generate.py tests/test_n8n_flow.py`
- `mypy --install-types --non-interactive llm/router.py scripts/ai_do.py scripts/n8n_generate.py tests/test_n8n_flow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e9315e548326afd2ae90fc42f6f4