### PR TITLE
Add change-aware CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,53 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.check.outputs.code_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for code changes
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_PR: ${{ github.event.pull_request.base.sha }}
+          BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE="$BASE_PR"
+          else
+            BASE="$BEFORE"
+          fi
+          git fetch origin "$BASE" --depth=1 || true
+          only_docs_or_comments=true
+          for file in $(git diff --name-only "$BASE" "$HEAD_SHA"); do
+            if [[ "$file" =~ ^docs/ || "$file" =~ \.md$ ]]; then
+              continue
+            fi
+            diff_lines=$(git diff -U0 "$BASE" "$HEAD_SHA" -- "$file" | grep -E '^[+-]' | grep -vE '^\+\+\+|^---')
+            while IFS= read -r line; do
+              line="${line:1}"
+              trimmed="$(echo "$line" | sed 's/^\s*//')"
+              if [[ -z "$trimmed" || "$trimmed" =~ ^(#|//) ]]; then
+                continue
+              fi
+              only_docs_or_comments=false
+              break 2
+            done <<< "$diff_lines"
+          done
+          if [ "$only_docs_or_comments" = false ]; then
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   tests:
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -31,6 +77,8 @@ jobs:
         run: pytest -n auto
 
   extras-tests:
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,4 +94,3 @@ jobs:
         run: pip install -r requirements.txt
       - name: Run tests with extras
         run: pytest -n auto
-


### PR DESCRIPTION
## Summary
- add a job that checks for doc-only or comment-only updates
- skip testing jobs when no code changed
- keep using pip caching for faster runs

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_686dbe33f46c8326845003ff18a4e09e