### PR TITLE
Add httpx to test extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ test = [
     "mypy",
     "fastapi",
     "uvicorn",
+    "httpx",
 ]
 cli = ["tomli_w"]
 lmql = ["lmql"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tomli_w
 streamlit
 textual
 requests
+httpx


### PR DESCRIPTION
## Summary
- add `httpx` to `[project.optional-dependencies.test]`
- regenerate `requirements.txt`

## Testing
- `ruff check .`
- `pytest -n auto` *(fails: AssertionError in tests/test_ai_do.py::test_main_notifies)*

------
https://chatgpt.com/codex/tasks/task_e_6869de9513948326a88a4032b0ad79ab