### PR TITLE
Centralize install routines

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -8,11 +8,7 @@ param(
 )
 
 & "$PSScriptRoot/scripts/fix-path.ps1"
-if ($IsWindows) {
-    & "$PSScriptRoot/scripts/setup-hooks.ps1"
-} else {
-    & bash "$PSScriptRoot/scripts/setup-hooks.sh"
-}
+& bash "$PSScriptRoot/scripts/install_common.sh"
 
 if ($InstallWinget -and $IsWindows) {
     & "$PSScriptRoot/scripts/setup-winget.ps1"

--- a/install.sh
+++ b/install.sh
@@ -54,20 +54,14 @@ run_pwsh() {
     pwsh -NoLogo -NoProfile -File "$scripts/$script" "$@"
 }
 
-install_nerd_font_macos() {
-    if ! command -v brew >/dev/null; then
-        echo "Homebrew is required on macOS to install fonts" >&2
-        return 1
-    fi
-    if ! brew list --cask font-caskaydia-cove-nerd-font >/dev/null 2>&1; then
-        brew tap homebrew/cask-fonts >/dev/null
-        brew install --cask font-caskaydia-cove-nerd-font
-    fi
-}
 
 if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
     run_pwsh fix-path.ps1
-    run_pwsh setup-hooks.ps1
+fi
+
+bash "$scripts/install_common.sh"
+
+if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
     if $install_winget; then run_pwsh setup-winget.ps1; fi
     if $install_windows_terminal; then run_pwsh install-windows-terminal.ps1; fi
     if $install_wsl; then run_pwsh install-wsl.ps1; fi
@@ -78,10 +72,6 @@ if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == 
         run_pwsh setup-docker.ps1 "${args[@]}"
     fi
 else
-    bash "$scripts/setup-hooks.sh"
-    if [[ $OSTYPE == darwin* ]]; then
-        install_nerd_font_macos
-    fi
     if $setup_wsl; then bash "$scripts/setup-wsl.sh"; fi
     if $setup_docker; then
         args=()

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+scripts="$repo_root/scripts"
+
+bash "$scripts/setup-hooks.sh"
+bash "$scripts/install.sh"

--- a/tests/test_bootstrap_ps1.py
+++ b/tests/test_bootstrap_ps1.py
@@ -39,9 +39,9 @@ if [[ $base == bootstrap.ps1 ]]; then
     esac
   done
   echo fix-path.ps1 >> "$log_file"
-  echo setup-hooks.ps1 >> "$log_file"
-  if [[ -f "$root/scripts/setup-hooks.sh" ]]; then
-    /bin/bash "$root/scripts/setup-hooks.sh"
+  echo install_common.sh >> "$log_file"
+  if [[ -f "$root/scripts/install_common.sh" ]]; then
+    /bin/bash "$root/scripts/install_common.sh"
   fi
   $install_winget && echo setup-winget.ps1 >> "$log_file"
   $install_windows_terminal && echo install-windows-terminal.ps1 >> "$log_file"
@@ -126,7 +126,7 @@ def test_bootstrap_invokes_optional_scripts(tmp_path: Path) -> None:
         )
         lines = log_file.read_text().splitlines()
         assert "fix-path.ps1" in lines
-        assert "setup-hooks.ps1" in lines
+        assert "install_common.sh" in lines
         assert expected in lines
 
 


### PR DESCRIPTION
## Summary
- simplify install workflow across platforms
- call new `install_common.sh` from `install.sh` and `bootstrap.ps1`
- update tests for new script

## Testing
- `ruff check .`
- `pytest tests/test_install_sh.py tests/test_bootstrap_ps1.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686c6b9985a483269cf8412621e8fdba