### PR TITLE
Handle missing dependencies in install.sh

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,25 @@ Windows users can run the PowerShell variant:
 irm https://raw.githubusercontent.com/d0tTino/d0tTino/main/scripts/install.ps1 | iex
 ```
 
+## Prerequisites
+
+The install scripts rely on `curl`, `unzip` and `git`. On macOS these
+dependencies are installed automatically when [Homebrew](https://brew.sh)
+is available:
+
+```bash
+brew install curl unzip git
+```
+
+Debian based distributions use `apt-get` if present:
+
+```bash
+sudo apt-get install curl unzip git
+```
+
+If neither package manager is detected you'll need to install the tools
+manually before running the installer.
+
 
 ## Node.js
 

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 from tests.stubs import create_stub_install, create_stub_install_common, create_stub_pwsh
 
+
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
 def test_install_sh_creates_hooks_and_palettes(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     repo = tmp_path / "repo"
@@ -146,3 +151,85 @@ def test_install_sh_installs_nerd_font_linux(tmp_path: Path) -> None:
     assert "install_common" in lines
     assert "install_fonts_unix" in lines
     assert "pull_palettes" in lines
+
+
+def test_install_sh_installs_missing_deps_brew(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_brew"
+    repo.mkdir()
+    shutil.copy(repo_root / "install.sh", repo / "install.sh")
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+    install_log = tmp_path / "install_brew.log"
+    create_stub_install(repo / "scripts" / "install.sh", install_log)
+    create_stub_install_common(repo / "scripts" / "install_common.sh", install_log)
+    shutil.copytree(repo_root / ".githooks", repo / ".githooks")
+    shutil.copytree(repo_root / "palettes", repo / "palettes")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    brew_log = tmp_path / "brew.log"
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+    create_exe(
+        bin_dir / "brew",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{brew_log}'\nif [[ $1 == install ]]; then\n  shift\n  for pkg in \"$@\"; do\n    /bin/touch '{bin_dir}'/$pkg\n    /bin/chmod 755 '{bin_dir}'/$pkg\n  done\nfi\n",
+    )
+    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n\"$@\"\n")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+
+    env = os.environ.copy()
+    env.update({
+        "OSTYPE": "darwin",
+        "PATH": str(bin_dir),
+    })
+
+    subprocess.run(["/bin/bash", "install.sh"], cwd=repo, check=True, env=env)
+
+    lines = brew_log.read_text().splitlines()
+    assert any("install" in line for line in lines)
+    assert any("curl" in line for line in lines)
+    assert any("unzip" in line for line in lines)
+    assert any("git" in line for line in lines)
+    assert "install_common" in install_log.read_text().splitlines()
+
+
+def test_install_sh_installs_missing_deps_apt(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_apt"
+    repo.mkdir()
+    shutil.copy(repo_root / "install.sh", repo / "install.sh")
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+    install_log = tmp_path / "install_apt.log"
+    create_stub_install(repo / "scripts" / "install.sh", install_log)
+    create_stub_install_common(repo / "scripts" / "install_common.sh", install_log)
+    shutil.copytree(repo_root / ".githooks", repo / ".githooks")
+    shutil.copytree(repo_root / "palettes", repo / "palettes")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    apt_log = tmp_path / "apt.log"
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+    create_exe(
+        bin_dir / "apt-get",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{apt_log}'\nif [[ $1 == install ]]; then\n  shift\n  for pkg in \"$@\"; do\n    /bin/touch '{bin_dir}'/$pkg\n    /bin/chmod 755 '{bin_dir}'/$pkg\n  done\nfi\n",
+    )
+    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n\"$@\"\n")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+
+    env = os.environ.copy()
+    env.update({
+        "OSTYPE": "linux-gnu",
+        "PATH": str(bin_dir),
+    })
+
+    subprocess.run(["/bin/bash", "install.sh"], cwd=repo, check=True, env=env)
+
+    lines = apt_log.read_text().splitlines()
+    assert any("install" in line for line in lines)
+    assert any("curl" in line for line in lines)
+    assert any("unzip" in line for line in lines)
+    assert any("git" in line for line in lines)
+    assert "install_common" in install_log.read_text().splitlines()


### PR DESCRIPTION
## Summary
- install missing dependencies using brew or apt-get in `install.sh`
- document prerequisite tools
- test Homebrew and apt-get dependency installs

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f08e2a8cc8326b94b952d4cd29531