### PR TITLE
Add tauri test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ __pycache__/
 node_modules/
 *.egg-info/
 .env
+src-tauri/target/
+src-tauri/Cargo.lock

--- a/src-tauri/tests/window.rs
+++ b/src-tauri/tests/window.rs
@@ -1,0 +1,11 @@
+use tauri::Manager;
+
+#[tauri::test]
+async fn main_window_title() {
+    let context = tauri::generate_context!();
+    let app = tauri::Builder::default()
+        .build(context)
+        .expect("failed to build app");
+    let window = app.get_window("main").expect("missing main window");
+    assert_eq!(window.title().unwrap(), "UME Dashboard");
+}

--- a/tests/README
+++ b/tests/README
@@ -18,3 +18,13 @@ The CI workflow installs the runtime requirements with
 `pip install -r requirements.txt` before running the tests.
 Running the same command locally ensures your environment matches the
 automated checks.
+
+## Tauri Tests
+
+The CI pipeline also compiles the Tauri application in release mode to run a
+basic window test. The test will be skipped if the required GTK libraries are
+missing. Build and test it locally with:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --release
+```

--- a/tests/test_tauri.py
+++ b/tests/test_tauri.py
@@ -1,0 +1,36 @@
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+def _has_tauri_deps() -> bool:
+    """Return True if required system dependencies are available."""
+    if shutil.which("cargo") is None or shutil.which("pkg-config") is None:
+        return False
+    try:
+        subprocess.run(
+            ["pkg-config", "--exists", "javascriptcoregtk-4.0"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _has_tauri_deps(), reason="missing Tauri system dependencies")
+def test_tauri_build_release() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    manifest = repo_root / "src-tauri" / "Cargo.toml"
+    result = subprocess.run(
+        ["cargo", "test", "--manifest-path", str(manifest), "--release"],
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout)
+    print(result.stderr)
+    assert result.returncode == 0
+


### PR DESCRIPTION
## Summary
- add Tauri window title test harness in Rust
- run Tauri build in release mode from pytest
- document Tauri build step in CI instructions
- ignore Tauri build outputs
- skip Tauri test when system dependencies are missing

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest tests/test_tauri.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6871d2fab1b0832689d6237145c91cec