### PR TITLE
Fix DSPy plugin exports

### DIFF
--- a/llm/backends/plugins/gemini_dspy.py
+++ b/llm/backends/plugins/gemini_dspy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, cast
 
 from ..base import Backend
 
@@ -18,7 +18,7 @@ if dspy is not None:
     if lm is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
 
-    LM: Callable[..., Any] = lm
+    LM = cast(Callable[..., Any], lm)
 
     class _GeminiDSPyBackend(Backend):
         """Gemini backend implemented via ``dspy``."""
@@ -30,8 +30,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
-    _GeminiDSPyBackend = _RealGeminiDSPyBackend
-    GeminiDSPyBackend: type[Backend] | None = _GeminiDSPyBackend
+    GeminiDSPyBackend = _GeminiDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing
     GeminiDSPyBackend = None

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, cast
 
 from ..base import Backend
 
@@ -18,7 +18,7 @@ if dspy is not None:
     if lm is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
 
-    LM: Callable[..., Any] = lm
+    LM = cast(Callable[..., Any], lm)
 
     class _OllamaDSPyBackend(Backend):
         """Ollama backend implemented via ``dspy``."""
@@ -30,8 +30,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
-    _OllamaDSPyBackend = _RealOllamaDSPyBackend
-    OllamaDSPyBackend: type[Backend] | None = _OllamaDSPyBackend
+    OllamaDSPyBackend = _OllamaDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing
     OllamaDSPyBackend = None

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, cast
 
 from ..base import Backend
 
@@ -18,7 +18,7 @@ if dspy is not None:
     if lm is None:  # pragma: no cover - sanity check
         raise ImportError("dspy does not expose an LLM wrapper")
 
-    LM: Callable[..., Any] = lm
+    LM = cast(Callable[..., Any], lm)
 
     class _OpenRouterDSPyBackend(Backend):
         """OpenRouter backend implemented via ``dspy``."""
@@ -30,8 +30,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
-    _OpenRouterDSPyBackend = _RealOpenRouterDSPyBackend
-    OpenRouterDSPyBackend: type[Backend] | None = _OpenRouterDSPyBackend
+    OpenRouterDSPyBackend = _OpenRouterDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing
     OpenRouterDSPyBackend = None

--- a/llm/router.py
+++ b/llm/router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from pathlib import Path
 
 from typing import Any, Callable, List, cast
 
@@ -15,6 +16,7 @@ from .backends import (
     OllamaDSPyBackend,  # noqa: F401 - re-exported for tests
     OpenRouterBackend,  # noqa: F401 - re-exported for tests
     OpenRouterDSPyBackend,  # noqa: F401 - re-exported for tests
+    SuperClaudeBackend,  # noqa: F401 - re-exported for tests
     register_backend,
     get_backend,
 

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,7 +29,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed")
+            send_notification("ai-do completed with exit code 0")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 

--- a/tests/test_dspy_backend_imports.py
+++ b/tests/test_dspy_backend_imports.py
@@ -1,0 +1,16 @@
+import importlib
+import pytest
+
+dspy = pytest.importorskip("dspy")  # noqa: F401 - ensure dspy is installed
+
+
+@pytest.mark.parametrize("module_name, attr", [
+    ("llm.backends.plugins.gemini_dspy", "GeminiDSPyBackend"),
+    ("llm.backends.plugins.ollama_dspy", "OllamaDSPyBackend"),
+    ("llm.backends.plugins.openrouter_dspy", "OpenRouterDSPyBackend"),
+])
+def test_dspy_backend_imports(module_name, attr):
+    module = importlib.import_module(module_name)
+    assert hasattr(module, attr)
+    backend = getattr(module, attr)
+    assert backend is not None


### PR DESCRIPTION
## Summary
- ensure DSPy backends export the correct classes
- add missing imports in router
- test that DSPy plugin modules import cleanly when dspy is installed
- fix ai_do notification message

## Testing
- `ruff check llm/backends/plugins/gemini_dspy.py llm/backends/plugins/ollama_dspy.py llm/backends/plugins/openrouter_dspy.py tests/test_dspy_backend_imports.py llm/router.py scripts/ai_do.py`
- `mypy --install-types --non-interactive llm/backends/plugins/gemini_dspy.py llm/backends/plugins/ollama_dspy.py llm/backends/plugins/openrouter_dspy.py llm/router.py tests/test_dspy_backend_imports.py scripts/ai_do.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868640ebcf083268c5f91fd01b0d984