### PR TITLE
Add plug-in SDK and update docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,7 +1,7 @@
 # Writing a Backend Plug-in
 
 Third-party packages can add new LLM backends without modifying this repository.
-A plug-in must call `llm.backends.register_backend` when it is imported so the
+A plug-in must call `llm.backends.plugin_sdk.register_backend` when it is imported so the
 backend becomes available to the routing utilities.
 
 ## Required Entry Point
@@ -25,7 +25,7 @@ model name, returning the model's response as a string. The callable can be a
 function or a method of a `Backend` subclass.
 
 ```python
-from llm.backends import register_backend, Backend
+from llm.backends.plugin_sdk import Backend, register_backend
 
 class MyBackend(Backend):
     def run(self, prompt: str) -> str:
@@ -100,8 +100,16 @@ A recipe exposes a callable that matches the following interface:
 ```python
 from typing import List
 
+from llm.backends.plugin_sdk import register_recipe, Recipe
+
+class MyRecipe(Recipe):
+    def run(self, goal: str) -> List[str]:
+        return [f"echo {goal}"]
+
 def run(goal: str) -> List[str]:
-    ...
+    return MyRecipe().run(goal)
+
+register_recipe("my_recipe", run)
 ```
 
 Expose the callable via the `d0ttino.recipes` entry point group so the

--- a/llm/backends/plugin_sdk.py
+++ b/llm/backends/plugin_sdk.py
@@ -1,0 +1,52 @@
+"""SDK for writing llm and recipe plug-ins."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Dict, List
+
+from . import register_backend as _register_backend
+from .base import Backend
+
+BACKEND_ENTRYPOINT_GROUP = "llm.plugins"
+RECIPE_ENTRYPOINT_GROUP = "d0ttino.recipes"
+
+RecipeCallable = Callable[[str], List[str]]
+
+_RECIPE_REGISTRY: Dict[str, RecipeCallable] = {}
+
+
+class Recipe(ABC):
+    """Base class for automation recipes."""
+
+    @abstractmethod
+    def run(self, goal: str) -> List[str]:
+        """Return shell commands for ``goal``."""
+        raise NotImplementedError
+
+
+def register_backend(name: str, func: Callable[[str, str | None], str]) -> None:
+    """Register ``func`` under ``name`` for backend routing."""
+    _register_backend(name, func)
+
+
+def register_recipe(name: str, func: RecipeCallable) -> None:
+    """Register ``func`` under ``name`` for recipe discovery."""
+    _RECIPE_REGISTRY[name] = func
+
+
+def get_registered_recipes() -> Dict[str, RecipeCallable]:
+    """Return all recipes registered via :func:`register_recipe`."""
+    return dict(_RECIPE_REGISTRY)
+
+
+__all__ = [
+    "Backend",
+    "Recipe",
+    "BACKEND_ENTRYPOINT_GROUP",
+    "RECIPE_ENTRYPOINT_GROUP",
+    "register_backend",
+    "register_recipe",
+    "get_registered_recipes",
+]

--- a/llm/backends/plugins/gemini.py
+++ b/llm/backends/plugins/gemini.py
@@ -4,8 +4,7 @@ import subprocess
 
 from typing import Any, cast
 
-from .. import register_backend
-from ..base import Backend
+from ..plugin_sdk import Backend, register_backend
 
 GeminiDSPyBackend: type[Backend] | None
 try:  # pragma: no cover - optional dependency

--- a/llm/backends/plugins/gemini_dspy.py
+++ b/llm/backends/plugins/gemini_dspy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Mapping, cast
 
-from ..base import Backend
+from ..plugin_sdk import Backend
 
 try:  # pragma: no cover - optional dependency
     import dspy

--- a/llm/backends/plugins/guidance.py
+++ b/llm/backends/plugins/guidance.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from .. import register_backend
-from ..base import Backend
+from ..plugin_sdk import Backend, register_backend
 
 try:  # pragma: no cover - optional dependency
     import guidance  # noqa: F401

--- a/llm/backends/plugins/lmql.py
+++ b/llm/backends/plugins/lmql.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from .. import register_backend
-from ..base import Backend
+from ..plugin_sdk import Backend, register_backend
 
 LMQLBackend: type[Backend] | None = None
 

--- a/llm/backends/plugins/lobechat.py
+++ b/llm/backends/plugins/lobechat.py
@@ -5,8 +5,7 @@ from typing import Any, Mapping, cast
 
 import requests
 
-from .. import register_backend
-from ..base import Backend
+from ..plugin_sdk import Backend, register_backend
 
 
 DEFAULT_BASE_URL = "http://localhost:3210/api"

--- a/llm/backends/plugins/mindbridge.py
+++ b/llm/backends/plugins/mindbridge.py
@@ -5,8 +5,7 @@ from typing import Any, Mapping, cast
 
 import requests
 
-from .. import register_backend
-from ..base import Backend
+from ..plugin_sdk import Backend, register_backend
 
 DEFAULT_BASE_URL = "https://api.mindbridge.ai/v1"
 

--- a/llm/backends/plugins/ollama.py
+++ b/llm/backends/plugins/ollama.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import subprocess
 from typing import Any, cast
 
-from .. import register_backend
-from ..base import Backend
+from ..plugin_sdk import Backend, register_backend
 
 OllamaDSPyBackend: type[Backend] | None
 try:  # pragma: no cover - optional dependency

--- a/llm/backends/plugins/ollama_dspy.py
+++ b/llm/backends/plugins/ollama_dspy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Mapping, cast
 
-from ..base import Backend
+from ..plugin_sdk import Backend
 
 try:  # pragma: no cover - optional dependency
     import dspy

--- a/llm/backends/plugins/openrouter.py
+++ b/llm/backends/plugins/openrouter.py
@@ -5,8 +5,7 @@ from typing import Any, Mapping, cast
 
 import requests
 
-from .. import register_backend
-from ..base import Backend
+from ..plugin_sdk import Backend, register_backend
 
 OpenRouterDSPyBackend: type[Backend] | None
 try:  # pragma: no cover - optional dependency

--- a/llm/backends/plugins/openrouter_dspy.py
+++ b/llm/backends/plugins/openrouter_dspy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Mapping, cast
 
-from ..base import Backend
+from ..plugin_sdk import Backend
 
 try:  # pragma: no cover - optional dependency
     import dspy

--- a/llm/backends/plugins/sample.py
+++ b/llm/backends/plugins/sample.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from .. import register_backend
-from ..base import Backend
+from ..plugin_sdk import Backend, register_backend
 
 
 class SampleBackend(Backend):

--- a/scripts/recipes/plugins/sample.py
+++ b/scripts/recipes/plugins/sample.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 
 from typing import List
 
+from llm.backends.plugin_sdk import register_recipe
+
 
 def run(goal: str) -> List[str]:
     """Return a simple command echoing the goal."""
     return [f"echo {goal}"]
+
+register_recipe("sample", run)
 
 __all__ = ["run"]


### PR DESCRIPTION
## Summary
- implement `plugin_sdk` with Backend/Recipe base classes and registration helpers
- update built-in plug-ins to import from new SDK
- expose recipe registry and registration in loader
- document new plug-in interface

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7ced5480832690449f242e390d51