### PR TITLE
Refactor router

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 import asyncio
 
 
-from scripts.ai_router import send_prompt
+from llm.router import send_prompt
 from scripts.thm import apply_palette, REPO_ROOT
 from scripts import ai_exec
 

--- a/llm/router.py
+++ b/llm/router.py
@@ -123,6 +123,8 @@ def _preferred_backends() -> tuple[str, str | None]:
 
 def _run_backend(name: str, prompt: str, model: str) -> str:
     """Return response for ``prompt`` using backend ``name``."""
+    if name.lower() == "langchain":
+        return run_langchain(prompt)
 
     func = get_backend(name)
     return func(prompt, model)

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -22,17 +22,8 @@ run_ollama = router.run_ollama
 run_openrouter = router.run_openrouter
 create_default_chain = router.create_default_chain
 run_langchain = router.run_langchain
-
-
-def _run_backend(name: str, prompt: str, model: str) -> str:
-    """Delegate to ``router._run_backend`` with LangChain support."""
-    if name.lower() == "langchain":
-        return send_prompt(prompt, model=model)
-    return router._run_backend(name, prompt, model)
-
-def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL) -> str:
-    """Proxy to ``router.send_prompt`` so tests can monkeypatch it."""
-    return router.send_prompt(prompt, local=local, model=model)
+_run_backend = router._run_backend
+send_prompt = router.send_prompt
 
 
 
@@ -65,12 +56,9 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.backend:
-            if args.backend.lower() == "langchain":
-                output = router.send_prompt(prompt, local=args.local, model=args.model)
-            else:
-                output = router._run_backend(args.backend, prompt, args.model)
+            output = router._run_backend(args.backend, prompt, args.model)
         else:
-            output = send_prompt(prompt, local=args.local, model=args.model)
+            output = router.send_prompt(prompt, local=args.local, model=args.model)
 
 
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -8,7 +8,7 @@ from pathlib import Path
 def load_app(send_prompt=lambda p, local=False: f"resp-{p}", apply_palette=lambda n, r: None, state_path: Path | None = None):
     stub_router = types.SimpleNamespace(send_prompt=send_prompt)
     stub_thm = types.SimpleNamespace(apply_palette=apply_palette, REPO_ROOT=Path('.'))
-    sys.modules['scripts.ai_router'] = stub_router
+    sys.modules['llm.router'] = stub_router
     sys.modules['scripts.thm'] = stub_thm
     if state_path is None:
         state_path = Path('state.json')


### PR DESCRIPTION
## Summary
- support `langchain` in the main router
- simplify `scripts/ai_router` wrapper
- import `send_prompt` from `llm.router` in the API
- adjust API route tests

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b18dc76d08326871b865a56aaecc0