### PR TITLE
Add dynamic plugin registry

### DIFF
--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,50 @@
+import json
+
+from scripts import plugins
+
+
+def test_load_registry_fetches_and_caches(monkeypatch, tmp_path):
+    cached = tmp_path / "cache.json"
+    monkeypatch.setattr(plugins, "CACHE_PATH", cached)
+
+    result = {"x": "pkg"}
+
+    class Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return result
+
+    def fake_get(url, timeout=None):
+        return Resp()
+
+    monkeypatch.setattr(plugins, "requests", type("req", (), {"get": fake_get}))
+    monkeypatch.setenv("PLUGIN_REGISTRY_URL", "https://example.com")
+
+    registry = plugins.load_registry()
+    assert registry == result
+    assert json.loads(cached.read_text()) == result
+
+
+def test_load_registry_uses_cache_on_error(monkeypatch, tmp_path):
+    cached = tmp_path / "cache.json"
+    cached.write_text(json.dumps({"y": "pkg"}))
+    monkeypatch.setattr(plugins, "CACHE_PATH", cached)
+
+    def fake_get(url, timeout=None):
+        raise OSError()
+
+    monkeypatch.setattr(plugins, "requests", type("req", (), {"get": fake_get}))
+    monkeypatch.setenv("PLUGIN_REGISTRY_URL", "https://example.com")
+
+    registry = plugins.load_registry()
+    assert registry == {"y": "pkg"}
+
+
+def test_load_registry_defaults_when_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(plugins, "CACHE_PATH", tmp_path / "missing.json")
+    monkeypatch.delenv("PLUGIN_REGISTRY_URL", raising=False)
+
+    registry = plugins.load_registry()
+    assert registry == plugins.PLUGIN_REGISTRY

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -3,7 +3,7 @@ from scripts import plugins
 
 
 def test_list_outputs_available_plugins(monkeypatch, capsys):
-    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    monkeypatch.setattr(plugins, "load_registry", lambda: {"dummy": "dummy-pkg"})
     monkeypatch.setattr(plugins, "_is_installed", lambda p: False)
     rc = plugins.main(["list"])
     captured = capsys.readouterr().out
@@ -20,7 +20,7 @@ def test_install_runs_pip(monkeypatch):
             returncode = 0
         return Result()
     monkeypatch.setattr(plugins.subprocess, "run", fake_run)
-    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    monkeypatch.setattr(plugins, "load_registry", lambda: {"dummy": "dummy-pkg"})
     rc = plugins.main(["install", "dummy"])
     assert rc == 0
     assert called["cmd"][0] == sys.executable
@@ -43,7 +43,7 @@ def test_remove_runs_pip(monkeypatch):
         return Result()
 
     monkeypatch.setattr(plugins.subprocess, "run", fake_run)
-    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    monkeypatch.setattr(plugins, "load_registry", lambda: {"dummy": "dummy-pkg"})
     rc = plugins.main(["remove", "dummy"])
     assert rc == 0
     assert called["cmd"][0] == sys.executable
@@ -60,7 +60,7 @@ def test_install_failure_propagates(monkeypatch, capsys):
         )
 
     monkeypatch.setattr(plugins.subprocess, "run", fake_run)
-    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    monkeypatch.setattr(plugins, "load_registry", lambda: {"dummy": "dummy-pkg"})
     rc = plugins.main(["install", "dummy"])
     captured = capsys.readouterr()
     assert rc == 5
@@ -72,7 +72,7 @@ def test_remove_failure_propagates(monkeypatch, capsys):
         raise plugins.subprocess.CalledProcessError(3, cmd, stderr="boom\n")
 
     monkeypatch.setattr(plugins.subprocess, "run", fake_run)
-    monkeypatch.setattr(plugins, "PLUGIN_REGISTRY", {"dummy": "dummy-pkg"})
+    monkeypatch.setattr(plugins, "load_registry", lambda: {"dummy": "dummy-pkg"})
     rc = plugins.main(["remove", "dummy"])
     captured = capsys.readouterr()
     assert rc == 3


### PR DESCRIPTION
## Summary
- load plugin registry from URL via `PLUGIN_REGISTRY_URL`
- cache registry JSON locally
- update plugin management script to use loaded registry
- adjust existing tests
- add coverage for registry loading

## Testing
- `ruff check scripts/plugins.py tests/test_plugins_script.py tests/test_plugin_registry.py`
- `mypy --install-types --non-interactive scripts/plugins.py tests/test_plugins_script.py tests/test_plugin_registry.py`
- `pytest tests/test_plugins_script.py tests/test_plugin_registry.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6b981f208326a43da424b9af6aa4