### PR TITLE
Add LLM search hotkey with plan overlay

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -194,6 +194,9 @@ python -m ui.textual_app
 Use **Send** to route prompts via `ai_router.send_prompt` and **Apply** to call
 `thm.apply_palette`. Palette names are loaded from the `palettes/` directory and
 responses or status messages show directly in the terminal window.
+Press **Ctrl+P** to search available scripts and n8n flows via the LLM; a list of
+matches appears and the chosen entry runs after confirming the plan. The
+traditional command palette is available with **Ctrl+Shift+P**.
 ---
 
 ## Cloning & Managing Dotfiles

--- a/llm/router.py
+++ b/llm/router.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 
 from typing import Any, Callable, List, cast
+from pathlib import Path
 
 
 from .backends import (
@@ -17,6 +18,7 @@ from .backends import (
     OpenRouterDSPyBackend,  # noqa: F401 - re-exported for tests
     register_backend,
     get_backend,
+    SuperClaudeBackend,
 
 )
 

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,7 +29,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed")
+            send_notification(f"ai-do completed with exit code {exit_code}")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 


### PR DESCRIPTION
## Summary
- support selecting actions via Ctrl+P in TerminalUI
- show plan overlay before executing the chosen item
- rebind command palette to Ctrl+Shift+P
- document the new hotkey in the terminal docs
- adjust tests for new behavior
- fix ai_do notifications and missing imports

## Testing
- `ruff check ui/textual_app.py`
- `ruff check tests/test_textual_ui.py`
- `ruff check scripts/ai_do.py`
- `ruff check llm/router.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686864796a1c832683bad5e754f01f9c