### PR TITLE
Add UME quickstart documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Additional guides:
 - [Repository navigation](docs/navigation.md)
 - [AI automation tooling](docs/ai-automation.md)
 - [Dashboard overview](docs/dashboard.md)
+- [UME Quickstart](docs/ume.md)
 
 ## Git hooks
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -36,3 +36,5 @@ npm run dev
 ```
 
 Visit `http://localhost:3000` to view the dashboard.
+
+See [UME Quickstart](ume.md) for cloning and running the backend with Poetry.

--- a/docs/ume.md
+++ b/docs/ume.md
@@ -1,0 +1,35 @@
+# UME Quickstart
+
+The Universal Memory Engine (UME) powers the dashboard backend. Follow these steps to run it locally.
+
+## Clone the Repository
+
+Clone the [UME repository](https://github.com/d0tTino/UME.git) and change into its directory:
+
+```bash
+git clone https://github.com/d0tTino/UME.git
+cd UME
+```
+
+## Install Dependencies
+
+Install the project using [Poetry](https://python-poetry.org/):
+
+```bash
+poetry install
+```
+
+## Start the Services
+
+Launch the API and supporting services:
+
+```bash
+poetry run python ume_cli.py up
+```
+
+The API will be available at <http://localhost:8000>.
+
+## LangGraph Retrieval Demo
+
+Run `examples/langgraph_integration.ipynb` to explore retrieval through LangGraph. Execute the notebook after the services have started.
+


### PR DESCRIPTION
## Summary
- document how to clone and run the UME project
- cross-link the new quickstart from the dashboard docs and README
- refine wording and bullet capitalization

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686866ada748832682abae4106635aba