### PR TITLE
Add jsonschema optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ cli = ["tomli_w"]
 lmql = ["lmql"]
 guidance = ["guidance"]
 etl = ["unstructured", "chromadb"]
+plugins = ["jsonschema"]
 
 [project.scripts]
 thm = "scripts.thm:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests
 httpx
 fastapi
 uvicorn
+jsonschema

--- a/scripts/nsm_stats.py
+++ b/scripts/nsm_stats.py
@@ -8,12 +8,12 @@ import os
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Any, Dict, Iterable
 
 import requests
 
 
-Event = Dict[str, object]
+Event = Dict[str, Any]
 
 
 def _read_lines(source: str) -> Iterable[str]:


### PR DESCRIPTION
## Summary
- include `jsonschema` as a new optional dependency under `plugins`
- add `jsonschema` to `requirements.txt`
- fix `scripts/nsm_stats.py` typing for mypy

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e77ea9e688326b3a308737eb8925f