### PR TITLE
Enable strict checks and add plugin discovery tests

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -11,6 +11,10 @@ from .base import Backend
 
 
 _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
+GeminiBackend: type[Backend] | None = None
+OllamaBackend: type[Backend] | None = None
+OpenRouterBackend: type[Backend] | None = None
+SuperClaudeBackend: type[Backend] | None = None
 GeminiDSPyBackend = None
 OllamaDSPyBackend = None
 OpenRouterDSPyBackend = None
@@ -23,6 +27,10 @@ __all__ = [
     "clear_registry",
     "discover_plugins",
     "available_backends",
+    "GeminiBackend",
+    "OllamaBackend",
+    "OpenRouterBackend",
+    "SuperClaudeBackend",
     "GeminiDSPyBackend",
     "OllamaDSPyBackend",
     "OpenRouterDSPyBackend",

--- a/llm/backends/plugins/gemini.py
+++ b/llm/backends/plugins/gemini.py
@@ -8,9 +8,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .gemini_dspy import GeminiDSPyBackend  # type: ignore
+    from .gemini_dspy import GeminiDSPyBackend as _GeminiDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    GeminiDSPyBackend = None
+    _GeminiDSPyBackend = None
+
+GeminiDSPyBackend: type[Backend] | None = _GeminiDSPyBackend
 
 
 class GeminiBackend(Backend):

--- a/llm/backends/plugins/lmql.py
+++ b/llm/backends/plugins/lmql.py
@@ -5,6 +5,8 @@ from typing import Any, cast
 from .. import register_backend
 from ..base import Backend
 
+_LMQLBackend: type[Backend] | None = None
+
 try:  # pragma: no cover - optional dependency
     import lmql  # noqa: F401
 except ImportError:  # pragma: no cover - missing optional dep
@@ -12,7 +14,7 @@ except ImportError:  # pragma: no cover - missing optional dep
 
 
 if lmql is not None:
-    class LMQLBackend(Backend):
+    class _RealLMQLBackend(Backend):
         """Backend implemented using `lmql`."""
 
         def __init__(self, model: str) -> None:
@@ -20,8 +22,11 @@ if lmql is not None:
 
         def run(self, prompt: str) -> str:  # pragma: no cover - network placeholder
             return f"lmql:{prompt}:{self.model}"
+    _LMQLBackend = _RealLMQLBackend
 else:  # pragma: no cover - optional dependency missing
-    LMQLBackend = None  # type: ignore
+    _LMQLBackend = None
+
+LMQLBackend: type[Backend] | None = _LMQLBackend
 
 
 def run_lmql(prompt: str, model: str) -> str:

--- a/llm/backends/plugins/ollama.py
+++ b/llm/backends/plugins/ollama.py
@@ -7,9 +7,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .ollama_dspy import OllamaDSPyBackend  # type: ignore
+    from .ollama_dspy import OllamaDSPyBackend as _OllamaDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    OllamaDSPyBackend = None
+    _OllamaDSPyBackend = None
+
+OllamaDSPyBackend: type[Backend] | None = _OllamaDSPyBackend
 
 
 class OllamaBackend(Backend):

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -5,19 +5,20 @@ from typing import Any, Callable, Mapping
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    import dspy  # type: ignore
+    import dspy
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
 _LM: Callable[..., Any] | None = None
 LM: Callable[..., Any]
+_OllamaDSPyBackend: type[Backend] | None = None
 if dspy is not None:
     _LM = getattr(dspy, "LLM", getattr(dspy, "LM", None))
     if _LM is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
     LM = _LM
 
-    class OllamaDSPyBackend(Backend):
+    class _RealOllamaDSPyBackend(Backend):
         """Ollama backend implemented via ``dspy``."""
 
         def __init__(self, model: str) -> None:
@@ -26,8 +27,10 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
-else:  # pragma: no cover - optional dependency missing
-    OllamaDSPyBackend = None  # type: ignore
+
+    _OllamaDSPyBackend = _RealOllamaDSPyBackend
+
+OllamaDSPyBackend: type[Backend] | None = _OllamaDSPyBackend
 
 
 def _extract_text(result: Mapping[str, Any]) -> str:

--- a/llm/backends/plugins/openrouter.py
+++ b/llm/backends/plugins/openrouter.py
@@ -6,9 +6,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .openrouter_dspy import OpenRouterDSPyBackend  # type: ignore
+    from .openrouter_dspy import OpenRouterDSPyBackend as _OpenRouterDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    OpenRouterDSPyBackend = None
+    _OpenRouterDSPyBackend = None
+
+OpenRouterDSPyBackend: type[Backend] | None = _OpenRouterDSPyBackend
 
 
 class OpenRouterBackend(Backend):

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -5,19 +5,20 @@ from typing import Any, Callable, Mapping
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    import dspy  # type: ignore
+    import dspy
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
 _LM: Callable[..., Any] | None = None
 LM: Callable[..., Any]
+_OpenRouterDSPyBackend: type[Backend] | None = None
 if dspy is not None:
     _LM = getattr(dspy, "LLM", getattr(dspy, "LM", None))
     if _LM is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
     LM = _LM
 
-    class OpenRouterDSPyBackend(Backend):
+    class _RealOpenRouterDSPyBackend(Backend):
         """OpenRouter backend implemented via ``dspy``."""
 
         def __init__(self, model: str) -> None:
@@ -26,8 +27,10 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
-else:  # pragma: no cover - optional dependency missing
-    OpenRouterDSPyBackend = None  # type: ignore
+
+    _OpenRouterDSPyBackend = _RealOpenRouterDSPyBackend
+
+OpenRouterDSPyBackend: type[Backend] | None = _OpenRouterDSPyBackend
 
 
 def _extract_text(result: Mapping[str, Any]) -> str:

--- a/llm/router.py
+++ b/llm/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from typing import List
+from typing import Any, Callable, List, cast
 
 from .backends import (
     GeminiBackend,  # noqa: F401 - re-exported for tests
@@ -15,6 +15,8 @@ from .backends import (
     OpenRouterDSPyBackend,  # noqa: F401 - re-exported for tests
 
     get_backend,
+    register_backend,
+    SuperClaudeBackend,
 )
 from .ai_router import get_preferred_models
 from .langchain_backend import LangChainBackend
@@ -34,7 +36,7 @@ def estimate_prompt_complexity(prompt: str) -> int:
 def run_gemini(prompt: str, model: str | None = None) -> str:
     """Return Gemini response for ``prompt`` using registered backend."""
 
-    func = get_backend("gemini")
+    func = cast(Callable[[str, str | None], str], get_backend("gemini"))
     return func(prompt, model)
 
 
@@ -54,7 +56,7 @@ def run_openrouter(prompt: str, model: str) -> str:
 
 def run_superclaude(prompt: str, model: str) -> str:
     """Return SuperClaude response for ``prompt`` using ``model``."""
-    backend = SuperClaudeBackend(model)
+    backend = cast(Any, SuperClaudeBackend)(model)
     return backend.run(prompt)
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,5 +10,8 @@ files = llm, scripts
 [mypy.llm.*]
 strict = true
 
+[mypy.llm.backends.plugins.*]
+strict = true
+
 [mypy.scripts.*]
 strict = true

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,7 +29,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed")
+            send_notification("ai-do completed with exit code 0")
 
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+
+from llm import backends
+
+
+def _reset_plugins():
+    backends.clear_registry()
+    for mod in list(sys.modules):
+        if mod.startswith("llm.backends.plugins"):  # clear plugin modules
+            sys.modules.pop(mod)
+
+def test_discover_plugins_ignores_import_errors(monkeypatch):
+    _reset_plugins()
+
+    original_import = importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "llm.backends.plugins.guidance":
+            raise ImportError("missing guidance")
+        return original_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    backends.discover_plugins()
+
+    assert "guidance" not in backends.available_backends()
+
+
+def test_discover_plugins_handles_missing_optional_dependency(monkeypatch):
+    _reset_plugins()
+
+    original_import = importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "llm.backends.plugins.gemini_dspy":
+            raise ImportError("dspy missing")
+        return original_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    backends.discover_plugins()
+
+    assert "gemini" in backends.available_backends()

--- a/tests/test_superclaude_backend.py
+++ b/tests/test_superclaude_backend.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("requests")  # ensure dependency present
+
 from llm.backends.superclaude import SuperClaudeBackend
 from llm import router as ai_router
 


### PR DESCRIPTION
## Summary
- enable mypy strict checks for `llm/backends/plugins`
- ensure optional plugin dependencies don't break discovery
- fix router and plugins so mypy passes
- include exit code in `ai-do` notifications
- skip SuperClaude tests when `requests` isn't available

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865e934ac4c8326a98677a3cc6989ce