### PR TITLE
Improve async exec streaming test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ streamlit
 textual
 requests
 httpx
+fastapi
+uvicorn

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -3,6 +3,7 @@ import sys
 import time
 
 import pytest
+import httpx
 from fastapi.testclient import TestClient
 from api import app
 from scripts import ai_exec
@@ -53,4 +54,25 @@ def test_plan_and_exec(monkeypatch):
 
     assert any('$ echo test' in line for line in lines)
     assert any('test' in line for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_exec_stream_async(monkeypatch):
+    monkeypatch.setattr(ai_exec, 'plan', lambda goal: ['echo one', 'echo two'])
+
+    async with httpx.AsyncClient(
+        base_url="http://test",
+        transport=httpx.ASGITransport(app=app),
+    ) as client:
+        async with client.stream("GET", "/api/exec", params={"goal": "x"}) as response:
+            lines = [line async for line in response.aiter_lines() if line]
+
+    assert lines == [
+        'data: $ echo one',
+        'data: one',
+        'data: (exit 0)',
+        'data: $ echo two',
+        'data: two',
+        'data: (exit 0)',
+    ]
 


### PR DESCRIPTION
## Summary
- add `fastapi` and `uvicorn` to requirements for web app tests
- verify `/api/exec` stream output using `httpx.AsyncClient`

## Testing
- `ruff check tests/test_web_app.py`
- `pytest tests/test_web_app.py::test_exec_stream_async -q`
- `pytest tests/test_web_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6869e871cf8c832699b5203f1cd74bbd