### PR TITLE
Make backend plugin discovery explicit

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Dict
-import importlib
-import importlib.metadata
-import pkgutil
+
+from .loader import discover_plugins, load_backends
 
 from .base import Backend
 from .superclaude import SuperClaudeBackend as _RealSuperClaudeBackend
@@ -32,6 +31,7 @@ __all__ = [
     "get_backend",
     "clear_registry",
     "discover_plugins",
+    "load_backends",
     "available_backends",
     "GeminiBackend",
     "OllamaBackend",
@@ -71,38 +71,4 @@ def available_backends() -> list[str]:
     return sorted(_BACKEND_REGISTRY)
 
 
-def discover_plugins() -> None:
-    """Import backend plugins so they register themselves."""
-    package = f"{__name__}.plugins"
-    paths: list[str] = []
-    try:
-        pkg = importlib.import_module(package)
-        paths = list(pkg.__path__)
-    except Exception:  # pragma: no cover - plugins package missing
-        pass
-
-    for mod in pkgutil.iter_modules(paths):
-        name = f"{package}.{mod.name}"
-        try:
-            module = importlib.import_module(name)
-        except Exception:  # pragma: no cover - optional dependency missing
-            continue
-        for attr in getattr(module, "__all__", []):
-            globals()[attr] = getattr(module, attr)
-            if attr not in __all__:
-                __all__.append(attr)
-
-    for entry in importlib.metadata.entry_points().select(group="llm.plugins"):
-        try:
-            module = entry.load()
-        except Exception:  # pragma: no cover - optional dependency missing
-            continue
-        for attr in getattr(module, "__all__", []):
-            globals()[attr] = getattr(module, attr)
-            if attr not in __all__:
-                __all__.append(attr)
-
-
-# Discover plugins at import time
-discover_plugins()
 

--- a/llm/backends/loader.py
+++ b/llm/backends/loader.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import pkgutil
+
+import llm.backends as backends
+
+__all__ = ["discover_plugins", "load_backends"]
+
+
+def discover_plugins() -> None:
+    """Import backend plugins so they register themselves."""
+    package = f"{backends.__name__}.plugins"
+    paths: list[str] = []
+    try:
+        pkg = importlib.import_module(package)
+        paths = list(pkg.__path__)
+    except Exception:  # pragma: no cover - plugins package missing
+        pass
+
+    for mod in pkgutil.iter_modules(paths):
+        name = f"{package}.{mod.name}"
+        try:
+            module = importlib.import_module(name)
+        except Exception:  # pragma: no cover - optional dependency missing
+            continue
+        for attr in getattr(module, "__all__", []):
+            setattr(backends, attr, getattr(module, attr))
+            if attr not in backends.__all__:
+                backends.__all__.append(attr)
+
+    for entry in importlib.metadata.entry_points().select(group="llm.plugins"):
+        try:
+            module = entry.load()
+        except Exception:  # pragma: no cover - optional dependency missing
+            continue
+        for attr in getattr(module, "__all__", []):
+            setattr(backends, attr, getattr(module, attr))
+            if attr not in backends.__all__:
+                backends.__all__.append(attr)
+
+
+def load_backends() -> None:
+    """Convenience wrapper to import all available backends."""
+    discover_plugins()

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -10,9 +10,12 @@ from pathlib import Path
 from typing import List, Optional
 
 from llm import router
+from llm.backends import load_backends
 from scripts import ai_exec
 from scripts.cli_common import execute_steps, read_prompt, record_event
 import time
+
+load_backends()
 
 
 def _cmd_send(args: argparse.Namespace) -> int:

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -9,13 +9,14 @@ import sys
 
 
 from llm import router
-from llm.backends import available_backends
+from llm.backends import available_backends, load_backends
 
 DEFAULT_MODEL = router.DEFAULT_MODEL
 DEFAULT_PRIMARY_BACKEND = router.DEFAULT_PRIMARY_BACKEND
 DEFAULT_FALLBACK_BACKEND = router.DEFAULT_FALLBACK_BACKEND
 DEFAULT_COMPLEXITY_THRESHOLD = router.DEFAULT_COMPLEXITY_THRESHOLD
 
+load_backends()
 
 run_gemini = router.run_gemini
 run_ollama = router.run_ollama

--- a/tests/test_lmql_guidance_backends.py
+++ b/tests/test_lmql_guidance_backends.py
@@ -1,6 +1,9 @@
 import pytest
 
-from llm.backends import LMQLBackend, GuidanceBackend
+from llm import backends
+backends.load_backends()
+LMQLBackend = backends.LMQLBackend
+GuidanceBackend = backends.GuidanceBackend
 
 
 def test_lmql_backend_returns_string():

--- a/tests/test_openrouter_backend.py
+++ b/tests/test_openrouter_backend.py
@@ -2,8 +2,10 @@ import pytest
 
 pytest.importorskip("requests")
 
-from llm.backends import OpenRouterBackend
-from llm import router as ai_router
+from llm import backends, router as ai_router
+
+backends.load_backends()
+OpenRouterBackend = backends.OpenRouterBackend
 
 
 def test_openrouter_backend_makes_request(monkeypatch):

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -113,6 +113,7 @@ def test_backends_import_loads_entry_point_plugins(monkeypatch):
     monkeypatch.setattr(importlib.metadata, "import_module", fake_import)
 
     reloaded = importlib.reload(backends)
+    reloaded.load_backends()
 
     assert "dummy" in reloaded.available_backends()
     _reset_plugins()
@@ -134,6 +135,7 @@ def test_backends_import_skips_unknown_entry_points(monkeypatch):
     )
 
     reloaded = importlib.reload(backends)
+    reloaded.load_backends()
 
     assert "ghost" not in reloaded.available_backends()
     _reset_plugins()


### PR DESCRIPTION
## Summary
- add `load_backends()` helper to explicitly discover available LLM backends
- update CLI entrypoints to call `load_backends()` at startup
- move plugin discovery logic to new `llm.backends.loader` module
- adapt tests to load backends via the new API
- expose loader utilities via `__all__`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686db59524448326a8d4a4e4fb651c56