### PR TITLE
Add palette function tests

### DIFF
--- a/tests/test_apply_palette.py
+++ b/tests/test_apply_palette.py
@@ -33,3 +33,66 @@ def test_apply_palette_updates_configs(tmp_path: Path) -> None:
     assert wt_data.get("profiles", {}).get("defaults", {}).get("colorScheme") == "Dracula"
     assert all(p.get("colorScheme") == "Dracula" for p in wt_data.get("profiles", {}).get("list", []))
     assert any(s.get("name") == "Dracula" for s in wt_data.get("schemes", []))
+
+
+def test_apply_palette_unknown_palette(tmp_path: Path) -> None:
+    pytest.importorskip("tomli_w")
+    repo_root = Path(__file__).resolve().parents[1]
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+    shutil.copy(repo_root / "starship.toml", dest / "starship.toml")
+    shutil.copy(repo_root / "windows-terminal" / "settings.json", dest / "windows-terminal" / "settings.json")
+    for p in (repo_root / "palettes").glob("*.toml"):
+        shutil.copy(p, dest / "palettes" / p.name)
+
+    with pytest.raises(FileNotFoundError):
+        apply_palette("missing", dest)
+
+
+def test_apply_palette_missing_key(tmp_path: Path) -> None:
+    pytest.importorskip("tomli_w")
+    repo_root = Path(__file__).resolve().parents[1]
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+    shutil.copy(repo_root / "starship.toml", dest / "starship.toml")
+    shutil.copy(repo_root / "windows-terminal" / "settings.json", dest / "windows-terminal" / "settings.json")
+    # create palette file with wrong key
+    (dest / "palettes" / "foo.toml").write_text("[bar]\nfoo='bar'\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        apply_palette("foo", dest)
+
+
+def test_apply_palette_missing_starship(tmp_path: Path) -> None:
+    pytest.importorskip("tomli_w")
+    repo_root = Path(__file__).resolve().parents[1]
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+    shutil.copy(repo_root / "windows-terminal" / "settings.json", dest / "windows-terminal" / "settings.json")
+    for p in (repo_root / "palettes").glob("*.toml"):
+        shutil.copy(p, dest / "palettes" / p.name)
+
+    with pytest.raises(SystemExit):
+        apply_palette("dracula", dest)
+
+
+def test_apply_palette_missing_wt_settings(tmp_path: Path) -> None:
+    pytest.importorskip("tomli_w")
+    repo_root = Path(__file__).resolve().parents[1]
+
+    dest = tmp_path / "repo"
+    (dest / "windows-terminal").mkdir(parents=True)
+    (dest / "palettes").mkdir()
+    shutil.copy(repo_root / "starship.toml", dest / "starship.toml")
+    for p in (repo_root / "palettes").glob("*.toml"):
+        shutil.copy(p, dest / "palettes" / p.name)
+
+    with pytest.raises(SystemExit):
+        apply_palette("dracula", dest)
+

--- a/tests/test_list_palettes.py
+++ b/tests/test_list_palettes.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import shutil
+
+from scripts.thm import list_palettes
+
+
+def test_list_palettes_outputs_names(tmp_path, capsys):
+    repo_root = Path(__file__).resolve().parents[1]
+    dest = tmp_path / "repo"
+    (dest / "palettes").mkdir(parents=True)
+    for p in (repo_root / "palettes").glob("*.toml"):
+        shutil.copy(p, dest / "palettes" / p.name)
+
+    list_palettes(dest)
+    output = capsys.readouterr().out.strip().splitlines()
+    assert "blacklight" in output
+    assert "dracula" in output
+


### PR DESCRIPTION
## Summary
- test available palettes listing
- test error paths for palette application

## Testing
- `ruff check tests/test_apply_palette.py tests/test_list_palettes.py`
- `pytest tests/test_apply_palette.py tests/test_list_palettes.py -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686dbe32f27083268dc0ec5b09dbe31e