### PR TITLE
Configure CI to install test extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: ["**"]
   pull_request:
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e . -r requirements.txt
+          pip install -e '.[test]' -r requirements.txt
       - name: Run ruff
         run: ruff check .
       - name: Run mypy
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies with extras
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[lmql,guidance]' textual -r requirements.txt
+          pip install -e '.[test,lmql,guidance]' textual -r requirements.txt
       - name: Run tests with extras
         run: pytest -n auto
 

--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -15,12 +15,11 @@ _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
 GeminiBackend: type[Backend] | None = None
 OllamaBackend: type[Backend] | None = None
 OpenRouterBackend: type[Backend] | None = None
-SuperClaudeBackend: type[Backend] | None = None
-GeminiDSPyBackend = None
-OllamaDSPyBackend = None
-OpenRouterDSPyBackend = None
-LMQLBackend = None
-GuidanceBackend = None
+GeminiDSPyBackend: type[Backend] | None = None
+OllamaDSPyBackend: type[Backend] | None = None
+OpenRouterDSPyBackend: type[Backend] | None = None
+LMQLBackend: type[Backend] | None = None
+GuidanceBackend: type[Backend] | None = None
 __all__ = [
     "Backend",
     "register_backend",
@@ -37,7 +36,6 @@ __all__ = [
     "OpenRouterDSPyBackend",
     "LMQLBackend",
     "GuidanceBackend",
-    "SuperClaudeBackend",
 ]
 
 

--- a/llm/backends/plugins/gemini.py
+++ b/llm/backends/plugins/gemini.py
@@ -7,10 +7,11 @@ from typing import Any, cast
 from .. import register_backend
 from ..base import Backend
 
+GeminiDSPyBackend: type[Backend] | None
 try:  # pragma: no cover - optional dependency
-    from .gemini_dspy import GeminiDSPyBackend
+    from .gemini_dspy import GeminiDSPyBackend as GeminiDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    GeminiDSPyBackend = None  # type: ignore[misc, assignment]
+    GeminiDSPyBackend = None
 
 
 class GeminiBackend(Backend):

--- a/llm/backends/plugins/gemini_dspy.py
+++ b/llm/backends/plugins/gemini_dspy.py
@@ -9,16 +9,15 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
-_LM: Callable[..., Any] | None = None
-LM: Callable[..., Any]
-_GeminiDSPyBackend: type[Backend] | None = None
+GeminiDSPyBackend: type[Backend] | None
 if dspy is not None:
-    _LM = getattr(dspy, "LLM", getattr(dspy, "LM", None))
-    if _LM is None:  # pragma: no cover - sanity check
+    lm = getattr(dspy, "LLM", getattr(dspy, "LM", None))
+    if lm is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
-    LM = _LM
 
-    class _RealGeminiDSPyBackend(Backend):
+    LM: Callable[..., Any] = lm
+
+    class _GeminiDSPyBackend(Backend):
         """Gemini backend implemented via ``dspy``."""
 
         def __init__(self, model: str | None = None) -> None:
@@ -27,8 +26,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    GeminiDSPyBackend = _GeminiDSPyBackend
 else:  # pragma: no cover - optional dependency missing
-    GeminiDSPyBackend = None  # type: ignore[misc, assignment]
+    GeminiDSPyBackend = None
 
 
 

--- a/llm/backends/plugins/lmql.py
+++ b/llm/backends/plugins/lmql.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 from .. import register_backend
 from ..base import Backend
 
-_LMQLBackend: type[Backend] | None = None
+LMQLBackend: type[Backend] | None = None
 
 try:  # pragma: no cover - optional dependency
     import lmql  # noqa: F401
@@ -22,9 +22,9 @@ if lmql is not None:
 
         def run(self, prompt: str) -> str:  # pragma: no cover - network placeholder
             return f"lmql:{prompt}:{self.model}"
-    _LMQLBackend = _RealLMQLBackend
+    LMQLBackend = _RealLMQLBackend
 else:  # pragma: no cover - optional dependency missing
-    LMQLBackend = None  # type: ignore[misc, assignment]
+    LMQLBackend = None
 
 
 

--- a/llm/backends/plugins/ollama.py
+++ b/llm/backends/plugins/ollama.py
@@ -6,10 +6,11 @@ from typing import Any, cast
 from .. import register_backend
 from ..base import Backend
 
+OllamaDSPyBackend: type[Backend] | None
 try:  # pragma: no cover - optional dependency
-    from .ollama_dspy import OllamaDSPyBackend
+    from .ollama_dspy import OllamaDSPyBackend as OllamaDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    OllamaDSPyBackend = None  # type: ignore[misc, assignment]
+    OllamaDSPyBackend = None
 
 
 

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -9,16 +9,15 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
-_LM: Callable[..., Any] | None = None
-LM: Callable[..., Any]
-_OllamaDSPyBackend: type[Backend] | None = None
+OllamaDSPyBackend: type[Backend] | None
 if dspy is not None:
-    _LM = getattr(dspy, "LLM", getattr(dspy, "LM", None))
-    if _LM is None:  # pragma: no cover - sanity check
+    lm = getattr(dspy, "LLM", getattr(dspy, "LM", None))
+    if lm is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
-    LM = _LM
 
-    class _RealOllamaDSPyBackend(Backend):
+    LM: Callable[..., Any] = lm
+
+    class _OllamaDSPyBackend(Backend):
         """Ollama backend implemented via ``dspy``."""
 
         def __init__(self, model: str) -> None:
@@ -27,8 +26,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    OllamaDSPyBackend = _OllamaDSPyBackend
 else:  # pragma: no cover - optional dependency missing
-    OllamaDSPyBackend = None  # type: ignore[misc, assignment]
+    OllamaDSPyBackend = None
 
 
 

--- a/llm/backends/plugins/openrouter.py
+++ b/llm/backends/plugins/openrouter.py
@@ -5,10 +5,11 @@ from typing import Any, cast
 from .. import register_backend
 from ..base import Backend
 
+OpenRouterDSPyBackend: type[Backend] | None
 try:  # pragma: no cover - optional dependency
-    from .openrouter_dspy import OpenRouterDSPyBackend
+    from .openrouter_dspy import OpenRouterDSPyBackend as OpenRouterDSPyBackend
 except Exception:  # pragma: no cover - optional dependency missing
-    OpenRouterDSPyBackend = None  # type: ignore[misc, assignment]
+    OpenRouterDSPyBackend = None
 
 
 

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -9,16 +9,15 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
-_LM: Callable[..., Any] | None = None
-LM: Callable[..., Any]
-_OpenRouterDSPyBackend: type[Backend] | None = None
+OpenRouterDSPyBackend: type[Backend] | None
 if dspy is not None:
-    _LM = getattr(dspy, "LLM", getattr(dspy, "LM", None))
-    if _LM is None:  # pragma: no cover - sanity check
+    lm = getattr(dspy, "LLM", getattr(dspy, "LM", None))
+    if lm is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
-    LM = _LM
 
-    class _RealOpenRouterDSPyBackend(Backend):
+    LM: Callable[..., Any] = lm
+
+    class _OpenRouterDSPyBackend(Backend):
         """OpenRouter backend implemented via ``dspy``."""
 
         def __init__(self, model: str) -> None:
@@ -27,8 +26,9 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    OpenRouterDSPyBackend = _OpenRouterDSPyBackend
 else:  # pragma: no cover - optional dependency missing
-    OpenRouterDSPyBackend = None  # type: ignore[misc, assignment]
+    OpenRouterDSPyBackend = None
 
 
 

--- a/llm/router.py
+++ b/llm/router.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import os
 import subprocess
-from typing import Callable, List, cast
+from typing import Any, List, cast
 
-from .backends import (  # type: ignore[attr-defined]
+from .backends import (
     GeminiBackend,  # noqa: F401 - re-exported for tests
     GeminiDSPyBackend,  # noqa: F401 - re-exported for tests
     OllamaBackend,  # noqa: F401 - re-exported for tests
@@ -16,8 +16,8 @@ from .backends import (  # type: ignore[attr-defined]
 
     register_backend,
     get_backend,
-    register_backend,
 )
+from .backends.plugins.gemini import run_gemini as _plugin_run_gemini
 from .backends.superclaude import SuperClaudeBackend
 
 from .ai_router import get_preferred_models
@@ -38,8 +38,7 @@ def estimate_prompt_complexity(prompt: str) -> int:
 def run_gemini(prompt: str, model: str | None = None) -> str:
     """Return Gemini response for ``prompt`` using registered backend."""
 
-    func = cast(Callable[[str, str | None], str], get_backend("gemini"))
-    return func(prompt, model)
+    return _plugin_run_gemini(prompt, model)
 
 
 def run_ollama(prompt: str, model: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ test = [
     "pytest-asyncio",
     "json5",
     "mypy",
+    "fastapi",
+    "uvicorn",
 ]
 cli = ["tomli_w"]
 lmql = ["lmql"]

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,8 +29,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed with exit code 0")
-
+            send_notification("ai-do completed")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 


### PR DESCRIPTION
## Summary
- run CI on all branches
- install test extras for core tests
- install test extras for optional dependency tests
- fix recursion in gemini backend resolution
- make notifications match expected messages
- ensure web app tests run by including fastapi/uvicorn in test extras

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68669353c3488326a8d9ef7b8bc6d9c6