### PR TITLE
Add recipe plug‑in registry support

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -43,7 +43,7 @@ See `llm/backends/plugins/sample.py` for a full example.
 
 ## Managing Plug-ins
 
-Use the `plugins` helper to install or remove third-party backends.
+Use the `plugins` helper to install or remove third-party backends and recipes.
 
 ```bash
 # List available plug-ins
@@ -56,11 +56,20 @@ python -m scripts.plugins install sample
 python -m scripts.plugins remove sample
 ```
 
+Recipe packages are managed via the `recipes` subcommand:
+
+```bash
+python -m scripts.plugins recipes list
+python -m scripts.plugins recipes install echo
+python -m scripts.plugins recipes remove echo
+```
+
 ### Adding Your Plug-in
 
 Plug-ins listed by the helper come from a small registry file. Update
 `plugin-registry.json` in this repository with your plug-in name and the pip
-package that provides it. The file must conform to
+package that provides it. Recipe packages go under the `recipes` section.
+The file must conform to
 [plugin-registry.schema.json](../plugin-registry.schema.json).
 
 Example entry:
@@ -68,6 +77,16 @@ Example entry:
 ```json
 {
   "my_backend": "my-package"
+}
+```
+
+Add recipe packages under the `recipes` key:
+
+```json
+{
+  "recipes": {
+    "my_recipe": "my-recipe-package"
+  }
 }
 ```
 
@@ -82,6 +101,7 @@ Sample plug-in packages for the built-in backends are included under
 python -m scripts.plugins install openrouter
 python -m scripts.plugins install lobechat
 python -m scripts.plugins install mindbridge
+python -m scripts.plugins recipes install echo
 ```
 
 ## Built-in Backends

--- a/examples/plugins/echo_recipe/d0ttino_echo_recipe/__init__.py
+++ b/examples/plugins/echo_recipe/d0ttino_echo_recipe/__init__.py
@@ -1,0 +1,10 @@
+"""Echo recipe plug-in."""
+from llm.backends.plugin_sdk import register_recipe
+
+def run(goal: str):
+    """Return a command that echoes the goal."""
+    return [f"echo {goal}"]
+
+register_recipe("echo", run)
+
+__all__ = ["run"]

--- a/examples/plugins/echo_recipe/pyproject.toml
+++ b/examples/plugins/echo_recipe/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "d0ttino-echo-recipe"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."d0ttino.recipes"]
+echo = "d0ttino_echo_recipe:run"

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -1,6 +1,11 @@
 {
-  "sample": "d0ttino-sample-plugin",
-  "openrouter": "d0ttino-openrouter-plugin",
-  "lobechat": "d0ttino-lobechat-plugin",
-  "mindbridge": "d0ttino-mindbridge-plugin"
+  "plugins": {
+    "sample": "d0ttino-sample-plugin",
+    "openrouter": "d0ttino-openrouter-plugin",
+    "lobechat": "d0ttino-lobechat-plugin",
+    "mindbridge": "d0ttino-mindbridge-plugin"
+  },
+  "recipes": {
+    "echo": "d0ttino-echo-recipe"
+  }
 }

--- a/plugin-registry.schema.json
+++ b/plugin-registry.schema.json
@@ -2,10 +2,23 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/d0ttino/plugin-registry.schema.json",
   "title": "d0tTino Plug-in Registry",
-  "description": "Mapping of plug-in names to pip packages.",
+  "description": "Mapping of plug-in and recipe names to pip packages.",
   "type": "object",
-  "additionalProperties": {
-    "type": "string",
-    "description": "Name of the pip package containing the plug-in"
-  }
+  "properties": {
+    "plugins": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "description": "Name of the pip package containing the plug-in"
+      }
+    },
+    "recipes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "description": "Name of the pip package containing the recipe"
+      }
+    }
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- add new `recipes` section to plugin-registry and schema
- create example `echo` recipe package
- extend `scripts/plugins.py` to manage recipe packages
- update docs for recipe workflow
- add tests for new behaviour

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f14b6dafc832691246c9a8c35c9b8