### PR TITLE
Update installation guide for docker services

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -156,29 +156,54 @@ Launch `ghostty` instead of your default terminal to try it out.
 ## Nextcloud server
 
 [Nextcloud](https://nextcloud.com/) provides private file sync and collaborative
-editing. Launch it using the included helper script:
+editing.
 
-```bash
-./scripts/run-nextcloud.sh
-```
-
-The compose file maps port `8082` to the container's port `80`. Visit
-`http://localhost:8082` to finish the setup. Customize trusted domains with the
-`NEXTCLOUD_TRUSTED_DOMAINS` environment variable if you expose it to the
-network.
+1. Start the container with the helper script:
+   ```bash
+   ./scripts/run-nextcloud.sh
+   ```
+2. Open <http://localhost:8082> to complete the installation wizard.
+3. Data lives under `./nextcloud`. Set the `NEXTCLOUD_TRUSTED_DOMAINS`
+   environment variable when exposing the service to the network.
+4. Stop the container with `Ctrl+C` or run `docker compose down` from another
+   shell.
 
 ## Mattermost chat
 
-Run an open-source team chat server using the Mattermost service defined in the
-compose file:
+Run an open-source team chat server with Mattermost.
 
-```bash
-./scripts/run-mattermost.sh
-```
+1. Launch the service using the helper script:
+   ```bash
+   ./scripts/run-mattermost.sh
+   ```
+2. Visit <http://localhost:8065> and create the admin account.
+3. Configuration is stored under `./mattermost`. Edit `config.json` to set the
+   site URL and enable integrations.
+4. Stop the container with `Ctrl+C` or use `docker compose down`.
 
-The initial configuration is stored under `./mattermost`. Edit `config.json` to
-set the site URL and enable integrations. The server listens on port `8065` by
-default.
+## RomM game library
+
+RomM manages your local game collection.
+
+1. Start the container:
+   ```bash
+   ./scripts/run-romm.sh
+   ```
+2. Open <http://localhost:8080> and create your user account.
+3. Game data is stored under `./romm` in the repository.
+4. To stop the service press `Ctrl+C` or run `docker compose down`.
+
+## Browser streaming with Neko
+
+Use Neko to stream a browser session.
+
+1. Start the container:
+   ```bash
+   ./scripts/run-neko.sh
+   ```
+2. The script maps port `8081` to container port `8080`.
+3. Open <http://localhost:8081> to connect.
+4. Stop the service with `Ctrl+C` or `docker compose down`.
 
 
 ## Hyper-V support
@@ -215,4 +240,29 @@ Hyper-V is useful for testing scripts in clean environments.
 2. Navigate to `http://localhost:5678` and create your first workflow.
 3. Mount a local directory to `/home/node/.n8n` to persist workflows between runs.
 4. A simple test flow watches a folder and sends new files to Nextcloud using the built-in nodes.
+
+## API service
+
+The compose file includes a FastAPI backend used by the upcoming dashboard.
+
+1. Start the API service:
+   ```bash
+   docker compose up api
+   ```
+2. The server listens on <http://localhost:8000>.
+3. Stop the service with `Ctrl+C` or `docker compose down`.
+
+## Enabling the dashboard
+
+When the new dashboard implementation lands:
+
+1. Ensure the API service is running as described above.
+2. Start the Next.js client:
+   ```bash
+   cd dashboard
+   npm install
+   npm run dev
+   ```
+3. Browse to <http://localhost:3000> to open the dashboard.
+4. See [the dashboard guide](dashboard.md) for development tips.
 


### PR DESCRIPTION
## Summary
- add step-by-step instructions for Nextcloud, Mattermost, RomM and Neko
- document how to start/stop the API service
- list steps for enabling the upcoming dashboard

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68669355aca48326ab417b3323069075