### PR TITLE
Add cross-platform installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,15 @@ automation scripts.
 
 Next, install the Git hooks so `pre-commit` runs automatically:
 
-```powershell
+```bash
+./install.sh
+# or on Windows
 ./bootstrap.ps1
 ```
 
-`bootstrap.ps1` sets up the hooks for you. It runs
-`scripts/setup-hooks.ps1` on Windows and `scripts/setup-hooks.sh` on other
-platforms so `pre-commit` runs on each commit.
+`install.sh` sets up the hooks for you. It detects your platform and calls
+`scripts/setup-hooks.ps1` on Windows or `scripts/setup-hooks.sh` elsewhere so
+`pre-commit` runs on each commit.
 
 You can then run the test suite to verify the configuration:
 
@@ -94,14 +96,14 @@ npm run smoke
 
 
 See the [installation guide](docs/installation.md) for setup instructions.
-After cloning the repository, run `./bootstrap.ps1` from an elevated
-PowerShell window. Running it with elevation allows
+After cloning the repository, run `./install.sh` (or `./bootstrap.ps1` from an
+elevated PowerShell window). Running it with elevation allows
 `scripts/fix-path.ps1` to modify your user PATH and enables the local Git
-hooks automatically. On Windows it invokes `scripts/setup-hooks.ps1` while on
-other platforms it runs `scripts/setup-hooks.sh`.
-To enable and set up WSL in one step, pass `-InstallWSL -SetupWSL` to
-`bootstrap.ps1`; see the [installation guide](docs/installation.md#WSL) for
-more details.
+hooks automatically. On Windows the script calls `scripts/setup-hooks.ps1`
+while on other platforms it invokes `scripts/setup-hooks.sh`.
+To enable and set up WSL in one step, pass `--install-wsl --setup-wsl` to
+`install.sh` or `-InstallWSL -SetupWSL` with `bootstrap.ps1`; see the
+[installation guide](docs/installation.md#WSL) for more details.
 
 After running the script, reload your profile with `. $PROFILE` or restart the terminal to pick up the new configuration. The profile defines an `ai` helper that forwards prompts to `python -m ai_router`.
 
@@ -125,10 +127,10 @@ Additional guides:
 ## Git hooks
 
 Run `scripts/setup-hooks.sh` to enable the local hooks automatically
-(equivalent to running `git config core.hooksPath .githooks`). `bootstrap.ps1`
-invokes the appropriate script for you (`scripts/setup-hooks.ps1` on Windows and
-`scripts/setup-hooks.sh` elsewhere), so you usually don't need to run it
-manually:
+(equivalent to running `git config core.hooksPath .githooks`). `install.sh`
+and `bootstrap.ps1` call the appropriate script for you (`scripts/setup-hooks.ps1`
+on Windows and `scripts/setup-hooks.sh` elsewhere), so you usually don't need to
+run it manually:
 
 ```bash
 ./scripts/setup-hooks.sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,13 +44,15 @@ ruff check .
    ./scripts/setup-winget.ps1
    ```
 2. Copy or symlink the files from this repository to your profile directory.
-3. From an elevated PowerShell window, run `bootstrap.ps1` to set up your PATH.
-   You must run the script from an **elevated** window so that
+3. From an elevated PowerShell window, run `bootstrap.ps1` (or call
+   `install.sh` from a regular shell) to set up your PATH. You must run the
+   PowerShell script from an **elevated** window so that
    `scripts/fix-path.ps1` can modify the user PATH.
-   Pass `-InstallWinget` to install the core tools automatically. You can also
-   add `-InstallWindowsTerminal` to copy the default Windows Terminal settings,
-   `-InstallWSL` to enable WSL, and `-SetupWSL` to configure the Ubuntu instance:
-   ```powershell
+   Pass the appropriate flags to install the core tools automatically. The
+   equivalent command using `install.sh` is shown below:
+   ```bash
+   ./install.sh --winget --windows-terminal --install-wsl --setup-wsl
+   # PowerShell alternative
    ./bootstrap.ps1 -InstallWinget -InstallWindowsTerminal -InstallWSL -SetupWSL
    ```
    The script calls `scripts/fix-path.ps1` to clean up duplicate entries and ensure your `bin` directory is included.
