### PR TITLE
Add sample backend plugin packages

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -75,10 +75,25 @@ During development you can point `PLUGIN_REGISTRY_URL` at a JSON file
 containing your entry. The file must pass validation against
 `plugin-registry.schema.json`.
 
+Sample plug-in packages for the built-in backends are included under
+`examples/plugins`. Install them with:
+
+```bash
+python -m scripts.plugins install openrouter
+python -m scripts.plugins install lobechat
+python -m scripts.plugins install mindbridge
+```
+
 ## Built-in Backends
 
-`llm` includes HTTP clients for LobeChat and MindBridge. Set the following
-environment variables to configure them:
+`llm` includes HTTP clients for OpenRouter, LobeChat and MindBridge. Set the
+following environment variables to configure them:
+
+### OpenRouter
+
+- `OPENROUTER_API_KEY` – API token for the OpenRouter service.
+- `OPENROUTER_BASE_URL` – Override the service URL (default
+  `https://openrouter.ai/api/v1`).
 
 ### LobeChat
 

--- a/examples/plugins/lobechat/d0ttino_lobechat_plugin/__init__.py
+++ b/examples/plugins/lobechat/d0ttino_lobechat_plugin/__init__.py
@@ -1,0 +1,4 @@
+"""LobeChat backend plug-in."""
+from llm.backends.plugins import lobechat  # registers on import
+
+__all__ = ["lobechat"]

--- a/examples/plugins/lobechat/pyproject.toml
+++ b/examples/plugins/lobechat/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "d0ttino-lobechat-plugin"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."llm.plugins"]
+lobechat = "d0ttino_lobechat_plugin"

--- a/examples/plugins/mindbridge/d0ttino_mindbridge_plugin/__init__.py
+++ b/examples/plugins/mindbridge/d0ttino_mindbridge_plugin/__init__.py
@@ -1,0 +1,4 @@
+"""MindBridge backend plug-in."""
+from llm.backends.plugins import mindbridge  # registers on import
+
+__all__ = ["mindbridge"]

--- a/examples/plugins/mindbridge/pyproject.toml
+++ b/examples/plugins/mindbridge/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "d0ttino-mindbridge-plugin"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."llm.plugins"]
+mindbridge = "d0ttino_mindbridge_plugin"

--- a/examples/plugins/openrouter/d0ttino_openrouter_plugin/__init__.py
+++ b/examples/plugins/openrouter/d0ttino_openrouter_plugin/__init__.py
@@ -1,0 +1,4 @@
+"""OpenRouter backend plug-in."""
+from llm.backends.plugins import openrouter  # registers on import
+
+__all__ = ["openrouter"]

--- a/examples/plugins/openrouter/pyproject.toml
+++ b/examples/plugins/openrouter/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "d0ttino-openrouter-plugin"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."llm.plugins"]
+openrouter = "d0ttino_openrouter_plugin"

--- a/llm/backends/plugins/gemini.py
+++ b/llm/backends/plugins/gemini.py
@@ -37,8 +37,14 @@ class GeminiBackend(Backend):
 def run_gemini(prompt: str, model: str | None = None) -> str:
     """Return Gemini response for ``prompt``."""
 
-    backend_cls = GeminiDSPyBackend if GeminiDSPyBackend is not None else GeminiBackend
-    backend = cast(Any, backend_cls)(model)
+    if GeminiDSPyBackend is not None:
+        backend = cast(Any, GeminiDSPyBackend)(model)
+        try:
+            return backend.run(prompt)
+        except Exception:
+            pass
+
+    backend = GeminiBackend(model)
     return backend.run(prompt)
 
 

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -1,3 +1,6 @@
 {
-  "sample": "d0ttino-sample-plugin"
+  "sample": "d0ttino-sample-plugin",
+  "openrouter": "d0ttino-openrouter-plugin",
+  "lobechat": "d0ttino-lobechat-plugin",
+  "mindbridge": "d0ttino-mindbridge-plugin"
 }

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -27,6 +27,9 @@ except Exception:
 # cannot be loaded from the network or cache.
 PLUGIN_REGISTRY: Dict[str, str] = {
     "sample": "d0ttino-sample-plugin",
+    "openrouter": "d0ttino-openrouter-plugin",
+    "lobechat": "d0ttino-lobechat-plugin",
+    "mindbridge": "d0ttino-mindbridge-plugin",
 }
 
 # Cache file for the remote registry


### PR DESCRIPTION
## Summary
- add example packages for the OpenRouter, LobeChat and MindBridge backends
- register those packages in the fallback registry
- document installing the sample plugins and the new OpenRouter variables
- ensure gemini backend falls back to the CLI if DSPy fails

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_686e7fb8f1488326847ebbfe75d1a503