### PR TITLE
Enable opt-in telemetry with hashed developer ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,11 @@ The `pre-commit` hook runs the same checks automatically.
 
 ## Telemetry and Metrics
 
-When invoked with the `--analytics` flag, the CLI tools (`ai-do`, `ai-exec`, and
-the `ai-cli` subcommands `send`, `plan`, `do`) send a small JSON payload to the
-URL specified by `EVENTS_URL`. Each payload contains the following fields:
+When invoked with the `--analytics` flag or when the `EVENTS_ENABLED`
+environment variable is set to a truthy value, the CLI tools (`ai-do`,
+`ai-exec`, and the `ai-cli` subcommands `send`, `plan`, `do`) send a small JSON
+payload to the URL specified by `EVENTS_URL`. Each payload contains the
+following fields:
 
 - `name` – event type such as `ai-cli-plan` or `ai-do`
 - `goal` – the provided goal or prompt
@@ -220,17 +222,19 @@ CSV rows for each successful `ai-do` run per developer per ISO week.
 
 ## Privacy
 
-`ai-do`, `ai-exec`, and the `ai-cli` subcommands (`send`, `plan`, `do`) can send anonymous
-completion events when invoked with `--analytics`. The data is posted to the URL
-specified in the `EVENTS_URL` environment variable with optional authorization
-via `EVENTS_TOKEN`. No information is sent unless the flag is provided.
+`ai-do`, `ai-exec`, and the `ai-cli` subcommands (`send`, `plan`, `do`) can send
+anonymous completion events. Set `EVENTS_ENABLED=true` to opt in globally or use
+`--analytics` per invocation. A hashed developer UUID derived from the current
+user name is included with each payload. Events are posted to the URL specified
+in `EVENTS_URL` with optional authorization via `EVENTS_TOKEN`.
 
 Licensed under the [Apache 2.0](LICENSE) license.
 
 ## North Star Metric
 
 The project tracks “successful automated tasks per active developer per week” as
-its north star metric. Every time a command completes successfully with the
-[--analytics](scripts/ai_do.py#L20-L24) flag enabled, an event is posted to
-`EVENTS_URL` and counted toward the developer's weekly total. Aggregating these
-numbers highlights adoption trends and guides future automation work.
+its north star metric. Every time a command completes successfully with
+analytics enabled (via `--analytics` or `EVENTS_ENABLED=true`), an event is
+posted to `EVENTS_URL` and counted toward the developer's weekly total.
+Aggregating these numbers highlights adoption trends and guides future
+automation work.

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -12,7 +12,12 @@ from typing import List, Optional
 from llm import router
 from llm.ai_router import get_preferred_models
 from llm.backends import load_backends
-from scripts.cli_common import read_prompt, record_event, send_notification
+from scripts.cli_common import (
+    read_prompt,
+    record_event,
+    send_notification,
+    analytics_default,
+)
 import time
 
 load_backends()
@@ -58,6 +63,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="Record anonymous usage events",
     )
     args = parser.parse_args(argv)
+    args.analytics = getattr(args, "analytics", analytics_default())
     cfg_path = Path(args.config) if args.config else None
     goal = read_prompt(args.goal)
     steps = plan(goal, config_path=cfg_path, analytics=args.analytics)

--- a/scripts/nsm_stats.py
+++ b/scripts/nsm_stats.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Aggregate ai-do success counts per developer per week."""
+"""Aggregate ai-do success counts per developer per week.
+
+Usage examples::
+
+    # Read events from a local NDJSON file
+    python scripts/nsm_stats.py events.json
+
+    # Fetch events from the server defined in ``EVENTS_URL``
+    EVENTS_URL=https://example.com python scripts/nsm_stats.py
+"""
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- add `analytics_default()` and hashed developer IDs in telemetry events
- opt-in telemetry via `EVENTS_ENABLED` env var
- only send analytics for successful `ai-do` runs
- document telemetry env var usage and `nsm_stats.py` examples
- add tests for `analytics_default`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e7fb7637c83268d82b89cfcc347f8