### PR TITLE
Add Lobechat & MindBridge backends

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -56,6 +56,23 @@ python -m scripts.plugins install sample
 python -m scripts.plugins remove sample
 ```
 
+## Built-in Backends
+
+`llm` includes HTTP clients for LobeChat and MindBridge. Set the following
+environment variables to configure them:
+
+### LobeChat
+
+- `LOBECHAT_API_KEY` – API token for your LobeChat instance (optional).
+- `LOBECHAT_BASE_URL` – Override the service URL (default
+  `http://localhost:3210/api`).
+
+### MindBridge
+
+- `MINDBRIDGE_API_KEY` – API token for the MindBridge service (optional).
+- `MINDBRIDGE_BASE_URL` – Override the service URL (default
+  `https://api.mindbridge.ai/v1`).
+
 # Writing a Recipe Plug-in
 
 Automation recipes are small helpers that return shell steps for a goal.

--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -16,6 +16,8 @@ _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
 GeminiBackend: type[Backend] | None = None
 OllamaBackend: type[Backend] | None = None
 OpenRouterBackend: type[Backend] | None = None
+LobeChatBackend: type[Backend] | None = None
+MindBridgeBackend: type[Backend] | None = None
 SuperClaudeBackend: type[Backend] | None = _RealSuperClaudeBackend  # noqa: F811
 
 GeminiDSPyBackend = None
