### PR TITLE
Add recipe execution subcommand

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -136,3 +136,13 @@ my_recipe = "my_package.recipes:run"
 ```
 
 See `scripts/recipes/plugins/sample.py` for a simple example.
+
+## Running a Recipe
+
+Use the ``ai-cli recipe`` subcommand to execute a named recipe. The command
+loads available recipes via ``discover_recipes()`` and runs the shell commands
+it returns interactively.
+
+```bash
+ai-cli recipe sample "Show my goal"
+```

--- a/llm/backends/plugins/gemini.py
+++ b/llm/backends/plugins/gemini.py
@@ -37,6 +37,7 @@ class GeminiBackend(Backend):
 def run_gemini(prompt: str, model: str | None = None) -> str:
     """Return Gemini response for ``prompt``."""
 
+    backend_cls: type[Backend]
     if shutil.which("gemini"):
         backend_cls = GeminiBackend
     elif GeminiDSPyBackend is not None:

--- a/llm/backends/plugins/guidance.py
+++ b/llm/backends/plugins/guidance.py
@@ -22,10 +22,10 @@ class GuidanceBackend(Backend):
         return f"guidance:{prompt}:{self.model}"
 
 
-def run_guidance(prompt: str, model: str) -> str:
+def run_guidance(prompt: str, model: str | None = None) -> str:
     """Return response using ``guidance`` backend."""
 
-    backend = cast(Any, GuidanceBackend)(model)
+    backend = cast(Any, GuidanceBackend)(model or "")
     return backend.run(prompt)
 
 

--- a/llm/backends/plugins/lmql.py
+++ b/llm/backends/plugins/lmql.py
@@ -27,10 +27,10 @@ else:  # pragma: no cover - optional dependency missing
 
 
 
-def run_lmql(prompt: str, model: str) -> str:
+def run_lmql(prompt: str, model: str | None = None) -> str:
     """Return response using ``lmql`` backend."""
 
-    backend = cast(Any, LMQLBackend)(model)
+    backend = cast(Any, LMQLBackend)(model or "")
     return backend.run(prompt)
 
 

--- a/llm/backends/plugins/lobechat.py
+++ b/llm/backends/plugins/lobechat.py
@@ -50,10 +50,10 @@ class LobeChatBackend(Backend):
         return _extract_text(data)
 
 
-def run_lobechat(prompt: str, model: str) -> str:
+def run_lobechat(prompt: str, model: str | None = None) -> str:
     """Return LobeChat response for ``prompt`` using ``model``."""
 
-    backend = cast(Any, LobeChatBackend)(model)
+    backend = cast(Any, LobeChatBackend)(model or "")
     return backend.run(prompt)
 
 

--- a/llm/backends/plugins/mindbridge.py
+++ b/llm/backends/plugins/mindbridge.py
@@ -49,10 +49,10 @@ class MindBridgeBackend(Backend):
         return _extract_text(data)
 
 
-def run_mindbridge(prompt: str, model: str) -> str:
+def run_mindbridge(prompt: str, model: str | None = None) -> str:
     """Return MindBridge response for ``prompt`` using ``model``."""
 
-    backend = cast(Any, MindBridgeBackend)(model)
+    backend = cast(Any, MindBridgeBackend)(model or "")
     return backend.run(prompt)
 
 

--- a/llm/backends/plugins/ollama.py
+++ b/llm/backends/plugins/ollama.py
@@ -30,11 +30,11 @@ class OllamaBackend(Backend):
         return result.stdout
 
 
-def run_ollama(prompt: str, model: str) -> str:
+def run_ollama(prompt: str, model: str | None = None) -> str:
     """Return Ollama response for ``prompt`` using ``model``."""
 
     backend_cls = OllamaDSPyBackend if OllamaDSPyBackend is not None else OllamaBackend
-    backend = cast(Any, backend_cls)(model)
+    backend = cast(Any, backend_cls)(model or "")
     return backend.run(prompt)
 
 

--- a/llm/backends/plugins/openrouter.py
+++ b/llm/backends/plugins/openrouter.py
@@ -59,13 +59,13 @@ class OpenRouterBackend(Backend):
         return _extract_text(data)
 
 
-def run_openrouter(prompt: str, model: str) -> str:
+def run_openrouter(prompt: str, model: str | None = None) -> str:
     """Return OpenRouter response for ``prompt`` using ``model``."""
 
     backend_cls = (
         OpenRouterDSPyBackend if OpenRouterDSPyBackend is not None else OpenRouterBackend
     )
-    backend = cast(Any, backend_cls)(model)
+    backend = cast(Any, backend_cls)(model or "")
     return backend.run(prompt)
 
 


### PR DESCRIPTION
## Summary
- add `recipe` subcommand for `ai-cli`
- support running recipes programmatically via `ai_do.run_recipe`
- validate plugin registry when jsonschema isn't installed
- make backend plugins accept an optional model name

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f08e1db54832692d67589e90ed1e5