### PR TITLE
Add routing strategy ranking

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -48,6 +48,9 @@ By default the tool picks the backend automatically based on the prompt length.
 Set `LLM_ROUTING_MODE` to `remote` or `local` to force the behavior, or tweak
 `LLM_COMPLEXITY_THRESHOLD` to adjust when the prompt is considered complex.
 
+Use `--route cost` to prefer the cheapest model or `--route context` to prefer
+the backend with the largest context window.
+
 ## Streamlit Web UI
 
 A lightweight web interface built with [Streamlit](https://streamlit.io/) exposes
@@ -73,7 +76,11 @@ Example configuration:
 ```json
 {
   "primary_model": "gpt-4",
-  "fallback_model": "gpt-3.5-turbo"
+  "fallback_model": "gpt-3.5-turbo",
+  "models": {
+    "gpt-4": {"cost": 0.06, "context": 8192},
+    "gpt-3.5-turbo": {"cost": 0.01, "context": 4096}
+  }
 }
 ```
 

--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -11,6 +11,9 @@ from .base import Backend
 
 
 _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
+GeminiBackend = None
+OllamaBackend = None
+OpenRouterBackend = None
 GeminiDSPyBackend = None
 OllamaDSPyBackend = None
 OpenRouterDSPyBackend = None
@@ -23,6 +26,9 @@ __all__ = [
     "clear_registry",
     "discover_plugins",
     "available_backends",
+    "GeminiBackend",
+    "OllamaBackend",
+    "OpenRouterBackend",
     "GeminiDSPyBackend",
     "OllamaDSPyBackend",
     "OpenRouterDSPyBackend",

--- a/llm/backends/plugins/gemini.py
+++ b/llm/backends/plugins/gemini.py
@@ -8,9 +8,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .gemini_dspy import GeminiDSPyBackend  # type: ignore
+    from .gemini_dspy import GeminiDSPyBackend as _GDSPY
 except Exception:  # pragma: no cover - optional dependency missing
-    GeminiDSPyBackend = None
+    GeminiDSPyBackend: Any = None
+else:
+    GeminiDSPyBackend = _GDSPY
 
 
 class GeminiBackend(Backend):

--- a/llm/backends/plugins/gemini_dspy.py
+++ b/llm/backends/plugins/gemini_dspy.py
@@ -5,19 +5,20 @@ from typing import Any, Callable, Mapping
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    import dspy  # type: ignore
+    import dspy
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
 _LM: Callable[..., Any] | None = None
 LM: Callable[..., Any]
+GeminiDSPyBackend: type[Backend] | None
 if dspy is not None:
     _LM = getattr(dspy, "LLM", getattr(dspy, "LM", None))
     if _LM is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
     LM = _LM
 
-    class GeminiDSPyBackend(Backend):
+    class _GeminiDSPyBackend(Backend):
         """Gemini backend implemented via ``dspy``."""
 
         def __init__(self, model: str | None = None) -> None:
@@ -26,8 +27,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    GeminiDSPyBackend = _GeminiDSPyBackend
 else:  # pragma: no cover - optional dependency missing
-    GeminiDSPyBackend = None  # type: ignore
+    GeminiDSPyBackend = None
 
 
 def _extract_text(result: Mapping[str, Any]) -> str:

--- a/llm/backends/plugins/lmql.py
+++ b/llm/backends/plugins/lmql.py
@@ -11,8 +11,9 @@ except ImportError:  # pragma: no cover - missing optional dep
     lmql = None
 
 
+LMQLBackend: type[Backend] | None
 if lmql is not None:
-    class LMQLBackend(Backend):
+    class _LMQLBackend(Backend):
         """Backend implemented using `lmql`."""
 
         def __init__(self, model: str) -> None:
@@ -20,8 +21,9 @@ if lmql is not None:
 
         def run(self, prompt: str) -> str:  # pragma: no cover - network placeholder
             return f"lmql:{prompt}:{self.model}"
+    LMQLBackend = _LMQLBackend
 else:  # pragma: no cover - optional dependency missing
-    LMQLBackend = None  # type: ignore
+    LMQLBackend = None
 
 
 def run_lmql(prompt: str, model: str) -> str:

--- a/llm/backends/plugins/ollama.py
+++ b/llm/backends/plugins/ollama.py
@@ -7,9 +7,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .ollama_dspy import OllamaDSPyBackend  # type: ignore
+    from .ollama_dspy import OllamaDSPyBackend as _ODSPY
 except Exception:  # pragma: no cover - optional dependency missing
-    OllamaDSPyBackend = None
+    OllamaDSPyBackend: Any = None
+else:
+    OllamaDSPyBackend = _ODSPY
 
 
 class OllamaBackend(Backend):

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -5,19 +5,20 @@ from typing import Any, Callable, Mapping
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    import dspy  # type: ignore
+    import dspy
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
 _LM: Callable[..., Any] | None = None
 LM: Callable[..., Any]
+OllamaDSPyBackend: type[Backend] | None
 if dspy is not None:
     _LM = getattr(dspy, "LLM", getattr(dspy, "LM", None))
     if _LM is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
     LM = _LM
 
-    class OllamaDSPyBackend(Backend):
+    class _OllamaDSPyBackend(Backend):
         """Ollama backend implemented via ``dspy``."""
 
         def __init__(self, model: str) -> None:
@@ -26,8 +27,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    OllamaDSPyBackend = _OllamaDSPyBackend
 else:  # pragma: no cover - optional dependency missing
-    OllamaDSPyBackend = None  # type: ignore
+    OllamaDSPyBackend = None
 
 
 def _extract_text(result: Mapping[str, Any]) -> str:

--- a/llm/backends/plugins/openrouter.py
+++ b/llm/backends/plugins/openrouter.py
@@ -6,9 +6,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .openrouter_dspy import OpenRouterDSPyBackend  # type: ignore
+    from .openrouter_dspy import OpenRouterDSPyBackend as _ORDSPY
 except Exception:  # pragma: no cover - optional dependency missing
-    OpenRouterDSPyBackend = None
+    OpenRouterDSPyBackend: Any = None
+else:
+    OpenRouterDSPyBackend = _ORDSPY
 
 
 class OpenRouterBackend(Backend):

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -5,19 +5,20 @@ from typing import Any, Callable, Mapping
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    import dspy  # type: ignore
+    import dspy
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
 _LM: Callable[..., Any] | None = None
 LM: Callable[..., Any]
+OpenRouterDSPyBackend: type[Backend] | None
 if dspy is not None:
     _LM = getattr(dspy, "LLM", getattr(dspy, "LM", None))
     if _LM is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
     LM = _LM
 
-    class OpenRouterDSPyBackend(Backend):
+    class _OpenRouterDSPyBackend(Backend):
         """OpenRouter backend implemented via ``dspy``."""
 
         def __init__(self, model: str) -> None:
@@ -26,8 +27,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    OpenRouterDSPyBackend = _OpenRouterDSPyBackend
 else:  # pragma: no cover - optional dependency missing
-    OpenRouterDSPyBackend = None  # type: ignore
+    OpenRouterDSPyBackend = None
 
 
 def _extract_text(result: Mapping[str, Any]) -> str:

--- a/llm/backends/superclaude.py
+++ b/llm/backends/superclaude.py
@@ -1,8 +1,22 @@
+"""SuperClaude backend."""
+
 from __future__ import annotations
 
-import requests
-
 from .base import Backend
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - optional dependency missing
+    import sys
+    import types
+
+    requests = types.ModuleType("requests")
+
+    def _missing(*_args: object, **_kwargs: object) -> None:
+        raise ModuleNotFoundError("requests package not installed")
+
+    setattr(requests, "post", _missing)
+    sys.modules["requests"] = requests
 
 
 class SuperClaudeBackend(Backend):

--- a/llm/llm_config.json
+++ b/llm/llm_config.json
@@ -1,4 +1,9 @@
 {
   "primary_model": "gpt-4",
-  "fallback_model": "gpt-3.5-turbo"
+  "fallback_model": "gpt-3.5-turbo",
+  "models": {
+    "gpt-4": {"cost": 0.06, "context": 8192},
+    "gpt-3.5-turbo": {"cost": 0.01, "context": 4096},
+    "llama3": {"cost": 0.0, "context": 8192}
+  }
 }

--- a/llm/router.py
+++ b/llm/router.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
+import json
 import subprocess
-from typing import List
+from pathlib import Path
+from typing import Any, List, Mapping
 
 from .backends import (
     GeminiBackend,  # noqa: F401 - re-exported for tests
@@ -13,10 +15,12 @@ from .backends import (
     OllamaDSPyBackend,  # noqa: F401 - re-exported for tests
     OpenRouterBackend,  # noqa: F401 - re-exported for tests
     OpenRouterDSPyBackend,  # noqa: F401 - re-exported for tests
-
+    register_backend,
     get_backend,
 )
+from .backends.superclaude import SuperClaudeBackend
 from .ai_router import get_preferred_models
+from .utils import get_repo_root
 from .langchain_backend import LangChainBackend
 
 DEFAULT_MODEL = "llama3"
@@ -24,6 +28,9 @@ DEFAULT_PRIMARY_BACKEND = "gemini"
 DEFAULT_FALLBACK_BACKEND = "ollama"
 
 DEFAULT_COMPLEXITY_THRESHOLD = 50
+
+# Configuration file storing model metadata
+_DEFAULT_CONFIG = get_repo_root() / "llm" / "llm_config.json"
 
 
 def estimate_prompt_complexity(prompt: str) -> int:
@@ -35,7 +42,7 @@ def run_gemini(prompt: str, model: str | None = None) -> str:
     """Return Gemini response for ``prompt`` using registered backend."""
 
     func = get_backend("gemini")
-    return func(prompt, model)
+    return func(prompt, model)  # type: ignore[arg-type]
 
 
 def run_ollama(prompt: str, model: str) -> str:
@@ -50,6 +57,31 @@ def run_openrouter(prompt: str, model: str) -> str:
 
     func = get_backend("openrouter")
     return func(prompt, model)
+
+
+def _load_model_data(path: Path) -> Mapping[str, Mapping[str, Any]]:
+    """Return model metadata loaded from ``path``."""
+    if not path.exists():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as fh:
+            cfg = json.load(fh)
+    except json.JSONDecodeError:  # pragma: no cover - invalid json
+        return {}
+    models = cfg.get("models")
+    if isinstance(models, dict):
+        return models
+    return {}
+
+
+def get_model_specs(config_path: Path | None = None) -> Mapping[str, Mapping[str, Any]]:
+    """Return model metadata mapping from ``config_path`` or default config."""
+    env_path = os.environ.get("LLM_CONFIG_PATH")
+    if config_path is None:
+        path = Path(env_path) if env_path else _DEFAULT_CONFIG
+    else:
+        path = config_path
+    return _load_model_data(path)
 
 
 def run_superclaude(prompt: str, model: str) -> str:
@@ -110,7 +142,13 @@ def _run_backend(name: str, prompt: str, model: str) -> str:
     return func(prompt, model)
 
 
-def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL) -> str:
+def send_prompt(
+    prompt: str,
+    *,
+    local: bool = False,
+    model: str = DEFAULT_MODEL,
+    strategy: str = "auto",
+) -> str:
     """Send ``prompt`` using the configured backends."""
     primary, fallback = _preferred_backends()
     order: List[str] = []
@@ -140,6 +178,25 @@ def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL)
                 if fallback:
                     order.append(fallback)
                 order.append(primary)
+
+    if strategy in {"cost", "context"} and len(order) > 1:
+        specs = get_model_specs()
+        primary_model, fallback_model = get_preferred_models(DEFAULT_MODEL, DEFAULT_MODEL)
+
+        def _model_name(backend: str) -> str:
+            if backend == primary:
+                return primary_model
+            if backend == fallback and fallback_model is not None:
+                return fallback_model
+            return model
+
+        if strategy == "cost":
+            order.sort(key=lambda b: specs.get(_model_name(b), {}).get("cost", float("inf")))
+        else:  # context
+            order.sort(
+                key=lambda b: specs.get(_model_name(b), {}).get("context", 0),
+                reverse=True,
+            )
     for backend_name in order:
         try:
             return _run_backend(backend_name, prompt, model)

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -17,7 +17,12 @@ from scripts.cli_common import execute_steps, read_prompt
 def _cmd_send(args: argparse.Namespace) -> int:
     prompt = read_prompt(args.prompt)
     try:
-        output = router.send_prompt(prompt, local=args.local, model=args.model)
+        output = router.send_prompt(
+            prompt,
+            local=args.local,
+            model=args.model,
+            strategy=args.route,
+        )
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -47,6 +52,12 @@ def build_parser() -> argparse.ArgumentParser:
     send.add_argument("prompt", help="Prompt or '-' to read from STDIN")
     send.add_argument("--local", action="store_true", help="Force use of fallback backend")
     send.add_argument("--model", default=router.DEFAULT_MODEL, help="Model name for Ollama (default: %(default)s)")
+    send.add_argument(
+        "--route",
+        choices=["auto", "cost", "context"],
+        default="auto",
+        help="Routing strategy (default: %(default)s)",
+    )
     send.set_defaults(func=_cmd_send)
 
     plan = sub.add_parser("plan", help="Generate a shell plan for a goal")

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,8 +29,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed")
-
+            send_notification(f"ai-do completed with exit code {exit_code}")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -6,10 +6,17 @@ from scripts import ai_cli
 
 
 def test_send_subcommand(monkeypatch):
-    def mock_send(prompt, *, local=False, model=ai_cli.router.DEFAULT_MODEL):
+    def mock_send(
+        prompt,
+        *,
+        local=False,
+        model=ai_cli.router.DEFAULT_MODEL,
+        strategy="auto",
+    ):
         assert prompt == "msg"
         assert local is True
         assert model == "m"
+        assert strategy == "auto"
         return "ok"
 
     monkeypatch.setattr(ai_cli.router, "send_prompt", mock_send)
@@ -18,6 +25,20 @@ def test_send_subcommand(monkeypatch):
         rc = ai_cli.main(["send", "--local", "--model", "m", "msg"])
     assert rc == 0
     assert out.getvalue().strip() == "ok"
+
+
+def test_send_subcommand_with_strategy(monkeypatch):
+    def mock_send(prompt, *, local=False, model=ai_cli.router.DEFAULT_MODEL, strategy="auto"):
+        assert prompt == "hey"
+        assert strategy == "cost"
+        return "done"
+
+    monkeypatch.setattr(ai_cli.router, "send_prompt", mock_send)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["send", "--route", "cost", "hey"])
+    assert rc == 0
+    assert out.getvalue().strip() == "done"
 
 
 def test_plan_subcommand(monkeypatch):


### PR DESCRIPTION
## Summary
- let the router load model cost and context data
- sort backends by cost or context when requested
- pass the `--route` flag through the AI CLI
- tweak ai-do success message
- document model metadata and routing strategies
- fix optional dependency handling and typing

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865e92b7a208326aa65d5fce1f07636