### PR TITLE
Refactor installation helpers

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -8,7 +8,16 @@ param(
 )
 
 & "$PSScriptRoot/scripts/fix-path.ps1"
-& bash "$PSScriptRoot/scripts/install_common.sh"
+
+if ($IsWindows) {
+    & "$PSScriptRoot/scripts/setup-hooks.ps1"
+    & "$PSScriptRoot/scripts/helpers/install_fonts.ps1"
+    & "$PSScriptRoot/scripts/helpers/sync_palettes.ps1"
+} elseif (Get-Command bash -ErrorAction SilentlyContinue) {
+    & bash "$PSScriptRoot/scripts/setup-hooks.sh"
+    & bash "$PSScriptRoot/scripts/helpers/install_fonts.sh"
+    & bash "$PSScriptRoot/scripts/helpers/sync_palettes.sh"
+}
 
 if ($InstallWinget -and $IsWindows) {
     & "$PSScriptRoot/scripts/setup-winget.ps1"
@@ -41,4 +50,3 @@ if ($SetupDocker) {
         & bash "$PSScriptRoot/scripts/setup-docker.sh" @bashArgs
     }
 }
-

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,8 @@
 # Installation
 
 Follow these steps to set up the configuration files on a new system.
+The provided install scripts are lightweight wrappers that call shared helpers to
+install fonts, sync color palettes and configure Git hooks.
 For a fully automated setup run the OS-aware installer:
 
 ```bash
@@ -57,7 +59,8 @@ ruff check .
    ```
 2. Copy or symlink the files from this repository to your profile directory.
 3. From an elevated PowerShell window, run `bootstrap.ps1` (or call
-   `install.sh` from a regular shell) to set up your PATH. You must run the
+   `install.sh` from a regular shell) to set up your PATH. The script relies on
+   the shared helpers for fonts, palettes and Git hooks. You must run the
    PowerShell script from an **elevated** window so that
    `scripts/fix-path.ps1` can modify the user PATH.
    Pass the appropriate flags to install the core tools automatically. The
