### PR TITLE
Improve font install script and error logging

### DIFF
--- a/scripts/helpers/install_fonts.sh
+++ b/scripts/helpers/install_fonts.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 install_fonts_unix() {
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "install_fonts.sh: curl is required" >&2
+        exit 1
+    fi
+    if ! command -v unzip >/dev/null 2>&1; then
+        echo "install_fonts.sh: unzip is required" >&2
+        exit 1
+    fi
     url="https://github.com/ryanoasis/nerd-fonts/releases/latest/download/CaskaydiaCove.zip"
     tmpdir="$(mktemp -d)"
-    curl -fsSL "$url" -o "$tmpdir/font.zip"
+    curl --retry 5 -fsSL "$url" -o "$tmpdir/font.zip"
     unzip -q "$tmpdir/font.zip" -d "$tmpdir"
     font_dir="$HOME/.local/share/fonts"
     mkdir -p "$font_dir"

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -52,7 +52,11 @@ def load_registry() -> Dict[str, str]:
                 CACHE_PATH.write_text(json.dumps(data))
                 return {str(k): str(v) for k, v in data.items()}
         except requests.exceptions.RequestException as exc:
-            logger.warning("Failed to fetch plug-in registry from %s: %s", url, exc)
+            logger.warning(
+                "Failed to fetch plug-in registry from %s: %s. Using cached registry if available.",
+                url,
+                exc,
+            )
         except Exception:
             pass
 

--- a/tests/test_install_fonts.py
+++ b/tests/test_install_fonts.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def _run_script(env):
+    script = Path(__file__).resolve().parents[1] / "scripts" / "helpers" / "install_fonts.sh"
+    return subprocess.run([
+        "/bin/bash",
+        str(script)
+    ], env=env, capture_output=True, text=True)
+
+
+def test_missing_curl(tmp_path):
+    env = os.environ.copy()
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    (stub_bin / "bash").symlink_to("/bin/bash")
+    (stub_bin / "uname").write_text("#!/usr/bin/env bash\necho Linux\n")
+    (stub_bin / "uname").chmod(0o755)
+    env["PATH"] = str(stub_bin)
+    result = _run_script(env)
+    assert result.returncode
+    assert "curl is required" in result.stderr
+
+
+def test_missing_unzip(tmp_path):
+    env = os.environ.copy()
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    # provide curl but not unzip
+    (stub_bin / "bash").symlink_to("/bin/bash")
+    (stub_bin / "curl").symlink_to("/usr/bin/curl")
+    (stub_bin / "uname").write_text("#!/usr/bin/env bash\necho Linux\n")
+    (stub_bin / "uname").chmod(0o755)
+    env["PATH"] = str(stub_bin)
+    result = _run_script(env)
+    assert result.returncode
+    assert "unzip is required" in result.stderr

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -60,6 +60,7 @@ def test_load_registry_logs_warning(monkeypatch, tmp_path, caplog):
 
     assert registry == {"y": "pkg"}
     assert any("Failed to fetch" in r.message for r in caplog.records)
+    assert any("cached registry" in r.message for r in caplog.records)
 
 
 def test_load_registry_defaults_when_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- validate `curl` and `unzip` in install_fonts.sh
- retry downloads in font installation
- log network errors in plugin registry with advice to use the cache
- test plugin registry warnings
- test failures for missing font install tools

## Testing
- `ruff check .`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_686e77ebb03c83269e6a7cdf76df006a