### PR TITLE
Add recipe plugin system

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -55,3 +55,25 @@ python -m scripts.plugins install sample
 # Remove a plug-in
 python -m scripts.plugins remove sample
 ```
+
+# Writing a Recipe Plug-in
+
+Automation recipes are small helpers that return shell steps for a goal.
+A recipe exposes a callable that matches the following interface:
+
+```python
+from typing import List
+
+def run(goal: str) -> List[str]:
+    ...
+```
+
+Expose the callable via the `d0ttino.recipes` entry point group so the
+loader can discover it:
+
+```toml
+[project.entry-points."d0ttino.recipes"]
+my_recipe = "my_package.recipes:run"
+```
+
+See `scripts/recipes/plugins/sample.py` for a simple example.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ plugins = "scripts.plugins:main"
 [project.entry-points."llm.plugins"]
 # Third-party packages can expose backends here
 
+[project.entry-points."d0ttino.recipes"]
+sample = "scripts.recipes.plugins.sample:run"
+
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/scripts/recipes/__init__.py
+++ b/scripts/recipes/__init__.py
@@ -1,0 +1,48 @@
+"""Recipe plug-in loader."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import pkgutil
+from collections.abc import Callable
+from typing import Dict, List
+
+RECIPE_ENTRYPOINT_GROUP = "d0ttino.recipes"
+
+Recipe = Callable[[str], List[str]]
+
+__all__ = ["Recipe", "RECIPE_ENTRYPOINT_GROUP", "discover_recipes"]
+
+
+def discover_recipes() -> Dict[str, Recipe]:
+    """Return mapping of recipe names to callables."""
+
+    package = f"{__name__}.plugins"
+    recipes: Dict[str, Recipe] = {}
+    paths: List[str] = []
+    try:
+        pkg = importlib.import_module(package)
+        paths = list(pkg.__path__)
+    except Exception:  # pragma: no cover - plugins package missing
+        pass
+
+    for mod in pkgutil.iter_modules(paths):
+        name = f"{package}.{mod.name}"
+        try:
+            module = importlib.import_module(name)
+        except Exception:  # pragma: no cover - optional dependency missing
+            continue
+        func = getattr(module, "run", None)
+        if callable(func):
+            recipes[mod.name] = func
+
+    for entry in importlib.metadata.entry_points().select(group=RECIPE_ENTRYPOINT_GROUP):
+        try:
+            func = entry.load()
+        except Exception:  # pragma: no cover - optional dependency missing
+            continue
+        if callable(func):
+            recipes[entry.name] = func
+
+    return recipes

--- a/scripts/recipes/plugins/sample.py
+++ b/scripts/recipes/plugins/sample.py
@@ -1,0 +1,11 @@
+"""Sample recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+
+def run(goal: str) -> List[str]:
+    """Return a simple command echoing the goal."""
+    return [f"echo {goal}"]
+
+__all__ = ["run"]

--- a/tests/test_recipe_plugins.py
+++ b/tests/test_recipe_plugins.py
@@ -1,0 +1,37 @@
+import importlib
+import importlib.metadata
+import sys
+import types
+
+from scripts import recipes
+
+
+def test_discover_recipes_finds_builtin_sample():
+    mapping = recipes.discover_recipes()
+    assert "sample" in mapping
+    assert mapping["sample"]("goal") == ["echo goal"]
+
+
+def test_discover_recipes_loads_entry_points(monkeypatch):
+    module = types.ModuleType("dummy_recipe")
+    exec(
+        "def run(goal: str):\n    return ['dummy:' + goal]\n",
+        module.__dict__,
+    )
+    sys.modules["dummy_recipe"] = module
+
+    entry = importlib.metadata.EntryPoint(
+        name="dummy",
+        value="dummy_recipe:run",
+        group="d0ttino.recipes",
+    )
+
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda: importlib.metadata.EntryPoints((entry,)),
+    )
+
+    mapping = recipes.discover_recipes()
+    assert mapping["dummy"]("goal") == ["dummy:goal"]
+


### PR DESCRIPTION
## Summary
- create loader that discovers `d0ttino.recipes` entry points
- add bundled sample recipe plug-in
- document recipe plug-ins in `docs/plugins.md`
- add tests for recipe plug-in discovery and execution
- expose constant for recipe entry point group

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686c6b9982c883268f3f5e4aa7bae973