### PR TITLE
Add iter_entry_points helper

### DIFF
--- a/llm/backends/loader.py
+++ b/llm/backends/loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib
-import importlib.metadata
+from plugins.discovery import iter_entry_points
 import pkgutil
 
 import llm.backends as backends
@@ -30,7 +30,7 @@ def discover_plugins() -> None:
             if attr not in backends.__all__:
                 backends.__all__.append(attr)
 
-    for entry in importlib.metadata.entry_points().select(group="llm.plugins"):
+    for entry in iter_entry_points("llm.plugins"):
         try:
             module = entry.load()
         except Exception:  # pragma: no cover - optional dependency missing

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for plug-in discovery."""
+
+from .discovery import iter_entry_points
+
+__all__ = ["iter_entry_points"]

--- a/plugins/discovery.py
+++ b/plugins/discovery.py
@@ -1,0 +1,22 @@
+"""Discovery utilities for plug-in entry points."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from importlib.metadata import EntryPoint
+from collections.abc import Iterator
+
+__all__ = ["iter_entry_points"]
+
+
+def iter_entry_points(group: str) -> Iterator[EntryPoint]:
+    """Yield entry points from ``group`` supporting multiple Python versions."""
+    eps = importlib.metadata.entry_points()
+    if hasattr(eps, "select"):
+        yield from eps.select(group=group)
+    elif isinstance(eps, dict):
+        yield from eps.get(group, ())
+    else:
+        for ep in eps:
+            if getattr(ep, "group", None) == group:
+                yield ep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ sample = "scripts.recipes.plugins.sample:run"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["llm*", "scripts*"]
+include = ["llm*", "scripts*", "plugins*"]
 
 [tool.ruff]
-src = ["llm", "scripts"]
+src = ["llm", "scripts", "plugins"]

--- a/scripts/recipes/__init__.py
+++ b/scripts/recipes/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import importlib
-import importlib.metadata
+from plugins.discovery import iter_entry_points
 import pkgutil
 from collections.abc import Callable
 from typing import Dict, List
@@ -41,7 +41,7 @@ def discover_recipes() -> Dict[str, Recipe]:
         if callable(func):
             recipes.setdefault(mod.name, func)
 
-    for entry in importlib.metadata.entry_points().select(group=RECIPE_ENTRYPOINT_GROUP):
+    for entry in iter_entry_points(RECIPE_ENTRYPOINT_GROUP):
         try:
             func = entry.load()
         except Exception:  # pragma: no cover - optional dependency missing

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -69,9 +69,9 @@ def test_discover_plugins_loads_entry_points(monkeypatch):
     )
 
     monkeypatch.setattr(
-        importlib.metadata,
-        "entry_points",
-        lambda: importlib.metadata.EntryPoints((entry,)),
+        backends.loader,
+        "iter_entry_points",
+        lambda group: iter([entry]),
     )
 
     backends.discover_plugins()
@@ -106,9 +106,9 @@ def test_backends_import_loads_entry_point_plugins(monkeypatch):
         return original_import(name, package)
 
     monkeypatch.setattr(
-        importlib.metadata,
-        "entry_points",
-        lambda: importlib.metadata.EntryPoints((entry,)),
+        backends.loader,
+        "iter_entry_points",
+        lambda group: iter([entry]),
     )
     monkeypatch.setattr(importlib.metadata, "import_module", fake_import)
 
@@ -129,9 +129,9 @@ def test_backends_import_skips_unknown_entry_points(monkeypatch):
     )
 
     monkeypatch.setattr(
-        importlib.metadata,
-        "entry_points",
-        lambda: importlib.metadata.EntryPoints((entry,)),
+        backends.loader,
+        "iter_entry_points",
+        lambda group: iter([entry]),
     )
 
     reloaded = importlib.reload(backends)

--- a/tests/test_recipe_plugins.py
+++ b/tests/test_recipe_plugins.py
@@ -27,9 +27,9 @@ def test_discover_recipes_loads_entry_points(monkeypatch):
     )
 
     monkeypatch.setattr(
-        importlib.metadata,
-        "entry_points",
-        lambda: importlib.metadata.EntryPoints((entry,)),
+        recipes,
+        "iter_entry_points",
+        lambda group: iter([entry]),
     )
 
     mapping = recipes.discover_recipes()


### PR DESCRIPTION
## Summary
- implement `plugins.iter_entry_points`
- refactor backend and recipe plugin loaders to use helper
- update tests for new entry point helper
- expose new package in project metadata
- drop unused imports in loaders

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687042ee84c88326a981ad3da5dbdcf7