### PR TITLE
Update CI to install runtime requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test]' -r requirements.txt
+          pip install -e '.[test]'
       - name: Run ruff
         run: ruff check .
       - name: Run mypy
         run: mypy --install-types --non-interactive
+      - name: Install runtime requirements
+        run: pip install -r requirements.txt
       - name: Run tests
         run: pytest -n auto
 
@@ -39,7 +41,9 @@ jobs:
       - name: Install dependencies with extras
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test,lmql,guidance]' textual -r requirements.txt
+          pip install -e '.[test,lmql,guidance]' textual
+      - name: Install runtime requirements
+        run: pip install -r requirements.txt
       - name: Run tests with extras
         run: pytest -n auto
 

--- a/tests/README
+++ b/tests/README
@@ -13,3 +13,8 @@ pip install -r requirements.txt
 pip install dspy-ai
 pytest
 ```
+
+The CI workflow installs the runtime requirements with
+`pip install -r requirements.txt` before running the tests.
+Running the same command locally ensures your environment matches the
+automated checks.


### PR DESCRIPTION
## Summary
- ensure CI installs runtime requirements before running tests
- note the same requirement in `tests/README`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_686c74b168c48326bc0c1ad61f0bc169