### PR TITLE
Implement recipe sync with install support

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -65,6 +65,9 @@ python -m scripts.plugins recipes remove echo
 python -m scripts.plugins recipes sync
 ```
 
+`recipes sync` downloads and installs the recipe packages listed in the
+registry into `scripts/recipes/packages` so they can be used offline.
+
 ### Adding Your Plug-in
 
 Plug-ins listed by the helper come from a remote registry. Submit a pull

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -6,6 +6,6 @@
     "mindbridge": "d0ttino-mindbridge-plugin"
   },
   "recipes": {
-    "echo": "d0ttino-echo-recipe"
+    "echo": "https://example.com/packages/d0ttino-echo-recipe.tar.gz"
   }
 }

--- a/plugin-registry.schema.json
+++ b/plugin-registry.schema.json
@@ -16,7 +16,8 @@
       "type": "object",
       "additionalProperties": {
         "type": "string",
-        "description": "Name of the pip package containing the recipe"
+        "format": "uri",
+        "description": "URL to the pip package containing the recipe"
       }
     }
   },

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -203,7 +203,7 @@ def _cmd_remove_recipes(args: argparse.Namespace) -> int:
 
 
 def _cmd_sync_recipes(args: argparse.Namespace) -> int:
-    """Download recipe packages listed in the registry."""
+    """Install recipe packages listed in the registry."""
     registry = load_registry("recipes")
     dest = Path(args.dest) if args.dest else RECIPE_DOWNLOAD_DIR
     dest.mkdir(parents=True, exist_ok=True)
@@ -214,9 +214,9 @@ def _cmd_sync_recipes(args: argparse.Namespace) -> int:
                     sys.executable,
                     "-m",
                     "pip",
-                    "download",
+                    "install",
                     "--no-deps",
-                    "-d",
+                    "--target",
                     str(dest),
                     pkg,
                 ],
@@ -264,11 +264,11 @@ def build_parser() -> argparse.ArgumentParser:
     r_remove.set_defaults(func=_cmd_remove_recipes)
 
     r_sync = recipe_sub.add_parser(
-        "sync", help="Download recipe packages from the registry"
+        "sync", help="Download and install recipe packages from the registry"
     )
     r_sync.add_argument(
         "--dest",
-        help="Directory to store downloaded packages",
+        help="Directory to install downloaded packages",
     )
     r_sync.set_defaults(func=_cmd_sync_recipes)
 

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -212,12 +212,17 @@ def test_recipe_sync(monkeypatch, tmp_path):
     rc = plugins.main(["recipes", "sync", "--dest", str(tmp_path)])
     assert rc == 0
     assert called
+    assert "install" in called[0]
+    assert "--target" in called[0]
     assert str(tmp_path) in called[0]
     assert "pkg" in called[0]
 
 
 def test_recipe_sync_failure(monkeypatch, tmp_path, capsys):
+    called = []
+
     def fake_run(cmd, *a, **k):
+        called.append(cmd)
         raise plugins.subprocess.CalledProcessError(2, cmd, stderr="err\n")
 
     def fake_load(section="plugins"):
@@ -232,4 +237,7 @@ def test_recipe_sync_failure(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     assert rc == 2
     assert "err" in captured.err
+    assert called
+    assert "install" in called[0]
+    assert "--target" in called[0]
 


### PR DESCRIPTION
## Summary
- expand plugin registry schema for recipe URLs
- store a sample recipe package URL in `plugin-registry.json`
- install recipe packages with `recipes sync`
- document the new sync behavior
- update tests for recipe syncing

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d2f5e5788326b67fc7e91f3d13f9