### PR TITLE
Add unified plugin entry point discovery helper

### DIFF
--- a/llm/backends/loader.py
+++ b/llm/backends/loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib
-from plugins.discovery import iter_entry_points
+from plugins.utils import discover_entry_points
 import pkgutil
 
 import llm.backends as backends
@@ -30,7 +30,7 @@ def discover_plugins() -> None:
             if attr not in backends.__all__:
                 backends.__all__.append(attr)
 
-    for entry in iter_entry_points("llm.plugins"):
+    for entry in discover_entry_points("llm.plugins"):
         try:
             module = entry.load()
         except Exception:  # pragma: no cover - optional dependency missing

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers for plug-in discovery."""
 
-from .discovery import iter_entry_points
+from .utils import discover_entry_points
 
-__all__ = ["iter_entry_points"]
+__all__ = ["discover_entry_points"]

--- a/plugins/utils.py
+++ b/plugins/utils.py
@@ -1,0 +1,22 @@
+"""Utility for discovering entry point plugins."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from importlib.metadata import EntryPoint
+from collections.abc import Iterator
+
+__all__ = ["discover_entry_points"]
+
+
+def discover_entry_points(group: str) -> Iterator[EntryPoint]:
+    """Yield entry points from ``group`` supporting multiple Python versions."""
+    eps = importlib.metadata.entry_points()
+    if hasattr(eps, "select"):
+        yield from eps.select(group=group)
+    elif isinstance(eps, dict):
+        yield from eps.get(group, ())
+    else:
+        for ep in eps:
+            if getattr(ep, "group", None) == group:
+                yield ep

--- a/scripts/recipes/__init__.py
+++ b/scripts/recipes/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import importlib
-from plugins.discovery import iter_entry_points
+from plugins.utils import discover_entry_points
 import pkgutil
 from collections.abc import Callable
 from typing import Dict, List
@@ -41,7 +41,7 @@ def discover_recipes() -> Dict[str, Recipe]:
         if callable(func):
             recipes.setdefault(mod.name, func)
 
-    for entry in iter_entry_points(RECIPE_ENTRYPOINT_GROUP):
+    for entry in discover_entry_points(RECIPE_ENTRYPOINT_GROUP):
         try:
             func = entry.load()
         except Exception:  # pragma: no cover - optional dependency missing

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -5,6 +5,7 @@ import types
 import pytest
 
 from llm import backends
+from plugins.utils import discover_entry_points  # noqa: F401
 
 
 def _reset_plugins():
@@ -70,7 +71,7 @@ def test_discover_plugins_loads_entry_points(monkeypatch):
 
     monkeypatch.setattr(
         backends.loader,
-        "iter_entry_points",
+        "discover_entry_points",
         lambda group: iter([entry]),
     )
 
@@ -107,7 +108,7 @@ def test_backends_import_loads_entry_point_plugins(monkeypatch):
 
     monkeypatch.setattr(
         backends.loader,
-        "iter_entry_points",
+        "discover_entry_points",
         lambda group: iter([entry]),
     )
     monkeypatch.setattr(importlib.metadata, "import_module", fake_import)
@@ -130,7 +131,7 @@ def test_backends_import_skips_unknown_entry_points(monkeypatch):
 
     monkeypatch.setattr(
         backends.loader,
-        "iter_entry_points",
+        "discover_entry_points",
         lambda group: iter([entry]),
     )
 

--- a/tests/test_recipe_plugins.py
+++ b/tests/test_recipe_plugins.py
@@ -4,6 +4,7 @@ import sys
 import types
 
 from scripts import recipes
+from plugins.utils import discover_entry_points  # noqa: F401
 
 
 def test_discover_recipes_finds_builtin_sample():
@@ -28,7 +29,7 @@ def test_discover_recipes_loads_entry_points(monkeypatch):
 
     monkeypatch.setattr(
         recipes,
-        "iter_entry_points",
+        "discover_entry_points",
         lambda group: iter([entry]),
     )
 


### PR DESCRIPTION
## Summary
- add `plugins/utils.py` with a new `discover_entry_points` helper
- use the helper in backend and recipe plugin loaders
- update tests to patch `discover_entry_points`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870680d73888326b2e610573dcecac0