### PR TITLE
Fix OSTYPE handling

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,6 +71,9 @@ ruff check .
 
 ## Windows
 
+> Required tools: **PowerShell**, **curl**, **git** and **unzip**. The
+> script uses **winget** for package management when available.
+
 1. Install packages using `winget`. You can either import the full package list
    or run the provided helper script for the essentials:
    ```powershell
@@ -96,6 +99,10 @@ ruff check .
 4. Restart the terminal or run `. $PROFILE` to reload the profile and load the new settings.
 
 ## WSL
+
+> Required tools: **curl**, **git**, **unzip** and `sudo`. The helper
+> scripts rely on `winget` on the Windows side or `apt-get` inside Ubuntu
+> to install packages.
 
 Before installing packages in Ubuntu, enable the required Windows features and
 install WSL:
@@ -125,6 +132,10 @@ sudo bash scripts/setup-wsl.sh
 ```
 
 ## Linux / macOS
+
+> Required tools: **bash**, **curl**, **git**, and **unzip**. Homebrew or
+> a compatible package manager should be available to install missing
+> dependencies automatically.
 
 1. Clone the repository:
    ```bash

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -6,11 +6,17 @@ scripts="$repo_root/scripts"
 
 # Determine the platform when OSTYPE is not provided
 if [[ -z "${OSTYPE:-}" ]]; then
-    OSTYPE="$(uname -s | tr '[:upper:]' '[:lower:]')"
-    case $OSTYPE in
-        mingw*) OSTYPE="msys" ;;
-    esac
+    OSTYPE="$(uname -s)"
 fi
+
+# Normalize Windows variants and lower-case the final value
+case $OSTYPE in
+    CYGWIN*|cygwin*) OSTYPE="cygwin" ;;
+    MINGW*|mingw*|MSYS*|msys*) OSTYPE="msys" ;;
+    Windows_NT*) OSTYPE="windows" ;;
+esac
+
+OSTYPE="${OSTYPE,,}"
 
 ensure_deps() {
     local missing=()

--- a/tests/test_install_common.py
+++ b/tests/test_install_common.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def test_install_common_runs_without_ostype(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    scripts_dir = repo / "scripts"
+    helpers_dir = scripts_dir / "helpers"
+    helpers_dir.mkdir(parents=True)
+
+    shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+
+    log = tmp_path / "install.log"
+    (scripts_dir / "setup-hooks.sh").write_text(
+        f"#!/usr/bin/env bash\necho setup_hooks >> '{log}'\n", encoding="utf-8"
+    )
+    (helpers_dir / "install_fonts.sh").write_text(
+        f"#!/usr/bin/env bash\necho install_fonts >> '{log}'\n", encoding="utf-8"
+    )
+    (helpers_dir / "sync_palettes.sh").write_text(
+        f"#!/usr/bin/env bash\necho sync_palettes >> '{log}'\n", encoding="utf-8"
+    )
+
+    for f in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
+        f.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("OSTYPE", None)
+
+    subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
+
+    lines = log.read_text().splitlines()
+    assert "setup_hooks" in lines
+    assert "install_fonts" in lines
+    assert "sync_palettes" in lines


### PR DESCRIPTION
## Summary
- handle missing OSTYPE in `install_common.sh`
- note platform requirements in installation docs
- test install_common.sh when OSTYPE is unset

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pip install -e .[test]`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870680e5e20832682e709129a146f89