### PR TITLE
Improve command parsing in execute_steps

### DIFF
--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -26,8 +26,13 @@ def execute_steps(steps: Iterable[str], *, log_path: Path) -> int:
         answer = input(f"{i}. {step} [y/N]?").strip().lower()
         if answer != "y":
             continue
-        tokens = shlex.split(step)
-        needs_shell = any(ch in step for ch in "|&;><$`")
+        try:
+            tokens = shlex.split(step)
+        except ValueError:
+            tokens = []
+            needs_shell = True
+        else:
+            needs_shell = any(ch in step for ch in "|&;><$`") or shlex.join(tokens) != step
         cmd = step if needs_shell else tokens
         cmd_str = step if needs_shell else " ".join(tokens)
         answer = input(f"Run command: {cmd_str} [y/N]?").strip().lower()


### PR DESCRIPTION
## Summary
- robustly determine when to invoke the shell in `execute_steps`
- test quoted arguments and fallback behaviour

## Testing
- `ruff check scripts/cli_common.py tests/test_cli_common.py`
- `pytest -q tests/test_cli_common.py::test_execute_steps_parses_quoted_args tests/test_cli_common.py::test_execute_steps_fallbacks_to_shell`

------
https://chatgpt.com/codex/tasks/task_e_68703fd569c48326a945fcb10a1bfc80