### PR TITLE
Implement remote plug-in registry

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -66,11 +66,15 @@ python -m scripts.plugins recipes remove echo
 
 ### Adding Your Plug-in
 
-Plug-ins listed by the helper come from a small registry file. Update
-`plugin-registry.json` in this repository with your plug-in name and the pip
-package that provides it. Recipe packages go under the `recipes` section.
+Plug-ins listed by the helper come from a remote registry. Submit a pull
+request updating
+[plugin-registry.json](../plugin-registry.json) with your plug-in name and the
+pip package that provides it. Recipe packages go under the `recipes` section.
 The file must conform to
-[plugin-registry.schema.json](../plugin-registry.schema.json).
+[plugin-registry.schema.json](../plugin-registry.schema.json). The CLI fetches
+this file from `https://raw.githubusercontent.com/d0tTino/d0tTino/main/plugin-registry.json`
+and caches it in `~/.cache/d0ttino/plugin_registry.json`. Override the URL with
+`PLUGIN_REGISTRY_URL` during development to test your own registry.
 
 Example entry:
 


### PR DESCRIPTION
## Summary
- fetch plug-in registry from a configurable URL
- cache registry data in `~/.cache/d0ttino`
- default to hosted registry when URL is unset
- document remote registry usage and registration process
- update tests for new behavior

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870482aa6d0832682d4fc030f7c00ff