### PR TITLE
Implement real OpenRouter backend

### DIFF
--- a/llm/backends/plugins/openrouter.py
+++ b/llm/backends/plugins/openrouter.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, cast
+import os
+from typing import Any, Mapping, cast
+
+import requests
 
 from .. import register_backend
 from ..base import Backend
@@ -13,14 +16,48 @@ except Exception:  # pragma: no cover - optional dependency missing
 
 
 
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def _extract_text(result: Mapping[str, Any]) -> str:
+    """Return the assistant text from a LiteLLM-style result."""
+    try:
+        choices = result["choices"]
+        first = choices[0]
+        if isinstance(first, dict):
+            if "message" in first:
+                return first["message"].get("content", "")
+            return first.get("text", "")
+    except Exception:  # pragma: no cover - fall back to str()
+        pass
+    return str(result)
+
+
 class OpenRouterBackend(Backend):
-    """Placeholder OpenRouter client."""
+    """HTTP client for the OpenRouter API."""
 
     def __init__(self, model: str) -> None:
         self.model = model
+        self.api_key = os.environ.get("OPENROUTER_API_KEY")
+        self.base_url = os.environ.get("OPENROUTER_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
 
-    def run(self, prompt: str) -> str:  # pragma: no cover - network placeholder
-        return f"openrouter:{prompt}:{self.model}"
+    def run(self, prompt: str) -> str:
+        if not self.api_key:  # pragma: no cover - sanity check
+            raise RuntimeError("OPENROUTER_API_KEY is not set")
+
+        url = f"{self.base_url}/chat/completions"
+        response = requests.post(
+            url,
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return _extract_text(data)
 
 
 def run_openrouter(prompt: str, model: str) -> str:


### PR DESCRIPTION
## Summary
- implement a real HTTP-based OpenRouter backend
- read API key and base URL from environment variables
- parse LiteLLM-style responses
- test OpenRouter backend using mocked requests

## Testing
- `ruff check llm/backends/plugins/openrouter.py tests/test_openrouter_backend.py`
- `pytest tests/test_openrouter_backend.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b394bc0d483269a1e5fa34a33d63c