### PR TITLE
Improve install platform detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scripts="$repo_root/scripts"
 
+# Determine the platform when OSTYPE is not provided
+if [[ -z "${OSTYPE:-}" ]]; then
+    OSTYPE="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    case $OSTYPE in
+        mingw*) OSTYPE="msys" ;;
+    esac
+fi
+
 install_winget=false
 install_windows_terminal=false
 install_wsl=false

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -23,4 +24,21 @@ def test_install_sh_creates_hooks_and_palettes(tmp_path: Path) -> None:
         check=True,
     )
     assert result.stdout.strip() == ".githooks"
+    assert (repo / "palettes" / "blacklight.toml").is_file()
+
+
+def test_install_sh_runs_without_ostype(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_no_ostype"
+    repo.mkdir()
+    shutil.copy(repo_root / "install.sh", repo / "install.sh")
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+    shutil.copytree(repo_root / ".githooks", repo / ".githooks")
+    shutil.copytree(repo_root / "palettes", repo / "palettes")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    env = os.environ.copy()
+    env.pop("OSTYPE", None)
+    subprocess.run(["/bin/bash", "install.sh"], cwd=repo, check=True, env=env)
+
     assert (repo / "palettes" / "blacklight.toml").is_file()


### PR DESCRIPTION
## Summary
- detect platform with `uname` if `$OSTYPE` is unset
- normalize `mingw` to `msys` for Git Bash
- test install.sh execution when OSTYPE is unset

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_686a00a73bf083268036098ac5edfa07