### PR TITLE
Add step notifications via ntfy

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -121,7 +121,15 @@ requires a `y` confirmation; pressing `Enter` or `n` skips that command. Output
 is appended to `ai_do.log` by default.
 
 Both `ai-plan` and `ai-do` accept a `--notify` flag to send a notification via
-[`ntfy`](https://ntfy.sh) when the command completes.
+[`ntfy`](https://ntfy.sh). When a topic is provided all step results are
+published under `TOPIC/step-N`:
+
+```text
+https://ntfy.sh/TOPIC/step-1  # "success", "failed" or "skipped"
+```
+
+If the flag is used without an explicit value the default topic is `ai-do`.
+The final completion status posts to `TOPIC` itself.
 
 ```bash
 ai-do "git add . && git commit -m 'update' && git push" --log my.log

--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -15,7 +15,6 @@ _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
 GeminiBackend: type[Backend] | None = None
 OllamaBackend: type[Backend] | None = None
 OpenRouterBackend: type[Backend] | None = None
-SuperClaudeBackend: type[Backend] | None = None
 GeminiDSPyBackend = None
 OllamaDSPyBackend = None
 OpenRouterDSPyBackend = None
@@ -37,7 +36,6 @@ __all__ = [
     "OpenRouterDSPyBackend",
     "LMQLBackend",
     "GuidanceBackend",
-    "SuperClaudeBackend",
 ]
 
 

--- a/llm/backends/plugins/gemini_dspy.py
+++ b/llm/backends/plugins/gemini_dspy.py
@@ -27,6 +27,8 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    _GeminiDSPyBackend = _RealGeminiDSPyBackend
+    GeminiDSPyBackend = _GeminiDSPyBackend
 else:  # pragma: no cover - optional dependency missing
     GeminiDSPyBackend = None  # type: ignore[misc, assignment]
 

--- a/llm/backends/plugins/lmql.py
+++ b/llm/backends/plugins/lmql.py
@@ -23,6 +23,7 @@ if lmql is not None:
         def run(self, prompt: str) -> str:  # pragma: no cover - network placeholder
             return f"lmql:{prompt}:{self.model}"
     _LMQLBackend = _RealLMQLBackend
+    LMQLBackend = _LMQLBackend
 else:  # pragma: no cover - optional dependency missing
     LMQLBackend = None  # type: ignore[misc, assignment]
 

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -27,6 +27,8 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    _OllamaDSPyBackend = _RealOllamaDSPyBackend
+    OllamaDSPyBackend = _OllamaDSPyBackend
 else:  # pragma: no cover - optional dependency missing
     OllamaDSPyBackend = None  # type: ignore[misc, assignment]
 

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -27,6 +27,8 @@ if dspy is not None:
         def run(self, prompt: str) -> str:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
+    _OpenRouterDSPyBackend = _RealOpenRouterDSPyBackend
+    OpenRouterDSPyBackend = _OpenRouterDSPyBackend
 else:  # pragma: no cover - optional dependency missing
     OpenRouterDSPyBackend = None  # type: ignore[misc, assignment]
 

--- a/llm/router.py
+++ b/llm/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from typing import Callable, List, cast
+from typing import Any, List, cast
 
 from .backends import (  # type: ignore[attr-defined]
     GeminiBackend,  # noqa: F401 - re-exported for tests
@@ -16,7 +16,6 @@ from .backends import (  # type: ignore[attr-defined]
 
     register_backend,
     get_backend,
-    register_backend,
 )
 from .backends.superclaude import SuperClaudeBackend
 
@@ -36,10 +35,10 @@ def estimate_prompt_complexity(prompt: str) -> int:
 
 
 def run_gemini(prompt: str, model: str | None = None) -> str:
-    """Return Gemini response for ``prompt`` using registered backend."""
+    """Return Gemini response for ``prompt`` using the Gemini plugin."""
 
-    func = cast(Callable[[str, str | None], str], get_backend("gemini"))
-    return func(prompt, model)
+    from .backends.plugins import gemini as gemini_plugin
+    return gemini_plugin.run_gemini(prompt, model)
 
 
 def run_ollama(prompt: str, model: str) -> str:

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -16,7 +16,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("goal", help="High level description of the task")
     parser.add_argument("--config")
-    parser.add_argument("--notify", action="store_true", help="Send notification when done")
+    parser.add_argument(
+        "--notify",
+        nargs="?",
+        const="ai-do",
+        help="Publish step status to ntfy topic (default: %(const)s)",
+    )
     parser.add_argument(
         "--log",
         type=Path,
@@ -26,13 +31,16 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     steps = ai_exec.plan(args.goal, config_path=args.config)
-    exit_code = execute_steps(steps, log_path=args.log)
+    exit_code = execute_steps(steps, log_path=args.log, notify_topic=args.notify)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed with exit code 0")
-
+            send_notification(
+                "ai-do completed with exit code 0", topic=args.notify
+            )
         else:
-            send_notification(f"ai-do failed with exit code {exit_code}")
+            send_notification(
+                f"ai-do failed with exit code {exit_code}", topic=args.notify
+            )
 
 
     return exit_code


### PR DESCRIPTION
## Summary
- enable per-step notifications in `execute_steps`
- send final status through `--notify` topic
- document the ntfy topic layout
- adjust tests for new notification behaviour
- fix backend plugins and routing helpers for test stability

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669352eb408326888627b66e139faf