@@ -107,11 +110,12 @@ sudo bash scripts/setup-wsl.sh
    git clone https://github.com/d0tTino/d0tTino.git
    ```
 2. Use `stow` or your preferred method to symlink the dotfiles into place.
-3. Run `install.sh` to clean up your PATH:
+3. Run `install.sh` to clean up your PATH and install the shared resources:
    ```bash
    ./install.sh
    ```
-   If you prefer PowerShell, you can run `./bootstrap.ps1` instead.
+   If you prefer PowerShell, you can run `./bootstrap.ps1` instead which invokes
+   the same helper scripts.
 4. Launch a new shell to pick up the configuration.
 
 ## Local LLM tools

--- a/scripts/helpers/install_fonts.ps1
+++ b/scripts/helpers/install_fonts.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    & bash (Join-Path $PSScriptRoot 'install_fonts.sh')
+    return
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Error 'winget is required but not installed.'
+    exit 1
+}
+
+winget install --id NerdFonts.CaskaydiaCove -e --accept-source-agreements --accept-package-agreements

--- a/scripts/helpers/install_fonts.sh
+++ b/scripts/helpers/install_fonts.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_fonts_unix() {
+    url="https://github.com/ryanoasis/nerd-fonts/releases/latest/download/CaskaydiaCove.zip"
+    tmpdir="$(mktemp -d)"
+    curl -fsSL "$url" -o "$tmpdir/font.zip"
+    unzip -q "$tmpdir/font.zip" -d "$tmpdir"
+    font_dir="$HOME/.local/share/fonts"
+    mkdir -p "$font_dir"
+    mv "$tmpdir"/*.ttf "$font_dir/"
+    fc-cache -f "$font_dir"
+    rm -rf "$tmpdir"
+}
+
+install_fonts_windows() {
+    if command -v winget >/dev/null; then
+        winget install --id NerdFonts.CaskaydiaCove -e \
+            --accept-source-agreements --accept-package-agreements
+    else
+        echo "winget is required on Windows" >&2
+        exit 1
+    fi
+}
+
+case "$(uname -s)" in
+    Linux*|Darwin*) install_fonts_unix ;;
+    CYGWIN*|MINGW*|MSYS*|Windows_NT) install_fonts_windows ;;
+    *) echo "Unsupported OS" >&2; exit 1 ;;
+esac

--- a/scripts/helpers/sync_palettes.ps1
+++ b/scripts/helpers/sync_palettes.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$base = 'https://raw.githubusercontent.com/d0tTino/d0tTino/main/palettes'
+$dest = Join-Path $repoRoot 'palettes'
+if (-not (Test-Path $dest)) {
+    New-Item -ItemType Directory -Path $dest | Out-Null
+}
+foreach ($name in 'blacklight','dracula','solarized-dark') {
+    Invoke-WebRequest -Uri "$base/$name.toml" -OutFile (Join-Path $dest "$name.toml")
+}

--- a/scripts/helpers/sync_palettes.sh
+++ b/scripts/helpers/sync_palettes.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+base="https://raw.githubusercontent.com/d0tTino/d0tTino/main/palettes"
+mkdir -p "$repo_root/palettes"
+for name in blacklight dracula solarized-dark; do
+    curl -fsSL "$base/$name.toml" -o "$repo_root/palettes/$name.toml"
+done

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,24 +1,9 @@
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = Split-Path $PSScriptRoot -Parent
-
 if (-not $IsWindows) {
     & bash (Join-Path $PSScriptRoot 'install.sh')
     return
 }
 
-if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-    Write-Error 'winget is required but not installed.'
-    exit 1
-}
-
-winget install --id NerdFonts.CaskaydiaCove -e --accept-source-agreements --accept-package-agreements
-
-$base = 'https://raw.githubusercontent.com/d0tTino/d0tTino/main/palettes'
-$dest = Join-Path $repoRoot 'palettes'
-if (-not (Test-Path $dest)) {
-    New-Item -ItemType Directory -Path $dest | Out-Null
-}
-foreach ($name in 'blacklight','dracula','solarized-dark') {
-    Invoke-WebRequest -Uri "$base/$name.toml" -OutFile (Join-Path $dest "$name.toml")
-}
+& "$PSScriptRoot/helpers/install_fonts.ps1"
+& "$PSScriptRoot/helpers/sync_palettes.ps1"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,42 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-install_fonts_unix() {
-    url="https://github.com/ryanoasis/nerd-fonts/releases/latest/download/CaskaydiaCove.zip"
-    tmpdir="$(mktemp -d)"
-    curl -fsSL "$url" -o "$tmpdir/font.zip"
-    unzip -q "$tmpdir/font.zip" -d "$tmpdir"
-    font_dir="$HOME/.local/share/fonts"
-    mkdir -p "$font_dir"
-    mv "$tmpdir"/*.ttf "$font_dir/"
-    fc-cache -f "$font_dir"
-    rm -rf "$tmpdir"
-}
-
-install_fonts_windows() {
-    if command -v winget >/dev/null; then
-        winget install --id NerdFonts.CaskaydiaCove -e \
-            --accept-source-agreements --accept-package-agreements
-    else
-        echo "winget is required on Windows" >&2
-        exit 1
-    fi
-}
-
-pull_palettes() {
-    base="https://raw.githubusercontent.com/d0tTino/d0tTino/main/palettes"
-    mkdir -p "$repo_root/palettes"
-    for name in blacklight dracula solarized-dark; do
-        curl -fsSL "$base/$name.toml" -o "$repo_root/palettes/$name.toml"
-    done
-}
-
-case "$(uname -s)" in
-    Linux*|Darwin*) install_fonts_unix ;;
-    CYGWIN*|MINGW*|MSYS*|Windows_NT) install_fonts_windows ;;
-    *) echo "Unsupported OS" >&2; exit 1 ;;
-esac
-
-pull_palettes
+bash "$script_dir/helpers/install_fonts.sh"
+bash "$script_dir/helpers/sync_palettes.sh"

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -5,4 +5,5 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 scripts="$repo_root/scripts"
 
 bash "$scripts/setup-hooks.sh"
-bash "$scripts/install.sh"
+bash "$scripts/helpers/install_fonts.sh"
+bash "$scripts/helpers/sync_palettes.sh"

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -62,18 +62,34 @@ fi
     )
     path.chmod(0o755)
 
-
 def create_stub_install_common(path: Path, log: Path) -> None:
-    """Create an install_common.sh stub."""
+    """Create an install_common.sh stub along with helper stubs."""
+    helpers = path.parent / "helpers"
+    helpers.mkdir(exist_ok=True)
+    (helpers / "install_fonts.sh").write_text(
+        f"#!/usr/bin/env bash\nif [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then\n  echo install_fonts_windows >> '{log}'\nelse\n  echo install_fonts_unix >> '{log}'\nfi\n",
+        encoding="utf-8",
+    )
+    (helpers / "sync_palettes.sh").write_text(
+        f"#!/usr/bin/env bash\necho pull_palettes >> '{log}'\n",
+        encoding="utf-8",
+    )
+    (helpers / "install_fonts.ps1").write_text(
+        f"#!/usr/bin/env bash\necho install_fonts_windows >> '{log}'\n",
+        encoding="utf-8",
+    )
+    (helpers / "sync_palettes.ps1").write_text(
+        f"#!/usr/bin/env bash\necho pull_palettes >> '{log}'\n",
+        encoding="utf-8",
+    )
+    for f in helpers.iterdir():
+        f.chmod(0o755)
     path.write_text(
-        f"""#!/usr/bin/env bash
-echo install_common >> '{log}'
-bash \"$(dirname \"${{BASH_SOURCE[0]}}\")/setup-hooks.sh\"
-bash \"$(dirname \"${{BASH_SOURCE[0]}}\")/install.sh\"
-""",
+        f"#!/usr/bin/env bash\necho install_common >> '{log}'\nbash \"$(dirname \"${{BASH_SOURCE[0]}}\")/setup-hooks.sh\"\nbash \"$(dirname \"${{BASH_SOURCE[0]}}\")/helpers/install_fonts.sh\"\nbash \"$(dirname \"${{BASH_SOURCE[0]}}\")/helpers/sync_palettes.sh\"\n",
         encoding="utf-8",
     )
     path.chmod(0o755)
+
 
 
 def create_stub_install(path: Path, log: Path) -> None:


### PR DESCRIPTION
## Summary
- add install_fonts/sync_palettes helpers for bash and PowerShell
- call the new helpers from install scripts and bootstrap.ps1
- document unified workflow for helper-based setup
- update test stubs for helper scripts

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db5949d948326a0d441384a4828a9