### PR TITLE
Add VM provisioning helper

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -7,8 +7,6 @@ from typing import Any
 
 from fastapi import FastAPI
 from pydantic import BaseModel
-import os
-import requests
 
 from scripts.ai_router import send_prompt
 from scripts.thm import apply_palette, REPO_ROOT

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -227,6 +227,14 @@ installation:
 ./scripts/create-hyperv-vm.ps1 -Name DevVM -IsoUrl https://example.com/os.iso -CloudInit ./seed.iso
 ```
 
+You can also provision a VM or WSL distribution using the Python helper. Pass
+`--notify` to post a message via `ntfy` when provisioning completes:
+
+```powershell
+python scripts/provision_vm.py hyperv --name DevVM --iso-url https://example.com/os.iso --cloud-init ./seed.iso --notify
+python scripts/provision_vm.py wsl --name DevDistro --rootfs ubuntu.tar --target C:\\VMs\\DevDistro --notify
+```
+
 Hyper-V is useful for testing scripts in clean environments.
 
 ## ETL automation with n8n

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,10 @@ export default [
     ignores: ["node_modules/**"],
     languageOptions: {
       ecmaVersion: "latest",
-      sourceType: "module"
+      sourceType: "module",
+      parserOptions: {
+        ecmaFeatures: { jsx: true }
+      }
     },
     rules: {}
   }

--- a/llm/backends/plugins/gemini_dspy.py
+++ b/llm/backends/plugins/gemini_dspy.py
@@ -30,6 +30,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
+    _GeminiDSPyBackend = _RealGeminiDSPyBackend
     GeminiDSPyBackend = _GeminiDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -30,6 +30,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
+    _OllamaDSPyBackend = _RealOllamaDSPyBackend
     OllamaDSPyBackend = _OllamaDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -30,6 +30,7 @@ if dspy is not None:
             result = self.lm.forward(prompt=prompt)
             return _extract_text(result)
 
+    _OpenRouterDSPyBackend = _RealOpenRouterDSPyBackend
     OpenRouterDSPyBackend = _OpenRouterDSPyBackend
 
 else:  # pragma: no cover - optional dependency missing

--- a/llm/router.py
+++ b/llm/router.py
@@ -7,7 +7,6 @@ import subprocess
 from pathlib import Path
 
 from typing import Any, Callable, List, cast
-from pathlib import Path
 
 
 from .backends import (
@@ -20,8 +19,6 @@ from .backends import (
     SuperClaudeBackend,  # noqa: F401 - re-exported for tests
     register_backend,
     get_backend,
-    SuperClaudeBackend,
-
 )
 
 

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -30,8 +30,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     exit_code = execute_steps(steps, log_path=args.log)
     if args.notify:
         if exit_code == 0:
-            send_notification("ai-do completed with exit code 0")
-
+            send_notification("ai-do completed")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
 

--- a/scripts/provision-vm.ps1
+++ b/scripts/provision-vm.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+param(
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]] $Args
+)
+
+$python = Get-Command python -ErrorAction SilentlyContinue
+if (-not $python) {
+    Write-Error 'python is required but not installed.'
+    exit 1
+}
+
+& $python (Join-Path $PSScriptRoot 'provision_vm.py') @Args

--- a/scripts/provision_vm.py
+++ b/scripts/provision_vm.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Provision a VM using Hyper-V Quick Create or WSL import."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+import sys
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from scripts.cli_common import send_notification
+
+
+def _find_powershell() -> str:
+    exe = shutil.which("pwsh") or shutil.which("powershell")
+    if not exe:
+        raise FileNotFoundError("PowerShell not found")
+    return exe
+
+
+def _run_hyperv(name: str, quick: bool, iso: str | None, cloud_init: Path | None) -> None:
+    ps = _find_powershell()
+    script = Path(__file__).with_name("create-hyperv-vm.ps1")
+    cmd = [
+        ps,
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        (
+            f"& '{script}' -Name {name}"
+            + (" -QuickCreate" if quick else "")
+            + (f" -IsoUrl {iso}" if iso else "")
+            + (f" -CloudInit {cloud_init}" if cloud_init else "")
+        ),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def _run_wsl(
+    name: str,
+    rootfs: Path,
+    target: Path,
+    version: int,
+    cloud_init: Path | None,
+) -> None:
+    cmd = [
+        "wsl",
+        "--import",
+        name,
+        str(target),
+        str(rootfs),
+        "--version",
+        str(version),
+    ]
+    subprocess.run(cmd, check=True)
+    if cloud_init:
+        subprocess.run(
+            [
+                "wsl",
+                "-d",
+                name,
+                "--",
+                "mkdir",
+                "-p",
+                "/var/lib/cloud/seed/nocloud",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "wsl",
+                "-d",
+                name,
+                "--",
+                "cp",
+                str(cloud_init),
+                "/var/lib/cloud/seed/nocloud/user-data",
+            ],
+            check=True,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    hyperv = sub.add_parser("hyperv", help="Provision a Hyper-V VM")
+    hyperv.add_argument("--name", required=True)
+    hyperv.add_argument("--quick", action="store_true", help="Use Quick Create")
+    hyperv.add_argument("--iso-url")
+    hyperv.add_argument("--cloud-init", type=Path)
+    hyperv.add_argument("--notify", action="store_true", help="Send ntfy notification")
+
+    wsl = sub.add_parser("wsl", help="Import a WSL distribution")
+    wsl.add_argument("--name", required=True)
+    wsl.add_argument("--rootfs", type=Path, required=True)
+    wsl.add_argument("--target", type=Path, required=True)
+    wsl.add_argument("--version", default=2, type=int)
+    wsl.add_argument("--cloud-init", type=Path)
+    wsl.add_argument("--notify", action="store_true", help="Send ntfy notification")
+
+    args = parser.parse_args(argv)
+
+    if args.mode == "hyperv":
+        _run_hyperv(args.name, args.quick, args.iso_url, args.cloud_init)
+        if args.notify:
+            send_notification(f"Hyper-V VM {args.name} is ready")
+    else:
+        _run_wsl(args.name, args.rootfs, args.target, args.version, args.cloud_init)
+        if args.notify:
+            send_notification(f"WSL distro {args.name} is ready")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -5,7 +5,7 @@ import sys
 import types
 from pathlib import Path
 
-import requests
+
 
 def load_app(send_prompt=lambda p, local=False: f"resp-{p}", apply_palette=lambda n, r: None, state_path: Path | None = None):
     stub_router = types.SimpleNamespace(send_prompt=send_prompt)
@@ -33,27 +33,10 @@ def test_health(tmp_path):
 
 def test_stats(tmp_path):
     app = load_app(state_path=tmp_path / 'state.json')
-
     client = TestClient(app)
     resp = client.get('/api/stats')
     assert resp.status_code == 200
-    assert resp.json() == {'queries': 1, 'memory': 2}
-    assert calls == ['http://ume/dashboard/stats']
-
-
-def test_graph(monkeypatch):
-    calls = []
-
-    class FakeResponse:
-        status_code = 200
-
-        @staticmethod
-        def json():
-            return {'nodes': ['n1'], 'edges': ['e1']}
-
-        @staticmethod
-        def raise_for_status():
-            pass
+    assert resp.json() == {'queries': 0, 'memory': 0}
 
     resp = client.post('/api/prompt', json={'prompt': 'hello'})
     assert resp.status_code == 200
@@ -63,7 +46,6 @@ def test_graph(monkeypatch):
 
 def test_graph(tmp_path):
     app = load_app(state_path=tmp_path / 'state.json')
-
     client = TestClient(app)
     resp = client.post('/api/prompt', json={'prompt': 'one'})
     assert resp.status_code == 200
@@ -74,7 +56,6 @@ def test_graph(tmp_path):
     data = resp.json()
     assert len(data['nodes']) == 2
     assert len(data['edges']) == 1
-
 
 
 def test_prompt(tmp_path):

--- a/tests/test_provision_vm.py
+++ b/tests/test_provision_vm.py
@@ -1,0 +1,76 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+def test_provision_vm_wsl_import(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "wsl.log"
+    ntfy_log = tmp_path / "ntfy.log"
+    create_exe(bin_dir / "wsl", f"#!/usr/bin/env bash\necho \"$@\" > '{log_file}'\n")
+    create_exe(bin_dir / "ntfy", f"#!/usr/bin/env bash\necho \"$@\" > '{ntfy_log}'\n")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    subprocess.run(
+        [
+            "python",
+            "scripts/provision_vm.py",
+            "wsl",
+            "--name",
+            "Dev",
+            "--rootfs",
+            str(tmp_path / "ubuntu.tar"),
+            "--target",
+            str(tmp_path / "dev"),
+            "--notify",
+        ],
+        check=True,
+        env=env,
+    )
+
+    args = log_file.read_text().strip().split()
+    assert "--import" in args
+    assert "Dev" in args
+    assert str(tmp_path / "dev") in args
+    assert str(tmp_path / "ubuntu.tar") in args
+    assert "send" in ntfy_log.read_text()
+
+
+def test_provision_vm_hyperv(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    ps_log = tmp_path / "ps.log"
+    ntfy_log = tmp_path / "ntfy.log"
+    create_exe(bin_dir / "pwsh", f"#!/usr/bin/env bash\necho \"$@\" > '{ps_log}'\n")
+    create_exe(bin_dir / "ntfy", f"#!/usr/bin/env bash\necho \"$@\" > '{ntfy_log}'\n")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    subprocess.run(
+        [
+            "python",
+            "scripts/provision_vm.py",
+            "hyperv",
+            "--name",
+            "TestVM",
+            "--quick",
+            "--notify",
+        ],
+        check=True,
+        env=env,
+    )
+
+    contents = ps_log.read_text()
+    assert "create-hyperv-vm.ps1" in contents
+    assert "-Name" in contents and "TestVM" in contents
+    assert "send" in ntfy_log.read_text()
+


### PR DESCRIPTION
## Summary
- add `provision_vm.py` for easy Hyper-V or WSL creation
- include a simple PowerShell wrapper
- document the helper in the installation guide
- test the helper script
- fix the provision CLI to allow `--notify` after the subcommand
- update dspy backend imports and api route tests
- fix lint and tests

## Testing
- `ruff check .`
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68686ba5130c8326aa978d42c721c15b