### PR TITLE
Fix Windows quoting in execute_steps

### DIFF
--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -32,7 +32,12 @@ def execute_steps(steps: Iterable[str], *, log_path: Path) -> int:
             tokens = []
             needs_shell = True
         else:
-            needs_shell = any(ch in step for ch in "|&;><$`") or shlex.join(tokens) != step
+            special_chars = any(ch in step for ch in "|&;><$`")
+            if os.name == "nt":
+                # ``shlex.join`` uses POSIX quoting which breaks on Windows.
+                needs_shell = special_chars
+            else:
+                needs_shell = special_chars or shlex.join(tokens) != step
         cmd = step if needs_shell else tokens
         cmd_str = step if needs_shell else " ".join(tokens)
         answer = input(f"Run command: {cmd_str} [y/N]?").strip().lower()


### PR DESCRIPTION
## Summary
- ensure execute_steps doesn't rely on posix quoting on Windows
- test windows path handling

## Testing
- `ruff check scripts/cli_common.py tests/test_cli_common.py`
- `mypy scripts/cli_common.py tests/test_cli_common.py --install-types --non-interactive`
- `pytest tests/test_cli_common.py -n auto`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68730fcbd0188326a7bc014979e10c22