### PR TITLE
Add dry-run checks and recipe plugin test

### DIFF
--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,0 +1,23 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+# Test syntax check (dry run) for install_common.sh using bash -n
+
+def test_install_common_sh_dry_run() -> None:
+    script = Path('scripts/install_common.sh')
+    subprocess.run(['/bin/bash', '-n', str(script)], check=True)
+
+
+# Test syntax check for install.ps1 using PowerShell parser
+@pytest.mark.skipif(shutil.which('pwsh') is None and shutil.which('powershell') is None,
+                    reason='requires PowerShell')
+def test_install_ps1_dry_run() -> None:
+    pwsh = shutil.which('pwsh') or shutil.which('powershell')
+    script = Path('scripts/install.ps1').resolve()
+    command = f"[System.Management.Automation.Language.Parser]::ParseFile('{script}',[ref]\$null,[ref]\$null) | Out-Null"
+    subprocess.run([pwsh, '-NoLogo', '-NoProfile', '-Command', command], check=True)


### PR DESCRIPTION
## Summary
- ensure `install_common.sh` parses by running `bash -n`
- ensure `install.ps1` parses using the PowerShell parser
- test that `ai_cli recipe` runs a plugin once and logs output

## Testing
- `ruff check tests/test_install_scripts.py tests/test_ai_cli.py`
- `pytest -q tests/test_install_scripts.py tests/test_ai_cli.py::test_recipe_executes_plugin_once_and_logs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706bfd767c8326b1323f1154b1b4c4