### PR TITLE
Add bootstrap helper script test

### DIFF
--- a/tests/test_bootstrap_ps1.py
+++ b/tests/test_bootstrap_ps1.py
@@ -77,6 +77,44 @@ def test_bootstrap_invokes_optional_scripts(tmp_path: Path) -> None:
         assert expected in lines
 
 
+def test_bootstrap_invokes_helper_scripts(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_helpers"
+    repo.mkdir()
+    shutil.copy(repo_root / "bootstrap.ps1", repo / "bootstrap.ps1")
+    shutil.copytree(repo_root / "scripts", repo / "scripts")
+
+    log_file = tmp_path / "pwsh.log"
+    create_stub_install_common(repo / "scripts" / "install_common.sh", log_file)
+
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    create_stub_pwsh(stub_dir / "pwsh", log_file)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{stub_dir}:{env['PATH']}",
+            "PWSH_LOG": str(log_file),
+            "STUB_IS_WINDOWS": "1",
+            "OSTYPE": "msys",
+        }
+    )
+
+    subprocess.run(
+        ["pwsh", "-NoLogo", "-NoProfile", "-File", str(repo / "bootstrap.ps1"), "-InstallWinget"],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+
+    lines = log_file.read_text().splitlines()
+    assert "install_common" in lines
+    assert "install_fonts_windows" in lines
+    assert "pull_palettes" in lines
+    assert "setup-winget.ps1" in lines
+
+
 def test_bootstrap_setup_docker(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary
- ensure bootstrap.ps1 executes helper scripts when installing winget

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest tests/test_bootstrap_ps1.py::test_bootstrap_invokes_helper_scripts`

------
https://chatgpt.com/codex/tasks/task_e_6870482ee9e08326a96c3d555b70d016