### PR TITLE
Define default registry URL constant

### DIFF
--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -47,6 +47,9 @@ RECIPE_REGISTRY: Dict[str, str] = {
 # Default directory for recipe packages downloaded via ``recipes sync``
 RECIPE_DOWNLOAD_DIR = Path(__file__).resolve().parent / "recipes" / "packages"
 
+# Default URL for downloading the plug-in registry
+DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/d0tTino/d0tTino/main/plugin-registry.json"
+
 
 # Cache file for the remote registry
 CACHE_PATH = Path.home() / ".cache" / "d0ttino" / "plugin_registry.json"

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -5,6 +5,10 @@ import logging
 from scripts import plugins
 
 
+def test_default_registry_url_constant_exists():
+    assert isinstance(plugins.DEFAULT_REGISTRY_URL, str)
+
+
 def test_load_registry_fetches_and_caches(monkeypatch, tmp_path):
     cached = tmp_path / "cache.json"
     monkeypatch.setattr(plugins, "CACHE_PATH", cached)


### PR DESCRIPTION
## Summary
- add `DEFAULT_REGISTRY_URL` constant in `scripts/plugins.py`
- ensure the constant exists in plugin registry tests

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870636f49d883269204d7cc9b4b7011