### PR TITLE
Clarify plugin helper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,17 @@ Guidance backends. Tests that rely on these packages will be skipped if
 they are missing:
 
 ```bash
-pip install -e .[cli] -r requirements.txt
+pip install -e .[cli,plugins] -r requirements.txt
 ```
-The `jsonschema` package included in the `cli` extras is required for
-managing plug-ins with `python -m scripts.plugins`. You can also
-install it separately with:
+The `[plugins]` extra installs `jsonschema` so you can manage plug-ins
+with `python -m scripts.plugins`. For example:
+
+```bash
+python -m scripts.plugins install openrouter
+```
+
+See the [backend plug-in guide](docs/plugins.md) for details. If you
+prefer not to install the extras, install `jsonschema` separately with:
 
 ```bash
 pip install jsonschema

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -33,7 +33,8 @@ Third-party packages may add new backends by exposing an entry point in the
 ``llm.plugins`` group. A plug-in module should import
 ``llm.backends.register_backend`` and call it when loaded.
 
-See [plugins.md](plugins.md) for a full template and interface description.
+See the [backend plug-in guide](plugins.md) for a full template and interface
+description.
 
 Example ``pyproject.toml`` snippet:
 
@@ -41,6 +42,13 @@ Example ``pyproject.toml`` snippet:
 [project.entry-points."llm.plugins"]
 my_backend = "my_package.plugins:backend"
 ```
+
+Install a community backend using the helper. For example:
+
+```bash
+python -m scripts.plugins install openrouter
+```
+
 
 ## LLM Routing CLI
 


### PR DESCRIPTION
## Summary
- mention `[plugins]` extra in README quickstart
- show a sample plug-in installation command
- reference the plug-in guide from the automation docs

## Testing
- `pytest -q`
- `ruff check .`
- `mypy --install-types --non-interactive`


------
https://chatgpt.com/codex/tasks/task_e_686f14baacc883269bfa1a3c6686f72f