### PR TITLE
Add type hints to utility scripts

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .ai_router import get_preferred_models as _get_preferred_models  # noqa: F401
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> object:
     if name == "get_preferred_models":
         from .ai_router import get_preferred_models as _get_preferred_models
 

--- a/llm/etl.py
+++ b/llm/etl.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Sequence
+from typing import Any, List, Sequence
 
 
 __all__ = [
@@ -51,7 +51,12 @@ def store_embeddings(
     return collection
 
 
-def register_retrieval_nodes(graph, collection, *, node_name: str = "retrieve"):
+def register_retrieval_nodes(
+    graph: Any,
+    collection: Any,
+    *,
+    node_name: str = "retrieve",
+) -> Any:
     """Register retrieval nodes on ``graph`` for ``collection`` using LangGraph."""
     try:
         from langgraph.prebuilt import retrieval

--- a/llm/router.py
+++ b/llm/router.py
@@ -93,7 +93,7 @@ def create_default_chain() -> object:
     if os.environ.get("OPENAI_API_KEY") is None:
 
         class DummyChain:
-            def invoke(self, _data):
+            def invoke(self, _data: object) -> str:
                 return "ok"
 
         return DummyChain()

--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -123,7 +123,7 @@ class LoggedFewShotWrapper(dspy.Module):
         self.__dict__.clear()
         self.__dict__.update(new_instance.__dict__)
 
-    def forward(self, **inputs):
+    def forward(self, **inputs: object) -> object:
         prediction = self.compiled(**inputs)
         serialisable_output = (
             prediction.as_dict() if hasattr(prediction, "as_dict") else str(prediction)

--- a/scripts/n8n_generate.py
+++ b/scripts/n8n_generate.py
@@ -16,7 +16,7 @@ DEFAULT_PROMPT = (
 )
 
 
-def generate(prompt: str) -> dict:
+def generate(prompt: str) -> dict[str, object]:
     """Return parsed workflow JSON for ``prompt``."""
     text = router.send_prompt(prompt)
     return json.loads(text)

--- a/scripts/thm.py
+++ b/scripts/thm.py
@@ -19,7 +19,7 @@ REPO_ROOT = Path(os.environ.get("THM_REPO_ROOT", Path(__file__).resolve().parent
 PALETTES_DIR = REPO_ROOT / "palettes"
 
 
-def load_palette(palette_path: Path) -> dict:
+def load_palette(palette_path: Path) -> dict[str, dict[str, str]]:
     """Load and return the palette dict from ``palette_path``."""
     with palette_path.open("rb") as f:
         return tomllib.load(f)

--- a/windows-terminal/generate_settings.py
+++ b/windows-terminal/generate_settings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import argparse
 
 
-def load_json(path: Path) -> dict:
+def load_json(path: Path) -> dict[str, object]:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as ex:
@@ -14,7 +14,7 @@ def load_json(path: Path) -> dict:
         sys.exit(1)
 
 
-def merge_profiles(common: dict, override: dict) -> dict:
+def merge_profiles(common: dict[str, object], override: dict[str, object]) -> dict[str, object]:
     result = {
         "defaults": {
             **common.get("defaults", {}),


### PR DESCRIPTION
## Summary
- specify dictionary return types in helper scripts
- install requests for testing

## Testing
- `pytest -q`
- `ruff check .`
- `mypy --install-types --non-interactive`


------
https://chatgpt.com/codex/tasks/task_e_68706bfdecb083269a5a18e5e2ddd5aa