### PR TITLE
Ensure httpx installed for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ pwsh -File scripts/export-winget.ps1
 
 ## Testing
 
-Before running the Python tests locally, install this repository in editable
-mode first and then install the rest of the dependencies:
+Install this repository in editable mode with the `[test]` extras to ensure
+`fastapi.testclient` and other utilities are available:
 
 ```bash
-pip install -e .[cli]
+pip install -e .[test]
 pip install -r requirements.txt
 # Optional: install `dspy` to run the complete suite
 pip install dspy-ai

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,6 +1,7 @@
 import pytest
 
 pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 import importlib
 import os

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Summary
- skip tests if httpx is missing
- mention `[test]` extras for installation in README
- fix ruff lint error in tests

## Testing
- `pip install -e .[test]`
- `pytest -q`
- `ruff check .`
- `mypy --install-types --non-interactive`


------
https://chatgpt.com/codex/tasks/task_e_6871425e55d88326bfac28d267a6b063