### PR TITLE
Add nsm_upload script

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -44,3 +44,16 @@ or service key for `EVENTS_URL` and `EVENTS_TOKEN`.
 
 With `EVENTS_URL` and `EVENTS_TOKEN` set, enable analytics globally by exporting
 `EVENTS_ENABLED=true` or pass `--analytics` to individual commands.
+
+## Upload Aggregated Statistics
+
+Use `nsm_upload.py` to compute weekly totals and send them to `EVENTS_URL`:
+
+```bash
+python scripts/nsm_upload.py events.json
+```
+
+Provide a path or URL with raw NDJSON events. The script aggregates successful
+`ai-do` runs per developer using `nsm_stats.aggregate_successful_runs()` and
+posts the resulting JSON to `EVENTS_URL`. Authentication via `EVENTS_TOKEN` is
+supported just like `record_event`.

--- a/scripts/nsm_upload.py
+++ b/scripts/nsm_upload.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Upload aggregated north star metric statistics."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Iterable
+
+import requests
+
+from . import nsm_stats
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "source",
+        nargs="?",
+        default=os.environ.get("EVENTS_URL"),
+        help="EVENTS_URL or path to local file",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if not args.source:
+        parser.error("source or EVENTS_URL required")
+
+    events = list(nsm_stats.iter_events(args.source))
+    counts = nsm_stats.aggregate_successful_runs(events)
+
+    url = os.environ.get("EVENTS_URL")
+    if not url:
+        parser.error("EVENTS_URL required for upload")
+    token = os.environ.get("EVENTS_TOKEN")
+    headers = {}
+    if token:
+        headers["apikey"] = token
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        requests.post(url, headers=headers, json=counts, timeout=10)
+    except Exception as exc:
+        print(f"failed to post stats: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_nsm_upload.py
+++ b/tests/test_nsm_upload.py
@@ -1,0 +1,40 @@
+from scripts import nsm_upload, nsm_stats
+
+
+def test_nsm_upload_posts_counts(monkeypatch):
+    events = [
+        {"name": "ai-do", "exit_code": 0, "developer": "alice", "end_ts": 1693516800},
+        {"name": "ai-do", "exit_code": 0, "developer": "bob", "end_ts": 1693603200},
+    ]
+    monkeypatch.setattr(nsm_upload.nsm_stats, "iter_events", lambda src: iter(events))
+
+    sent = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        sent["url"] = url
+        sent["headers"] = headers
+        sent["json"] = json
+
+    monkeypatch.setattr(nsm_upload.requests, "post", fake_post)
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    monkeypatch.setenv("EVENTS_TOKEN", "tok")
+
+    rc = nsm_upload.main(["dummy.json"])
+    expected = nsm_stats.aggregate_successful_runs(events)
+
+    assert rc == 0
+    assert sent["url"] == "https://example.com"
+    assert sent["json"] == expected
+    assert sent["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_nsm_upload_handles_error(monkeypatch):
+    monkeypatch.setattr(nsm_upload.nsm_stats, "iter_events", lambda src: iter(()))
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(nsm_upload.requests, "post", fake_post)
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    rc = nsm_upload.main(["dummy.json"])
+    assert rc == 1


### PR DESCRIPTION
## Summary
- add `scripts/nsm_upload.py` for posting weekly stats
- document aggregated stats upload in telemetry docs
- test payload formatting and error handling

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q tests/test_nsm_upload.py tests/test_nsm_stats.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d2f753448326ada83965accc3216