@@ -34,6 +36,8 @@ __all__ = [
     "GeminiBackend",
     "OllamaBackend",
     "OpenRouterBackend",
+    "LobeChatBackend",
+    "MindBridgeBackend",
     "SuperClaudeBackend",
     "GeminiDSPyBackend",
     "OllamaDSPyBackend",

--- a/llm/backends/plugins/lobechat.py
+++ b/llm/backends/plugins/lobechat.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, cast
+
+import requests
+
+from .. import register_backend
+from ..base import Backend
+
+
+DEFAULT_BASE_URL = "http://localhost:3210/api"
+
+
+def _extract_text(result: Mapping[str, Any]) -> str:
+    """Return the assistant text from a LiteLLM-style result."""
+    try:
+        choices = result["choices"]
+        first = choices[0]
+        if isinstance(first, dict):
+            if "message" in first:
+                return first["message"].get("content", "")
+            return first.get("text", "")
+    except Exception:  # pragma: no cover - fall back to str()
+        pass
+    return str(result)
+
+
+class LobeChatBackend(Backend):
+    """HTTP client for the LobeChat API."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        self.api_key = os.environ.get("LOBECHAT_API_KEY")
+        self.base_url = os.environ.get("LOBECHAT_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+    def run(self, prompt: str) -> str:
+        url = f"{self.base_url}/chat/completions"
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        response = requests.post(
+            url,
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return _extract_text(data)
+
+
+def run_lobechat(prompt: str, model: str) -> str:
+    """Return LobeChat response for ``prompt`` using ``model``."""
+
+    backend = cast(Any, LobeChatBackend)(model)
+    return backend.run(prompt)
+
+
+register_backend("lobechat", run_lobechat)
+
+__all__ = ["LobeChatBackend", "run_lobechat"]

--- a/llm/backends/plugins/mindbridge.py
+++ b/llm/backends/plugins/mindbridge.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, cast
+
+import requests
+
+from .. import register_backend
+from ..base import Backend
+
+DEFAULT_BASE_URL = "https://api.mindbridge.ai/v1"
+
+
+def _extract_text(result: Mapping[str, Any]) -> str:
+    """Return the assistant text from a LiteLLM-style result."""
+    try:
+        choices = result["choices"]
+        first = choices[0]
+        if isinstance(first, dict):
+            if "message" in first:
+                return first["message"].get("content", "")
+            return first.get("text", "")
+    except Exception:  # pragma: no cover - fall back to str()
+        pass
+    return str(result)
+
+
+class MindBridgeBackend(Backend):
+    """HTTP client for the MindBridge API."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        self.api_key = os.environ.get("MINDBRIDGE_API_KEY")
+        self.base_url = os.environ.get("MINDBRIDGE_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+    def run(self, prompt: str) -> str:
+        url = f"{self.base_url}/chat/completions"
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        response = requests.post(
+            url,
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return _extract_text(data)
+
+
+def run_mindbridge(prompt: str, model: str) -> str:
+    """Return MindBridge response for ``prompt`` using ``model``."""
+
+    backend = cast(Any, MindBridgeBackend)(model)
+    return backend.run(prompt)
+
+
+register_backend("mindbridge", run_mindbridge)
+
+__all__ = ["MindBridgeBackend", "run_mindbridge"]

--- a/tests/test_lobechat_backend.py
+++ b/tests/test_lobechat_backend.py
@@ -1,0 +1,52 @@
+from llm.backends.plugins.lobechat import LobeChatBackend, run_lobechat
+
+
+def test_lobechat_backend_makes_request(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json, headers, timeout):
+        calls["url"] = url
+        calls["json"] = json
+        calls["headers"] = headers
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        return Resp()
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setenv("LOBECHAT_API_KEY", "k")
+    monkeypatch.setenv("LOBECHAT_BASE_URL", "https://example.com/api")
+
+    backend = LobeChatBackend("m")
+    out = backend.run("p")
+
+    assert out == "ok"
+    assert calls["url"] == "https://example.com/api/chat/completions"
+    assert calls["json"] == {
+        "model": "m",
+        "messages": [{"role": "user", "content": "p"}],
+    }
+    assert calls["headers"] == {"Authorization": "Bearer k"}
+
+
+def test_run_lobechat(monkeypatch):
+    calls = []
+
+    class Dummy:
+        def __init__(self, model):
+            calls.append(("init", model))
+
+        def run(self, prompt: str) -> str:
+            calls.append(("run", prompt))
+            return "yes"
+
+    monkeypatch.setattr("llm.backends.plugins.lobechat.LobeChatBackend", Dummy)
+
+    result = run_lobechat("hi", "m")
+    assert result == "yes"
+    assert calls == [("init", "m"), ("run", "hi")]

--- a/tests/test_mindbridge_backend.py
+++ b/tests/test_mindbridge_backend.py
@@ -1,0 +1,54 @@
+from llm.backends.plugins.mindbridge import MindBridgeBackend, run_mindbridge
+
+
+def test_mindbridge_backend_makes_request(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json, headers, timeout):
+        calls["url"] = url
+        calls["json"] = json
+        calls["headers"] = headers
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        return Resp()
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setenv("MINDBRIDGE_API_KEY", "k")
+    monkeypatch.setenv("MINDBRIDGE_BASE_URL", "https://mb.example.com")
+
+    backend = MindBridgeBackend("m")
+    out = backend.run("p")
+
+    assert out == "ok"
+    assert calls["url"] == "https://mb.example.com/chat/completions"
+    assert calls["json"] == {
+        "model": "m",
+        "messages": [{"role": "user", "content": "p"}],
+    }
+    assert calls["headers"] == {"Authorization": "Bearer k"}
+
+
+def test_run_mindbridge(monkeypatch):
+    calls = []
+
+    class Dummy:
+        def __init__(self, model):
+            calls.append(("init", model))
+
+        def run(self, prompt: str) -> str:
+            calls.append(("run", prompt))
+            return "yes"
+
+    monkeypatch.setattr(
+        "llm.backends.plugins.mindbridge.MindBridgeBackend", Dummy
+    )
+
+    result = run_mindbridge("hi", "m")
+    assert result == "yes"
+    assert calls == [("init", "m"), ("run", "hi")]


### PR DESCRIPTION
## Summary
- implement lobechat and mindbridge backend clients
- register new backends
- document config options
- test both backends

## Testing
- `ruff check llm/backends/plugins/lobechat.py llm/backends/plugins/mindbridge.py llm/backends/__init__.py tests/test_lobechat_backend.py tests/test_mindbridge_backend.py`
- `mypy --install-types --non-interactive`
- `pytest -q tests/test_lobechat_backend.py tests/test_mindbridge_backend.py tests/test_openrouter_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_686c74ae5c6c8326aca48fb7af80cebc