### PR TITLE
Add recipe sync command

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -62,6 +62,7 @@ Recipe packages are managed via the `recipes` subcommand:
 python -m scripts.plugins recipes list
 python -m scripts.plugins recipes install echo
 python -m scripts.plugins recipes remove echo
+python -m scripts.plugins recipes sync
 ```
 
 ### Adding Your Plug-in

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -44,6 +44,9 @@ RECIPE_REGISTRY: Dict[str, str] = {
     "echo": "d0ttino-echo-recipe",
 }
 
+# Default directory for recipe packages downloaded via ``recipes sync``
+RECIPE_DOWNLOAD_DIR = Path(__file__).resolve().parent / "recipes" / "packages"
+
 # Cache file for the remote registry
 CACHE_PATH = Path.home() / ".cache" / "d0ttino" / "plugin_registry.json"
 
@@ -196,6 +199,35 @@ def _cmd_remove_recipes(args: argparse.Namespace) -> int:
     return _cmd_remove_impl(args, "recipes")
 
 
+def _cmd_sync_recipes(args: argparse.Namespace) -> int:
+    """Download recipe packages listed in the registry."""
+    registry = load_registry("recipes")
+    dest = Path(args.dest) if args.dest else RECIPE_DOWNLOAD_DIR
+    dest.mkdir(parents=True, exist_ok=True)
+    for pkg in registry.values():
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "download",
+                    "--no-deps",
+                    "-d",
+                    str(dest),
+                    pkg,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            if exc.stderr:
+                print(exc.stderr, file=sys.stderr, end="")
+            return exc.returncode
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -224,6 +256,15 @@ def build_parser() -> argparse.ArgumentParser:
     r_remove = recipe_sub.add_parser("remove", help="Remove a recipe")
     r_remove.add_argument("name", help="Recipe name")
     r_remove.set_defaults(func=_cmd_remove_recipes)
+
+    r_sync = recipe_sub.add_parser(
+        "sync", help="Download recipe packages from the registry"
+    )
+    r_sync.add_argument(
+        "--dest",
+        help="Directory to store downloaded packages",
+    )
+    r_sync.set_defaults(func=_cmd_sync_recipes)
 
     return parser
 


### PR DESCRIPTION
## Summary
- extend `scripts/plugins.py` with a `recipes sync` subcommand
- document the new command in `docs/plugins.md`
- test downloading recipe packages in `tests/test_plugins_script.py`

## Testing
- `ruff check scripts/plugins.py tests/test_plugins_script.py`
- `pytest -q tests/test_plugins_script.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870482b3e988326b5296739cd3e8da7