### PR TITLE
Add analytics recording to ai_cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ issues. The `pre-commit` hook runs the same command automatically.
 
 ## Privacy
 
-`ai-do` can send anonymous completion events when invoked with `--analytics`.
-The data is posted to the URL specified in the `EVENTS_URL` environment
-variable with optional authorization via `EVENTS_TOKEN`. No information is sent
-unless the flag is provided.
+`ai-do` and the `ai-cli` subcommands (`send`, `plan`, `do`) can send anonymous
+completion events when invoked with `--analytics`. The data is posted to the URL
+specified in the `EVENTS_URL` environment variable with optional authorization
+via `EVENTS_TOKEN`. No information is sent unless the flag is provided.
 
 Licensed under the [Apache 2.0](LICENSE) license.


### PR DESCRIPTION
## Summary
- record anonymous usage events from `ai-cli` commands
- describe `ai-cli` analytics option in the Privacy section of the README
- test that each subcommand records an event when `--analytics` is used
- allow `--analytics` to appear after the subcommand

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli.py`
- `mypy scripts/ai_cli.py tests/test_ai_cli.py --install-types --non-interactive`
- `pytest tests/test_ai_cli.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b18dd04ac8326b001018b82b2b6d7