### PR TITLE
Refactor plugin CLI with explicit backends command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `[plugins]` extra installs `jsonschema` so you can manage plug-ins
 with `python -m scripts.plugins`. For example:
 
 ```bash
-python -m scripts.plugins install openrouter
+python -m scripts.plugins backends install openrouter
 ```
 
 See the [backend plug-in guide](docs/plugins.md) for details. If you

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -46,7 +46,7 @@ my_backend = "my_package.plugins:backend"
 Install a community backend using the helper. For example:
 
 ```bash
-python -m scripts.plugins install openrouter
+python -m scripts.plugins backends install openrouter
 ```
 
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,13 +47,13 @@ Use the `plugins` helper to install or remove third-party backends and recipes.
 
 ```bash
 # List available plug-ins
-python -m scripts.plugins list
+python -m scripts.plugins backends list
 
 # Install a plug-in
-python -m scripts.plugins install sample
+python -m scripts.plugins backends install sample
 
 # Remove a plug-in
-python -m scripts.plugins remove sample
+python -m scripts.plugins backends remove sample
 ```
 
 Recipe packages are managed via the `recipes` subcommand:
@@ -115,16 +115,16 @@ Alternatively set `PLUGIN_REGISTRY_URL` to the local registry file and
 use the helper script to install them:
 
 ```bash
-PLUGIN_REGISTRY_URL=plugin-registry.json python -m scripts.plugins install openrouter
+PLUGIN_REGISTRY_URL=plugin-registry.json python -m scripts.plugins backends install openrouter
 ```
 
 You can also use the helper script to install them from the
 registry:
 
 ```bash
-python -m scripts.plugins install openrouter
-python -m scripts.plugins install lobechat
-python -m scripts.plugins install mindbridge
+python -m scripts.plugins backends install openrouter
+python -m scripts.plugins backends install lobechat
+python -m scripts.plugins backends install mindbridge
 python -m scripts.plugins recipes install echo
 ```
 

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Manage LLM backend plug-ins."""
+"""Manage LLM backend and recipe plug-ins."""
 
 from __future__ import annotations
 
@@ -136,7 +136,7 @@ def _cmd_list_impl(section: str) -> int:
     return 0
 
 
-def _cmd_list(args: argparse.Namespace) -> int:
+def _cmd_list_backends(args: argparse.Namespace) -> int:
     return _cmd_list_impl("plugins")
 
 
@@ -161,7 +161,7 @@ def _cmd_install_impl(args: argparse.Namespace, section: str) -> int:
         return e.returncode
 
 
-def _cmd_install(args: argparse.Namespace) -> int:
+def _cmd_install_backend(args: argparse.Namespace) -> int:
     return _cmd_install_impl(args, "plugins")
 
 
@@ -186,7 +186,7 @@ def _cmd_remove_impl(args: argparse.Namespace, section: str) -> int:
         return e.returncode
 
 
-def _cmd_remove(args: argparse.Namespace) -> int:
+def _cmd_remove_backend(args: argparse.Namespace) -> int:
     return _cmd_remove_impl(args, "plugins")
 
 
@@ -235,16 +235,19 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 
-    list_cmd = sub.add_parser("list", help="List available plug-ins")
-    list_cmd.set_defaults(func=_cmd_list)
+    backends = sub.add_parser("backends", help="Manage backend plug-ins")
+    backend_sub = backends.add_subparsers(dest="backend_command", required=True)
 
-    install_cmd = sub.add_parser("install", help="Install a plug-in")
-    install_cmd.add_argument("name", help="Plug-in name")
-    install_cmd.set_defaults(func=_cmd_install)
+    b_list = backend_sub.add_parser("list", help="List available backends")
+    b_list.set_defaults(func=_cmd_list_backends)
 
-    remove_cmd = sub.add_parser("remove", help="Remove a plug-in")
-    remove_cmd.add_argument("name", help="Plug-in name")
-    remove_cmd.set_defaults(func=_cmd_remove)
+    b_install = backend_sub.add_parser("install", help="Install a backend")
+    b_install.add_argument("name", help="Backend name")
+    b_install.set_defaults(func=_cmd_install_backend)
+
+    b_remove = backend_sub.add_parser("remove", help="Remove a backend")
+    b_remove.add_argument("name", help="Backend name")
+    b_remove.set_defaults(func=_cmd_remove_backend)
 
     recipe = sub.add_parser("recipes", help="Manage recipe plug-ins")
     recipe_sub = recipe.add_subparsers(dest="recipe_command", required=True)

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -8,7 +8,7 @@ def test_list_outputs_available_plugins(monkeypatch, capsys):
         plugins, "load_registry", lambda section="plugins": {"dummy": "dummy-pkg"}
     )
     monkeypatch.setattr(plugins, "_is_installed", lambda p: False)
-    rc = plugins.main(["list"])
+    rc = plugins.main(["backends", "list"])
     captured = capsys.readouterr().out
     assert rc == 0
     assert "dummy" in captured
@@ -26,7 +26,7 @@ def test_install_runs_pip(monkeypatch):
     monkeypatch.setattr(
         plugins, "load_registry", lambda section="plugins": {"dummy": "dummy-pkg"}
     )
-    rc = plugins.main(["install", "dummy"])
+    rc = plugins.main(["backends", "install", "dummy"])
     assert rc == 0
     assert called["cmd"][0] == sys.executable
     assert "dummy-pkg" in called["cmd"]
@@ -51,7 +51,7 @@ def test_remove_runs_pip(monkeypatch):
     monkeypatch.setattr(
         plugins, "load_registry", lambda section="plugins": {"dummy": "dummy-pkg"}
     )
-    rc = plugins.main(["remove", "dummy"])
+    rc = plugins.main(["backends", "remove", "dummy"])
     assert rc == 0
     assert called["cmd"][0] == sys.executable
     assert "dummy-pkg" in called["cmd"]
@@ -70,7 +70,7 @@ def test_install_failure_propagates(monkeypatch, capsys):
     monkeypatch.setattr(
         plugins, "load_registry", lambda section="plugins": {"dummy": "dummy-pkg"}
     )
-    rc = plugins.main(["install", "dummy"])
+    rc = plugins.main(["backends", "install", "dummy"])
     captured = capsys.readouterr()
     assert rc == 5
     assert "fail" in captured.err
@@ -84,7 +84,7 @@ def test_remove_failure_propagates(monkeypatch, capsys):
     monkeypatch.setattr(
         plugins, "load_registry", lambda section="plugins": {"dummy": "dummy-pkg"}
     )
-    rc = plugins.main(["remove", "dummy"])
+    rc = plugins.main(["backends", "remove", "dummy"])
     captured = capsys.readouterr()
     assert rc == 3
     assert "boom" in captured.err
@@ -108,7 +108,7 @@ def test_main_remove(monkeypatch, capsys, retcode):
     monkeypatch.setattr(
         plugins, "load_registry", lambda section="plugins": {"dummy": "dummy-pkg"}
     )
-    rc = plugins.main(["remove", "dummy"])
+    rc = plugins.main(["backends", "remove", "dummy"])
     captured = capsys.readouterr()
     assert called["cmd"][0] == sys.executable
     assert "dummy-pkg" in called["cmd"]
@@ -125,7 +125,7 @@ def test_main_warns_when_jsonschema_missing(monkeypatch, capsys):
         reloaded, "load_registry", lambda section="plugins": {"dummy": "pkg"}
     )
     monkeypatch.setattr(reloaded, "_is_installed", lambda p: False)
-    rc = reloaded.main(["list"])
+    rc = reloaded.main(["backends", "list"])
     out = capsys.readouterr()
     assert rc == 0
     assert "jsonschema is required" in out.err


### PR DESCRIPTION
## Summary
- handle backend commands under their own functions
- register `backends` subparser in `build_parser`
- update docs and tests for new `plugins backends` CLI
- clarify plugin helper module docstring

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871c5a5fd2c8326a925811118c85ec6