### PR TITLE
Add DSPy backend tests

### DIFF
--- a/llm/backends/plugins/gemini_dspy.py
+++ b/llm/backends/plugins/gemini_dspy.py
@@ -9,9 +9,8 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
-_LM: Callable[..., Any] | None = None
 LM: Callable[..., Any]
-GeminiDSPyBackend: type[Backend] | None = None
+GeminiDSPyBackend: type[Backend] | None
 
 if dspy is not None:
     lm = getattr(dspy, "LLM", getattr(dspy, "LM", None))
@@ -30,7 +29,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
-    GeminiDSPyBackend = _GeminiDSPyBackend
+    GeminiDSPyBackend = _RealGeminiDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing
     GeminiDSPyBackend = None

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -9,9 +9,8 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
-_LM: Callable[..., Any] | None = None
 LM: Callable[..., Any]
-OllamaDSPyBackend: type[Backend] | None = None
+OllamaDSPyBackend: type[Backend] | None
 
 if dspy is not None:
     lm = getattr(dspy, "LLM", getattr(dspy, "LM", None))
@@ -30,7 +29,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
-    OllamaDSPyBackend = _OllamaDSPyBackend
+    OllamaDSPyBackend = _RealOllamaDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing
     OllamaDSPyBackend = None

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -9,9 +9,8 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     dspy = None
 
-_LM: Callable[..., Any] | None = None
 LM: Callable[..., Any]
-OpenRouterDSPyBackend: type[Backend] | None = None
+OpenRouterDSPyBackend: type[Backend] | None
 
 if dspy is not None:
     lm = getattr(dspy, "LLM", getattr(dspy, "LM", None))
@@ -30,7 +29,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
-    OpenRouterDSPyBackend = _OpenRouterDSPyBackend
+    OpenRouterDSPyBackend = _RealOpenRouterDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing
     OpenRouterDSPyBackend = None

--- a/tests/test_dspy_backends.py
+++ b/tests/test_dspy_backends.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name, attr, model, expected",
+    [
+        ("llm.backends.plugins.gemini_dspy", "GeminiDSPyBackend", None, "google/gemini-pro"),
+        ("llm.backends.plugins.ollama_dspy", "OllamaDSPyBackend", "m", "m"),
+        ("llm.backends.plugins.openrouter_dspy", "OpenRouterDSPyBackend", "m", "m"),
+    ],
+)
+def test_dspy_backend_can_run(monkeypatch, module_name, attr, model, expected):
+    """Each DSPy backend should instantiate and return text using a dummy dspy module."""
+
+    class DummyLM:
+        def __init__(self, model=None):
+            self.model = model
+
+        def forward(self, prompt: str, **_: str):
+            return {"choices": [{"message": {"content": f"{prompt}-{self.model}"}}]}
+
+    dummy = types.SimpleNamespace(LM=DummyLM, LLM=DummyLM)
+    monkeypatch.setitem(sys.modules, "dspy", dummy)
+    monkeypatch.setitem(sys.modules, "requests", types.ModuleType("requests"))
+
+    module = importlib.import_module(module_name)
+    module = importlib.reload(module)
+
+    backend_cls = getattr(module, attr)
+    assert backend_cls is not None
+    backend = backend_cls(model)
+    result = backend.run("p")
+    assert result == f"p-{expected}"


### PR DESCRIPTION
## Summary
- test gemini, openrouter, and ollama DSPy backends with a dummy `dspy`
- fix missing class aliases in DSPy backend modules
- remove unused placeholders and directly assign backend classes

## Testing
- `ruff check llm/backends/plugins/gemini_dspy.py llm/backends/plugins/ollama_dspy.py llm/backends/plugins/openrouter_dspy.py tests/test_dspy_backends.py`
- `pytest tests/test_dspy_backends.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68686ba76e988326a98c3a5560748add