@@ -66,15 +68,20 @@ install WSL:
 ./scripts/install-wsl.ps1
 ```
 
-You can also pass `-InstallWSL` to `bootstrap.ps1` to run the same command.
+You can also pass `--install-wsl` to `install.sh` or `-InstallWSL` to
+`bootstrap.ps1` to run the same command.
 
 Run the provided script from the repository root to install the basic tools on
 a fresh Ubuntu/WSL instance. The script uses `apt-get` and may prompt for your
-password. Invoke it directly inside WSL or pass `-SetupWSL` to `bootstrap.ps1`
-from Windows to run it via `wsl.exe`:
+password. Invoke it directly inside WSL or pass `--setup-wsl` to `install.sh` or
+`-SetupWSL` to `bootstrap.ps1` from Windows to run it via `wsl.exe`:
 
 ```bash
 sudo bash scripts/setup-wsl.sh
+```
+
+```bash
+./install.sh --setup-wsl
 ```
 
 ```powershell
@@ -88,10 +95,11 @@ sudo bash scripts/setup-wsl.sh
    git clone https://github.com/d0tTino/d0tTino.git
    ```
 2. Use `stow` or your preferred method to symlink the dotfiles into place.
-3. Run `bootstrap.ps1` to clean up your PATH:
-   ```powershell
-   ./bootstrap.ps1
+3. Run `install.sh` to clean up your PATH:
+   ```bash
+   ./install.sh
    ```
+   If you prefer PowerShell, you can run `./bootstrap.ps1` instead.
 4. Launch a new shell to pick up the configuration.
 
 ## Local LLM tools
@@ -121,7 +129,7 @@ IMAGE_NAME=myimage bash scripts/setup-docker.sh
 ```
 
 On Windows you can call the PowerShell wrapper or use `bootstrap.ps1` with the
-`-SetupDocker` switch:
+`-SetupDocker` switch. From other shells you can run `install.sh --setup-docker`:
 
 ```powershell
 ./scripts/setup-docker.ps1
@@ -131,6 +139,10 @@ On Windows you can call the PowerShell wrapper or use `bootstrap.ps1` with the
 ./bootstrap.ps1 -SetupDocker
 # with image name forwarding
 ./bootstrap.ps1 -SetupDocker -DockerImageName myimage
+```
+
+```bash
+./install.sh --setup-docker --image myimage
 ```
 
 ## Ghostty terminal

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+scripts="$repo_root/scripts"
+
+install_winget=false
+install_windows_terminal=false
+install_wsl=false
+setup_wsl=false
+setup_docker=false
+docker_image=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --winget)
+            install_winget=true
+            ;;
+        --windows-terminal)
+            install_windows_terminal=true
+            ;;
+        --install-wsl)
+            install_wsl=true
+            ;;
+        --setup-wsl)
+            setup_wsl=true
+            ;;
+        --setup-docker)
+            setup_docker=true
+            ;;
+        --image)
+            docker_image=$2
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+run_pwsh() {
+    local script=$1
+    shift
+    pwsh -NoLogo -NoProfile -File "$scripts/$script" "$@"
+}
+
+if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
+    run_pwsh fix-path.ps1
+    run_pwsh setup-hooks.ps1
+    if $install_winget; then run_pwsh setup-winget.ps1; fi
+    if $install_windows_terminal; then run_pwsh install-windows-terminal.ps1; fi
+    if $install_wsl; then run_pwsh install-wsl.ps1; fi
+    if $setup_wsl; then run_pwsh setup-wsl.ps1; fi
+    if $setup_docker; then
+        args=()
+        [[ -n $docker_image ]] && args+=("-ImageName" "$docker_image")
+        run_pwsh setup-docker.ps1 "${args[@]}"
+    fi
+else
+    bash "$scripts/setup-hooks.sh"
+    if $setup_wsl; then bash "$scripts/setup-wsl.sh"; fi
+    if $setup_docker; then
+        args=()
+        [[ -n $docker_image ]] && args+=("--image" "$docker_image")
+        bash "$scripts/setup-docker.sh" "${args[@]}"
+    fi
+fi


### PR DESCRIPTION
## Summary
- add `install.sh` that detects platform and runs the appropriate setup scripts
- reference the new script in installation docs and README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e506003c8326a9f021991a22782e