### PR TITLE
Add optional analytics for ai-do

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,4 +188,11 @@ mypy --install-types --non-interactive
 After fixing any lint errors, rerun the command and verify that it reports zero
 issues. The `pre-commit` hook runs the same command automatically.
 
+## Privacy
+
+`ai-do` can send anonymous completion events when invoked with `--analytics`.
+The data is posted to the URL specified in the `EVENTS_URL` environment
+variable with optional authorization via `EVENTS_TOKEN`. No information is sent
+unless the flag is provided.
+
 Licensed under the [Apache 2.0](LICENSE) license.

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from scripts import ai_exec
-from scripts.cli_common import execute_steps, send_notification
+from scripts.cli_common import execute_steps, record_event, send_notification
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -17,6 +17,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("goal", help="High level description of the task")
     parser.add_argument("--config")
     parser.add_argument("--notify", action="store_true", help="Send notification when done")
+    parser.add_argument(
+        "--analytics",
+        action="store_true",
+        help="Record anonymous usage events",
+    )
     parser.add_argument(
         "--log",
         type=Path,
@@ -33,7 +38,11 @@ def main(argv: Optional[List[str]] = None) -> int:
             send_notification("ai-do completed with exit code 0")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
-
+    record_event(
+        "ai-do",
+        {"goal": args.goal, "exit_code": exit_code},
+        enabled=args.analytics,
+    )
 
     return exit_code
 

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -137,6 +137,22 @@ def test_main_notifies(monkeypatch, tmp_path):
     assert called == ["ai-do completed with exit code 0"]
 
 
+def test_main_records_event(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [])
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    recorded = []
+
+    def fake_record(name, payload, *, enabled=False):
+        recorded.append((name, payload, enabled))
+
+    monkeypatch.setattr(ai_do, "record_event", fake_record)
+    log = tmp_path / "log.txt"
+    rc = ai_do.main(["goal", "--log", str(log), "--analytics"])
+
+    assert rc == 0
+    assert recorded == [("ai-do", {"goal": "goal", "exit_code": 0}, True)]
+
+
 def test_main_accepts_config_path(monkeypatch):
     def fake_plan(goal: str, *, config_path=None):
         assert goal == "goal"

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -1,0 +1,44 @@
+from scripts import cli_common
+
+
+def test_record_event_skips_when_disabled(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    called = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called.append(True)
+
+    monkeypatch.setattr(cli_common.requests, "post", fake_post)
+    cli_common.record_event("name", {"a": 1}, enabled=False)
+    assert not called
+
+
+def test_record_event_posts(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    monkeypatch.setenv("EVENTS_TOKEN", "tok")
+    sent = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        sent["url"] = url
+        sent["headers"] = headers
+        sent["data"] = json
+
+    monkeypatch.setattr(cli_common.requests, "post", fake_post)
+    cli_common.record_event("name", {"a": 1}, enabled=True)
+
+    assert sent["url"] == "https://example.com"
+    assert sent["data"] == {"name": "name", "a": 1}
+    assert sent["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_record_event_requires_url(monkeypatch):
+    called = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called.append(True)
+
+    monkeypatch.setattr(cli_common.requests, "post", fake_post)
+    monkeypatch.delenv("EVENTS_URL", raising=False)
+    cli_common.record_event("name", {"a": 1}, enabled=True)
+
+    assert not called


### PR DESCRIPTION
## Summary
- add `record_event` helper and send events via environment settings
- allow ai-do to record completion events when `--analytics` flag is given
- include privacy notice for analytics flag
- refine the analytics helper to send JSON payloads and add tests

## Testing
- `ruff check tests/test_cli_common.py scripts/cli_common.py scripts/ai_do.py`
- `mypy --install-types --non-interactive scripts/cli_common.py scripts/ai_do.py tests/test_cli_common.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e506b1bc83268bbdb2234f03da1d