### PR TITLE
Handle pre-planned recipe steps

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -85,9 +85,14 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
     if args.name not in mapping:
         print(f"Unknown recipe: {args.name}", file=sys.stderr)
         return 1
-    steps = mapping[args.name](args.goal)
+    recipe_func = mapping[args.name]
+    steps = recipe_func(args.goal)
     exit_code = ai_do.run_recipe(
-        args.name, args.goal, log_path=args.log, analytics=args.analytics
+        args.name,
+        args.goal,
+        steps,
+        log_path=args.log,
+        analytics=args.analytics,
     )
     end = time.time()
     if exit_code == 0:

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -167,9 +167,10 @@ def test_recipe_subcommand(monkeypatch, tmp_path):
     )
     captured = {}
 
-    def fake_run_recipe(name, goal, *, log_path, analytics=False):
+    def fake_run_recipe(name, goal, steps, *, log_path, analytics=False):
         captured["name"] = name
         captured["goal"] = goal
+        captured["steps"] = steps
         captured["log"] = log_path
         captured["analytics"] = analytics
         return 0
@@ -180,6 +181,7 @@ def test_recipe_subcommand(monkeypatch, tmp_path):
     assert rc == 0
     assert captured["name"] == "dummy"
     assert captured["goal"] == "goal"
+    assert captured["steps"] == ["echo goal"]
     assert captured["log"] == log
 
 


### PR DESCRIPTION
## Summary
- let `ai_do.run_recipe` accept precomputed steps
- pass those steps from `_cmd_recipe`
- update CLI tests for new parameter

## Testing
- `ruff check scripts/ai_do.py scripts/ai_cli.py tests/test_ai_cli.py`
- `pytest -k "ai_cli or ai_do" -q`

------
https://chatgpt.com/codex/tasks/task_e_687063721004832692dd65d0c8b87626