### PR TITLE
Update dashboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Additional guides:
 - [Media containers](docs/media.md)
 - [Repository navigation](docs/navigation.md)
 - [AI automation tooling](docs/ai-automation.md)
-- [Dashboard concept and API endpoints](docs/dashboard.md)
+- [Dashboard overview](docs/dashboard.md)
 
 ## Git hooks
 

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -48,18 +48,34 @@ By default the tool picks the backend automatically based on the prompt length.
 Set `LLM_ROUTING_MODE` to `remote` or `local` to force the behavior, or tweak
 `LLM_COMPLEXITY_THRESHOLD` to adjust when the prompt is considered complex.
 
-## Streamlit Web UI
+## FastAPI/Next.js Dashboard
 
-A lightweight web interface built with [Streamlit](https://streamlit.io/) exposes
-the same prompt routing and palette controls. Launch it from the repository
-root:
+The project ships with a small FastAPI backend that exposes routes for sending
+prompts, applying palettes and monitoring the Universal Memory Engine. A
+Next.js front end consumes these endpoints and can also be packaged as a Tauri
+desktop app.
+
+To launch the API locally run:
+
+```bash
+uvicorn llm.api:app --reload --port 8000
+```
+
+The React dashboard connects to the same host, typically started with
+`pnpm dev` on <http://localhost:3000>. The Tauri build uses the same
+React code so both environments share a consistent interface.
+
+### Legacy Streamlit interface
+
+Earlier versions provided a Streamlit UI located at `ui/web_app.py`. It remains
+for reference and can be launched with:
 
 ```bash
 streamlit run ui/web_app.py --server.headless true
 ```
 
-Use **Send** to route prompts via `ai_router.send_prompt` and **Apply** to call
-`thm.apply_palette`.
+This prototype is no longer actively developed but still mirrors the prompt
+routing and palette controls.
 
 ## LLM Configuration
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,6 +1,11 @@
 # Dashboard Overview
 
-The dashboard is a planned React and Tailwind front end for the Universal Memory Engine (UME). It will visualize memory graphs, display query statistics and provide system health checks.
+The dashboard pairs a FastAPI backend with a React front end built using Next.js.
+The backend usually runs on <http://localhost:8000> while the dev server for
+the React dashboard listens on <http://localhost:3000>. The same code base can
+also be packaged as a Tauri application for a native desktop experience. It will
+visualize memory graphs, display query statistics and provide system health
+checks for the Universal Memory Engine (UME).
 
 ## API Endpoints
 

--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -8,6 +8,7 @@ import importlib
 import pkgutil
 
 from .base import Backend
+from .superclaude import SuperClaudeBackend
 
 
 _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
@@ -28,6 +29,7 @@ __all__ = [
     "OpenRouterDSPyBackend",
     "LMQLBackend",
     "GuidanceBackend",
+    "SuperClaudeBackend",
 ]
 
 

--- a/llm/router.py
+++ b/llm/router.py
@@ -13,7 +13,8 @@ from .backends import (
     OllamaDSPyBackend,  # noqa: F401 - re-exported for tests
     OpenRouterBackend,  # noqa: F401 - re-exported for tests
     OpenRouterDSPyBackend,  # noqa: F401 - re-exported for tests
-
+    SuperClaudeBackend,  # noqa: F401 - re-exported for tests
+    register_backend,
     get_backend,
 )
 from .ai_router import get_preferred_models

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,8 +29,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed")
-
+            send_notification("ai-do completed with exit code 0")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 


### PR DESCRIPTION
## Summary
- describe the FastAPI/Next.js dashboard, note the port numbers
- add legacy Streamlit reference
- expose `SuperClaudeBackend` in backends package
- fix notification text in `ai_do`
- tests now pass

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e935b9948326839579035a084d8a