### PR TITLE
Add parameterized plugin remove test

### DIFF
--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -1,4 +1,5 @@
 import sys
+import pytest
 from scripts import plugins
 
 
@@ -77,4 +78,29 @@ def test_remove_failure_propagates(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert rc == 3
     assert "boom" in captured.err
+
+
+@pytest.mark.parametrize("retcode", [0, 4])
+def test_main_remove(monkeypatch, capsys, retcode):
+    called = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        called["cmd"] = cmd
+        if retcode:
+            raise plugins.subprocess.CalledProcessError(retcode, cmd, stderr="fail\n")
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(plugins.subprocess, "run", fake_run)
+    monkeypatch.setattr(plugins, "load_registry", lambda: {"dummy": "dummy-pkg"})
+    rc = plugins.main(["remove", "dummy"])
+    captured = capsys.readouterr()
+    assert called["cmd"][0] == sys.executable
+    assert "dummy-pkg" in called["cmd"]
+    assert rc == retcode
+    if retcode:
+        assert "fail" in captured.err
 


### PR DESCRIPTION
## Summary
- add pytest to imports in test_plugins_script
- test plugin removal via parameterized test

## Testing
- `ruff check .`
- `pytest tests/test_plugins_script.py::test_main_remove -q`


------
https://chatgpt.com/codex/tasks/task_e_686c74b03f008326a5a9f11bea617251