### PR TITLE
Add macOS font install test

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,17 @@ run_pwsh() {
     pwsh -NoLogo -NoProfile -File "$scripts/$script" "$@"
 }
 
+install_nerd_font_macos() {
+    if ! command -v brew >/dev/null; then
+        echo "Homebrew is required on macOS to install fonts" >&2
+        return 1
+    fi
+    if ! brew list --cask font-caskaydia-cove-nerd-font >/dev/null 2>&1; then
+        brew tap homebrew/cask-fonts >/dev/null
+        brew install --cask font-caskaydia-cove-nerd-font
+    fi
+}
+
 if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
     run_pwsh fix-path.ps1
     run_pwsh setup-hooks.ps1
@@ -68,6 +79,9 @@ if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == 
     fi
 else
     bash "$scripts/setup-hooks.sh"
+    if [[ $OSTYPE == darwin* ]]; then
+        install_nerd_font_macos
+    fi
     if $setup_wsl; then bash "$scripts/setup-wsl.sh"; fi
     if $setup_docker; then
         args=()

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -4,6 +4,11 @@ import subprocess
 from pathlib import Path
 
 
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
 def test_install_sh_creates_hooks_and_palettes(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     repo = tmp_path / "repo"
@@ -42,3 +47,36 @@ def test_install_sh_runs_without_ostype(tmp_path: Path) -> None:
     subprocess.run(["/bin/bash", "install.sh"], cwd=repo, check=True, env=env)
 
     assert (repo / "palettes" / "blacklight.toml").is_file()
+
+
+def test_install_sh_installs_nerd_font_macos(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_macos"
+    repo.mkdir()
+    shutil.copy(repo_root / "install.sh", repo / "install.sh")
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+    shutil.copytree(repo_root / ".githooks", repo / ".githooks")
+    shutil.copytree(repo_root / "palettes", repo / "palettes")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    brew_log = tmp_path / "brew.log"
+    create_exe(
+        bin_dir / "brew",
+        (
+            "#!/usr/bin/env bash\n"
+            f"echo \"$@\" >> '{brew_log}'\n"
+            "if [[ $1 == list ]]; then exit 1; fi\n"
+        ),
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["OSTYPE"] = "darwin"
+    subprocess.run(["/bin/bash", "install.sh"], cwd=repo, check=True, env=env)
+
+    lines = brew_log.read_text().splitlines()
+    assert any("tap" in line for line in lines)
+    assert any("font-caskaydia-cove-nerd-font" in line for line in lines)


### PR DESCRIPTION
## Summary
- install Nerd Font on macOS in `install.sh`
- test Nerd Font installation logic with a stubbed `brew` command

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_686b1cf10b50832693889fb0548b76e3