### PR TITLE
Fix DSPy backend annotations

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -3,11 +3,25 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 import importlib
 import pkgutil
 
 from .base import Backend
+
+if TYPE_CHECKING:
+    from .plugins.gemini import (
+        GeminiBackend as GeminiBackend,
+        GeminiDSPyBackend as GeminiDSPyBackend,
+    )  # noqa: F401
+    from .plugins.ollama import (
+        OllamaBackend as OllamaBackend,
+        OllamaDSPyBackend as OllamaDSPyBackend,
+    )  # noqa: F401
+    from .plugins.openrouter import (
+        OpenRouterBackend as OpenRouterBackend,
+        OpenRouterDSPyBackend as OpenRouterDSPyBackend,
+    )  # noqa: F401
 
 
 _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}

--- a/llm/backends/plugins/gemini.py
+++ b/llm/backends/plugins/gemini.py
@@ -8,9 +8,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .gemini_dspy import GeminiDSPyBackend  # type: ignore
+    from .gemini_dspy import GeminiDSPyBackend as _GeminiDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    GeminiDSPyBackend = None
+    _GeminiDSPyBackend = None
+
+GeminiDSPyBackend: type[Backend] | None = _GeminiDSPyBackend
 
 
 class GeminiBackend(Backend):

--- a/llm/backends/plugins/gemini_dspy.py
+++ b/llm/backends/plugins/gemini_dspy.py
@@ -4,8 +4,10 @@ from typing import Any, Callable, Mapping
 
 from ..base import Backend
 
+GeminiDSPyBackend: type[Backend] | None = None
+
 try:  # pragma: no cover - optional dependency
-    import dspy  # type: ignore
+    import dspy
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
@@ -17,7 +19,7 @@ if dspy is not None:
         raise ImportError("dspy does not expose an LLM wrapper")
     LM = _LM
 
-    class GeminiDSPyBackend(Backend):
+    class GeminiDSPyBackendImpl(Backend):
         """Gemini backend implemented via ``dspy``."""
 
         def __init__(self, model: str | None = None) -> None:
@@ -26,8 +28,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    GeminiDSPyBackend = GeminiDSPyBackendImpl
 else:  # pragma: no cover - optional dependency missing
-    GeminiDSPyBackend = None  # type: ignore
+    GeminiDSPyBackend = None
 
 
 def _extract_text(result: Mapping[str, Any]) -> str:

--- a/llm/backends/plugins/ollama.py
+++ b/llm/backends/plugins/ollama.py
@@ -7,9 +7,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .ollama_dspy import OllamaDSPyBackend  # type: ignore
+    from .ollama_dspy import OllamaDSPyBackend as _OllamaDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    OllamaDSPyBackend = None
+    _OllamaDSPyBackend = None
+
+OllamaDSPyBackend: type[Backend] | None = _OllamaDSPyBackend
 
 
 class OllamaBackend(Backend):

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -4,8 +4,10 @@ from typing import Any, Callable, Mapping
 
 from ..base import Backend
 
+OllamaDSPyBackend: type[Backend] | None = None
+
 try:  # pragma: no cover - optional dependency
-    import dspy  # type: ignore
+    import dspy
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
@@ -17,7 +19,7 @@ if dspy is not None:
         raise ImportError("dspy does not expose an LLM wrapper")
     LM = _LM
 
-    class OllamaDSPyBackend(Backend):
+    class OllamaDSPyBackendImpl(Backend):
         """Ollama backend implemented via ``dspy``."""
 
         def __init__(self, model: str) -> None:
@@ -26,8 +28,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    OllamaDSPyBackend = OllamaDSPyBackendImpl
 else:  # pragma: no cover - optional dependency missing
-    OllamaDSPyBackend = None  # type: ignore
+    OllamaDSPyBackend = None
 
 
 def _extract_text(result: Mapping[str, Any]) -> str:

--- a/llm/backends/plugins/openrouter.py
+++ b/llm/backends/plugins/openrouter.py
@@ -6,9 +6,11 @@ from .. import register_backend
 from ..base import Backend
 
 try:  # pragma: no cover - optional dependency
-    from .openrouter_dspy import OpenRouterDSPyBackend  # type: ignore
+    from .openrouter_dspy import OpenRouterDSPyBackend as _OpenRouterDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    OpenRouterDSPyBackend = None
+    _OpenRouterDSPyBackend = None
+
+OpenRouterDSPyBackend: type[Backend] | None = _OpenRouterDSPyBackend
 
 
 class OpenRouterBackend(Backend):

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -4,8 +4,10 @@ from typing import Any, Callable, Mapping
 
 from ..base import Backend
 
+OpenRouterDSPyBackend: type[Backend] | None = None
+
 try:  # pragma: no cover - optional dependency
-    import dspy  # type: ignore
+    import dspy
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
@@ -17,7 +19,7 @@ if dspy is not None:
         raise ImportError("dspy does not expose an LLM wrapper")
     LM = _LM
 
-    class OpenRouterDSPyBackend(Backend):
+    class OpenRouterDSPyBackendImpl(Backend):
         """OpenRouter backend implemented via ``dspy``."""
 
         def __init__(self, model: str) -> None:
@@ -26,8 +28,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    OpenRouterDSPyBackend = OpenRouterDSPyBackendImpl
 else:  # pragma: no cover - optional dependency missing
-    OpenRouterDSPyBackend = None  # type: ignore
+    OpenRouterDSPyBackend = None
 
 
 def _extract_text(result: Mapping[str, Any]) -> str:

--- a/llm/backends/superclaude.py
+++ b/llm/backends/superclaude.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import requests
-
 from .base import Backend
 
 
@@ -12,6 +10,8 @@ class SuperClaudeBackend(Backend):
         self.model = model
 
     def run(self, prompt: str) -> str:  # pragma: no cover - network placeholder
+        import requests  # pragma: no cover - optional dependency
+
         response = requests.post(
             "https://api.superclaude.ai/generate",
             json={"model": self.model, "prompt": prompt},

--- a/llm/router.py
+++ b/llm/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from typing import List
+from typing import List, Callable, cast
 
 from .backends import (
     GeminiBackend,  # noqa: F401 - re-exported for tests
@@ -18,6 +18,8 @@ from .backends import (
 )
 from .ai_router import get_preferred_models
 from .langchain_backend import LangChainBackend
+from .backends.superclaude import SuperClaudeBackend
+from .backends import register_backend
 
 DEFAULT_MODEL = "llama3"
 DEFAULT_PRIMARY_BACKEND = "gemini"
@@ -34,7 +36,7 @@ def estimate_prompt_complexity(prompt: str) -> int:
 def run_gemini(prompt: str, model: str | None = None) -> str:
     """Return Gemini response for ``prompt`` using registered backend."""
 
-    func = get_backend("gemini")
+    func = cast(Callable[[str, str | None], str], get_backend("gemini"))
     return func(prompt, model)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tomli; python_version < '3.11'
 tomli_w
 streamlit
 textual
+requests

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,8 +29,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed")
-
+            send_notification("ai-do completed with exit code 0")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 


### PR DESCRIPTION
## Summary
- annotate optional DSPy backend classes as `type[Backend] | None`
- import DSPy implementations lazily and re-export typed classes
- expose backends for type checking in `llm.backends`
- adjust router imports and add typing cast
- lazily import `requests` for SuperClaude backend
- send exit code in ai_do notifications
- add requests dependency

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e92866e08326b2247178e8440c98