### PR TITLE
Refactor installers

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -10,13 +10,9 @@ param(
 & "$PSScriptRoot/scripts/fix-path.ps1"
 
 if ($IsWindows) {
-    & "$PSScriptRoot/scripts/setup-hooks.ps1"
-    & "$PSScriptRoot/scripts/helpers/install_fonts.ps1"
-    & "$PSScriptRoot/scripts/helpers/sync_palettes.ps1"
+    & "$PSScriptRoot/scripts/helpers/install_common.ps1"
 } elseif (Get-Command bash -ErrorAction SilentlyContinue) {
-    & bash "$PSScriptRoot/scripts/setup-hooks.sh"
-    & bash "$PSScriptRoot/scripts/helpers/install_fonts.sh"
-    & bash "$PSScriptRoot/scripts/helpers/sync_palettes.sh"
+    & bash "$PSScriptRoot/scripts/install_common.sh"
 }
 
 if ($InstallWinget -and $IsWindows) {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,8 +1,9 @@
 # Installation
 
 Follow these steps to set up the configuration files on a new system.
-The provided install scripts are lightweight wrappers that call shared helpers to
-install fonts, sync color palettes and configure Git hooks.
+The provided install scripts are lightweight wrappers that call
+`scripts/install_common.sh` or `scripts/helpers/install_common.ps1` to install
+fonts, sync color palettes and configure Git hooks.
 For a fully automated setup run the OS-aware installer:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -57,9 +57,10 @@ run_pwsh() {
 
 if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
     run_pwsh fix-path.ps1
+    run_pwsh helpers/install_common.ps1
+else
+    bash "$scripts/install_common.sh"
 fi
-
-bash "$scripts/install_common.sh"
 
 if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
     if $install_winget; then run_pwsh setup-winget.ps1; fi

--- a/scripts/helpers/install_common.ps1
+++ b/scripts/helpers/install_common.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$scripts = Join-Path $repoRoot 'scripts'
+
+& "$scripts/setup-hooks.ps1"
+& "$scripts/helpers/install_fonts.ps1"
+& "$scripts/helpers/sync_palettes.ps1"

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -38,9 +38,16 @@ if [[ $base == bootstrap.ps1 ]]; then
     esac
   done
   echo fix-path.ps1 >> "$log_file"
-  echo install_common.sh >> "$log_file"
-  if [[ -f "$root/scripts/install_common.sh" ]]; then
-    /bin/bash "$root/scripts/install_common.sh"
+  if [[ $is_windows == 1 ]]; then
+    echo install_common.ps1 >> "$log_file"
+    if [[ -f "$root/scripts/helpers/install_common.ps1" ]]; then
+      /bin/bash "$root/scripts/helpers/install_common.ps1"
+    fi
+  else
+    echo install_common.sh >> "$log_file"
+    if [[ -f "$root/scripts/install_common.sh" ]]; then
+      /bin/bash "$root/scripts/install_common.sh"
+    fi
   fi
   if [[ $is_windows == 1 ]]; then
     $install_winget && echo setup-winget.ps1 >> "$log_file"
@@ -55,6 +62,9 @@ if [[ $base == bootstrap.ps1 ]]; then
   exit 0
 else
   echo "$base" >> "$log_file"
+  if [[ $base == install_common.ps1 ]]; then
+    /bin/bash "$file"
+  fi
   exit 0
 fi
 """,
@@ -80,6 +90,13 @@ def create_stub_install_common(path: Path, log: Path) -> None:
     )
     (helpers / "sync_palettes.ps1").write_text(
         f"#!/usr/bin/env bash\necho pull_palettes >> '{log}'\n",
+        encoding="utf-8",
+    )
+    (helpers / "install_common.ps1").write_text(
+        f"#!/usr/bin/env bash\necho install_common >> '{log}'\n"
+        "bash \"$(dirname \"${BASH_SOURCE[0]}\")/../setup-hooks.sh\"\n"
+        "bash \"$(dirname \"${BASH_SOURCE[0]}\")/install_fonts.sh\"\n"
+        "bash \"$(dirname \"${BASH_SOURCE[0]}\")/sync_palettes.sh\"\n",
         encoding="utf-8",
     )
     for f in helpers.iterdir():

--- a/tests/test_bootstrap_ps1.py
+++ b/tests/test_bootstrap_ps1.py
@@ -11,6 +11,7 @@ def test_bootstrap_sets_hooks_path(tmp_path: Path) -> None:
     repo.mkdir()
     shutil.copy(repo_root / "bootstrap.ps1", repo / "bootstrap.ps1")
     shutil.copytree(repo_root / "scripts", repo / "scripts")
+    create_stub_install_common(repo / "scripts" / "install_common.sh", tmp_path / "pwsh.log")
 
     stub_dir = tmp_path / "bin"
     stub_dir.mkdir()
@@ -72,7 +73,7 @@ def test_bootstrap_invokes_optional_scripts(tmp_path: Path) -> None:
         )
         lines = log_file.read_text().splitlines()
         assert "fix-path.ps1" in lines
-        assert "install_common.sh" in lines
+        assert "install_common.ps1" in lines
         assert expected in lines
 
 


### PR DESCRIPTION
## Summary
- create new PowerShell helper `install_common.ps1`
- call the helper from the main installers
- adapt stubs and tests for new helper
- document shared installer helpers

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `PYTHONPATH=. pytest tests/test_install_sh.py tests/test_bootstrap_ps1.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7cec9d948326ae85b02a9336a694