### PR TITLE
Add plugin management CLI

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -40,3 +40,18 @@ register_backend("my_backend", run)
 ```
 
 See `llm/backends/plugins/sample.py` for a full example.
+
+## Managing Plug-ins
+
+Use the `plugins` helper to install or remove third-party backends.
+
+```bash
+# List available plug-ins
+python -m scripts.plugins list
+
+# Install a plug-in
+python -m scripts.plugins install sample
+
+# Remove a plug-in
+python -m scripts.plugins remove sample
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ ai-plan = "scripts.ai_cli:plan_main"
 ai-do = "scripts.ai_cli:do_main"
 ai-cli = "scripts.ai_cli:main"
 etl = "scripts.etl:main"
+plugins = "scripts.plugins:main"
 
 [project.entry-points."llm.plugins"]
 # Third-party packages can expose backends here

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Manage LLM backend plug-ins."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import subprocess
+import sys
+from typing import Dict, List, Optional
+
+# Mapping of plug-in name to pip package
+PLUGIN_REGISTRY: Dict[str, str] = {
+    "sample": "d0ttino-sample-plugin",
+}
+
+
+def _is_installed(package: str) -> bool:
+    try:
+        importlib.metadata.distribution(package)
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    for name, package in sorted(PLUGIN_REGISTRY.items()):
+        status = "installed" if _is_installed(package) else "not installed"
+        print(f"{name}\t({package}) - {status}")
+    return 0
+
+
+def _cmd_install(args: argparse.Namespace) -> int:
+    name = args.name
+    if name not in PLUGIN_REGISTRY:
+        print(f"Unknown plug-in: {name}", file=sys.stderr)
+        return 1
+    pkg = PLUGIN_REGISTRY[name]
+    result = subprocess.run([sys.executable, "-m", "pip", "install", pkg])
+    return result.returncode
+
+
+def _cmd_remove(args: argparse.Namespace) -> int:
+    name = args.name
+    if name not in PLUGIN_REGISTRY:
+        print(f"Unknown plug-in: {name}", file=sys.stderr)
+        return 1
+    pkg = PLUGIN_REGISTRY[name]
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "uninstall", "-y", pkg]
+    )
+    return result.returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    list_cmd = sub.add_parser("list", help="List available plug-ins")
+    list_cmd.set_defaults(func=_cmd_list)
+
+    install_cmd = sub.add_parser("install", help="Install a plug-in")
+    install_cmd.add_argument("name", help="Plug-in name")
+    install_cmd.set_defaults(func=_cmd_install)
+
+    remove_cmd = sub.add_parser("remove", help="Remove a plug-in")
+    remove_cmd.add_argument("name", help="Plug-in name")
+    remove_cmd.set_defaults(func=_cmd_remove)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -1,0 +1,27 @@
+import sys
+from scripts import plugins
+
+
+def test_list_outputs_available_plugins(monkeypatch, capsys):
+    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    monkeypatch.setattr(plugins, "_is_installed", lambda p: False)
+    rc = plugins.main(["list"])
+    captured = capsys.readouterr().out
+    assert rc == 0
+    assert "dummy" in captured
+
+
+def test_install_runs_pip(monkeypatch):
+    called = {}
+    def fake_run(cmd):
+        called["cmd"] = cmd
+        class Result:
+            returncode = 0
+        return Result()
+    monkeypatch.setattr(plugins.subprocess, "run", fake_run)
+    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    rc = plugins.main(["install", "dummy"])
+    assert rc == 0
+    assert called["cmd"][0] == sys.executable
+    assert "dummy-pkg" in called["cmd"]
+


### PR DESCRIPTION
## Summary
- manage plug-ins with new `scripts/plugins.py`
- expose the script as `plugins` entry point
- document plug-in management
- test listing and installing plug-ins

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1cf004708326866623772ab574b5