### PR TITLE
Add backend plug-in template and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Additional guides:
 - [AI automation tooling](docs/ai-automation.md)
 - [Dashboard overview](docs/dashboard.md)
 - [UME Quickstart](docs/ume.md)
+- [Backend plug-in guide](docs/plugins.md)
 
 ## Git hooks
 

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -33,6 +33,8 @@ Third-party packages may add new backends by exposing an entry point in the
 ``llm.plugins`` group. A plug-in module should import
 ``llm.backends.register_backend`` and call it when loaded.
 
+See [plugins.md](plugins.md) for a full template and interface description.
+
 Example ``pyproject.toml`` snippet:
 
 ```toml

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,42 @@
+# Writing a Backend Plug-in
+
+Third-party packages can add new LLM backends without modifying this repository.
+A plug-in must call `llm.backends.register_backend` when it is imported so the
+backend becomes available to the routing utilities.
+
+## Required Entry Point
+
+Expose the plug-in module via the `llm.plugins` entry point group in your
+`pyproject.toml`:
+
+```toml
+[project.entry-points."llm.plugins"]
+my_backend = "my_package.plugins:backend"
+```
+
+`my_package.plugins:backend` should point to a module that calls
+`register_backend` as shown below. When the library is installed, `llm`
+automatically loads this entry point.
+
+## Minimal Interface
+
+A backend plug-in registers a callable that accepts a prompt and an optional
+model name, returning the model's response as a string. The callable can be a
+function or a method of a `Backend` subclass.
+
+```python
+from llm.backends import register_backend, Backend
+
+class MyBackend(Backend):
+    def run(self, prompt: str) -> str:
+        # generate the completion using your model
+        return "response"
+
+def run(prompt: str, model: str | None = None) -> str:
+    backend = MyBackend()
+    return backend.run(prompt)
+
+register_backend("my_backend", run)
+```
+
+See `llm/backends/plugins/sample.py` for a full example.

--- a/llm/backends/plugins/sample.py
+++ b/llm/backends/plugins/sample.py
@@ -1,0 +1,25 @@
+"""Template backend plug-in."""
+
+from __future__ import annotations
+
+from .. import register_backend
+from ..base import Backend
+
+
+class SampleBackend(Backend):
+    """Example backend that echoes the prompt."""
+
+    def run(self, prompt: str) -> str:  # pragma: no cover - simple example
+        return f"Echo: {prompt}"
+
+
+def run_sample(prompt: str, model: str | None = None) -> str:
+    """Return a simple echo response."""
+
+    backend = SampleBackend()
+    return backend.run(prompt)
+
+
+register_backend("sample", run_sample)
+
+__all__ = ["SampleBackend", "run_sample"]


### PR DESCRIPTION
## Summary
- add a sample backend plugin under `llm/backends/plugins`
- document plug-in entry points and interface in `docs/plugins.md`
- link the new guide from README and `docs/ai-automation.md`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e5074c6883269870e240c3f877ee