### PR TITLE
Implement FastAPI dashboard tests and Tauri shell

### DIFF
--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -2,18 +2,64 @@ import { useEffect, useState } from 'react';
 
 export default function Home() {
   const [health, setHealth] = useState(null);
+  const [stats, setStats] = useState(null);
+  const [prompt, setPrompt] = useState('');
+  const [response, setResponse] = useState('');
+  const [palette, setPalette] = useState('');
+  const [status, setStatus] = useState('');
 
   useEffect(() => {
-    fetch('http://localhost:8000/api/health')
+    fetch('/api/health')
       .then((res) => res.json())
       .then(setHealth)
       .catch(() => setHealth({ status: 'error' }));
+
+    fetch('/api/stats')
+      .then((res) => res.json())
+      .then(setStats)
+      .catch(() => {});
   }, []);
+
+  const sendPrompt = () => {
+    fetch('/api/prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt })
+    })
+      .then((res) => res.json())
+      .then((data) => setResponse(data.response))
+      .catch(() => setResponse('error'));
+  };
+
+  const applyPalette = () => {
+    fetch('/api/palette', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: palette })
+    })
+      .then(() => setStatus('applied'))
+      .catch(() => setStatus('error'));
+  };
 
   return (
     <div>
       <h1>UME Dashboard</h1>
       {health && <p>API status: {health.status}</p>}
+      {stats && (
+        <p>
+          Queries: {stats.queries}, Memory: {stats.memory}
+        </p>
+      )}
+      <div>
+        <input value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="prompt" />
+        <button onClick={sendPrompt}>Send</button>
+        {response && <p>{response}</p>}
+      </div>
+      <div>
+        <input value={palette} onChange={(e) => setPalette(e.target.value)} placeholder="palette" />
+        <button onClick={applyPalette}>Apply</button>
+        {status && <p>{status}</p>}
+      </div>
     </div>
   );
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ume_tauri"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["http-all"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,20 @@
+{
+  "build": {
+    "distDir": "../dashboard",
+    "beforeBuildCommand": "",
+    "beforeDevCommand": ""
+  },
+  "package": {
+    "productName": "UME",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "UME Dashboard",
+        "width": 800,
+        "height": 600
+      }
+    ]
+  }
+}

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,0 +1,66 @@
+from fastapi.testclient import TestClient
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+
+def load_app(send_prompt=lambda p, local=False: f"resp-{p}", apply_palette=lambda n, r: None):
+    stub_router = types.SimpleNamespace(send_prompt=send_prompt)
+    stub_thm = types.SimpleNamespace(apply_palette=apply_palette, REPO_ROOT=Path('.'))
+    sys.modules['scripts.ai_router'] = stub_router
+    sys.modules['scripts.thm'] = stub_thm
+    if 'api' in sys.modules:
+        del sys.modules['api']
+    api = importlib.import_module('api')
+    return api.app
+
+
+def test_health():
+    app = load_app()
+    client = TestClient(app)
+    resp = client.get('/api/health')
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'ok'}
+
+
+def test_stats():
+    app = load_app()
+    client = TestClient(app)
+    resp = client.get('/api/stats')
+    assert resp.status_code == 200
+    assert resp.json() == {'queries': 0, 'memory': 0}
+
+
+def test_graph():
+    app = load_app()
+    client = TestClient(app)
+    resp = client.get('/api/graph')
+    assert resp.status_code == 200
+    assert resp.json() == {'nodes': [], 'edges': []}
+
+
+def test_prompt():
+    calls = []
+    def fake(prompt: str, local: bool = False):
+        calls.append(prompt)
+        return 'ok-' + prompt
+    app = load_app(send_prompt=fake)
+    client = TestClient(app)
+    resp = client.post('/api/prompt', json={'prompt': 'hello'})
+    assert resp.status_code == 200
+    assert resp.json() == {'response': 'ok-hello'}
+    assert calls == ['hello']
+
+
+def test_palette():
+    calls = []
+    def fake(name: str, repo_root: Path):
+        calls.append(name)
+    app = load_app(apply_palette=fake)
+    client = TestClient(app)
+    resp = client.post('/api/palette', json={'name': 'dracula'})
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'applied'}
+    assert calls == ['dracula']


### PR DESCRIPTION
## Summary
- build minimal Tauri config and main binary
- expand React dashboard to call all API endpoints
- add integration tests covering each API route

## Testing
- `ruff check api tests/test_api_routes.py`
- `pytest tests/test_api_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68669352b33083269344cb343477a9c9