### PR TITLE
Improve plugin management error handling

### DIFF
--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -36,8 +36,18 @@ def _cmd_install(args: argparse.Namespace) -> int:
         print(f"Unknown plug-in: {name}", file=sys.stderr)
         return 1
     pkg = PLUGIN_REGISTRY[name]
-    result = subprocess.run([sys.executable, "-m", "pip", "install", pkg])
-    return result.returncode
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", pkg],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return 0
+    except subprocess.CalledProcessError as e:
+        if e.stderr:
+            print(e.stderr, file=sys.stderr, end="")
+        return e.returncode
 
 
 def _cmd_remove(args: argparse.Namespace) -> int:
@@ -46,10 +56,18 @@ def _cmd_remove(args: argparse.Namespace) -> int:
         print(f"Unknown plug-in: {name}", file=sys.stderr)
         return 1
     pkg = PLUGIN_REGISTRY[name]
-    result = subprocess.run(
-        [sys.executable, "-m", "pip", "uninstall", "-y", pkg]
-    )
-    return result.returncode
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "uninstall", "-y", pkg],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return 0
+    except subprocess.CalledProcessError as e:
+        if e.stderr:
+            print(e.stderr, file=sys.stderr, end="")
+        return e.returncode
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -13,8 +13,9 @@ def test_list_outputs_available_plugins(monkeypatch, capsys):
 
 def test_install_runs_pip(monkeypatch):
     called = {}
-    def fake_run(cmd):
+    def fake_run(cmd, *args, **kwargs):
         called["cmd"] = cmd
+        called["kwargs"] = kwargs
         class Result:
             returncode = 0
         return Result()
@@ -24,4 +25,56 @@ def test_install_runs_pip(monkeypatch):
     assert rc == 0
     assert called["cmd"][0] == sys.executable
     assert "dummy-pkg" in called["cmd"]
+    assert called["kwargs"].get("check")
+    assert called["kwargs"].get("capture_output")
+    assert called["kwargs"].get("text")
+
+
+def test_remove_runs_pip(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        called["cmd"] = cmd
+        called["kwargs"] = kwargs
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(plugins.subprocess, "run", fake_run)
+    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    rc = plugins.main(["remove", "dummy"])
+    assert rc == 0
+    assert called["cmd"][0] == sys.executable
+    assert "dummy-pkg" in called["cmd"]
+    assert called["kwargs"].get("check")
+    assert called["kwargs"].get("capture_output")
+    assert called["kwargs"].get("text")
+
+
+def test_install_failure_propagates(monkeypatch, capsys):
+    def fake_run(cmd, *args, **kwargs):
+        raise plugins.subprocess.CalledProcessError(
+            5, cmd, stderr="fail\n"
+        )
+
+    monkeypatch.setattr(plugins.subprocess, "run", fake_run)
+    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    rc = plugins.main(["install", "dummy"])
+    captured = capsys.readouterr()
+    assert rc == 5
+    assert "fail" in captured.err
+
+
+def test_remove_failure_propagates(monkeypatch, capsys):
+    def fake_run(cmd, *args, **kwargs):
+        raise plugins.subprocess.CalledProcessError(3, cmd, stderr="boom\n")
+
+    monkeypatch.setattr(plugins.subprocess, "run", fake_run)
+    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    rc = plugins.main(["remove", "dummy"])
+    captured = capsys.readouterr()
+    assert rc == 3
+    assert "boom" in captured.err
 


### PR DESCRIPTION
## Summary
- capture stderr when uninstalling plugins and print errors
- assert subprocess options for install and remove
- verify stderr is printed on uninstall failures

## Testing
- `ruff check scripts/plugins.py tests/test_plugins_script.py`
- `mypy --install-types --non-interactive scripts/plugins.py tests/test_plugins_script.py`
- `pytest tests/test_plugins_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b394bc25c8326810faf6ff78712a9