### PR TITLE
Handle missing jsonschema in plug‑in manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ they are missing:
 ```bash
 pip install -e .[cli] -r requirements.txt
 ```
+The `jsonschema` package included in the `cli` extras is required for
+managing plug-ins with `python -m scripts.plugins`. You can also
+install it separately with:
+
+```bash
+pip install jsonschema
+```
 
 Run `ruff` to lint the Python code:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ test = [
     "uvicorn",
     "httpx",
 ]
-cli = ["tomli_w"]
+cli = ["tomli_w", "jsonschema"]
 lmql = ["lmql"]
 guidance = ["guidance"]
 etl = ["unstructured", "chromadb"]

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -104,3 +104,15 @@ def test_main_remove(monkeypatch, capsys, retcode):
     if retcode:
         assert "fail" in captured.err
 
+
+def test_main_warns_when_jsonschema_missing(monkeypatch, capsys):
+    monkeypatch.setitem(sys.modules, "jsonschema", None)
+    import importlib
+    reloaded = importlib.reload(plugins)
+    monkeypatch.setattr(reloaded, "load_registry", lambda: {"dummy": "pkg"})
+    monkeypatch.setattr(reloaded, "_is_installed", lambda p: False)
+    rc = reloaded.main(["list"])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "jsonschema is required" in out.err
+


### PR DESCRIPTION
## Summary
- ensure jsonschema is installed with the `cli` extras
- warn when running `scripts/plugins.py` without jsonschema
- document plug-in manager requirement
- add regression test for missing jsonschema
- clarify README instructions for installing jsonschema

## Testing
- `ruff check scripts/plugins.py tests/test_plugins_script.py`
- `pytest -k plugins_script -q`


------
https://chatgpt.com/codex/tasks/task_e_686e949996688326b72dbf3bac3b9ef4