### PR TITLE
Add telemetry module and update imports

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -12,12 +12,8 @@ from typing import List, Optional
 from llm import router
 from llm.backends import load_backends
 from scripts import ai_exec, ai_do, recipes
-from scripts.cli_common import (
-    execute_steps,
-    read_prompt,
-    record_event,
-    analytics_default,
-)
+from scripts.cli_common import execute_steps, read_prompt
+from telemetry import record_event, analytics_default
 import time
 
 load_backends()

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -11,12 +11,8 @@ import time
 
 from scripts import ai_exec
 from llm.backends import load_backends
-from scripts.cli_common import (
-    execute_steps,
-    record_event,
-    send_notification,
-    analytics_default,
-)
+from scripts.cli_common import execute_steps, send_notification
+from telemetry import record_event, analytics_default
 
 load_backends()
 

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -13,12 +13,8 @@ from threading import Lock
 from llm import router
 from llm.ai_router import get_preferred_models
 from llm.backends import load_backends
-from scripts.cli_common import (
-    read_prompt,
-    record_event,
-    send_notification,
-    analytics_default,
-)
+from scripts.cli_common import read_prompt, send_notification
+from telemetry import record_event, analytics_default
 import time
 
 _LAST_MODEL_REMOTE = True

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -5,11 +5,11 @@ import os
 import shlex
 import subprocess
 import sys
-import uuid
 from pathlib import Path
 from typing import Iterable
 
-import requests
+import requests  # noqa: F401 -- imported for backward-compatibility
+from telemetry import analytics_default, record_event
 
 
 def read_prompt(prompt: str) -> str:
@@ -64,36 +64,6 @@ def send_notification(message: str) -> None:
     subprocess.run(["ntfy", "send", message], check=False)
 
 
-def analytics_default() -> bool:
-    """Return ``True`` when ``EVENTS_ENABLED`` is set to a truthy value."""
-    val = os.environ.get("EVENTS_ENABLED")
-    return str(val).lower() in {"1", "true", "yes", "y"}
-
-
-def record_event(name: str, payload: dict, *, enabled: bool = False) -> None:
-    """Send ``payload`` to ``EVENTS_URL`` when ``enabled`` is ``True``."""
-    if not enabled:
-        return
-    url = os.environ.get("EVENTS_URL")
-    if not url:
-        return
-    token = os.environ.get("EVENTS_TOKEN")
-    headers = {}
-    if token:
-        headers["apikey"] = token
-        headers["Authorization"] = f"Bearer {token}"
-    dev_src = (
-        os.environ.get("GIT_AUTHOR_EMAIL")
-        or os.environ.get("EMAIL")
-        or os.environ.get("USER")
-        or "unknown"
-    )
-    developer = uuid.uuid5(uuid.NAMESPACE_DNS, dev_src).hex
-    data = {"name": name, "developer": developer, **payload}
-    try:
-        requests.post(url, headers=headers, json=data, timeout=5)
-    except Exception:
-        pass
 
 
 __all__ = [

--- a/telemetry.py
+++ b/telemetry.py
@@ -1,0 +1,43 @@
+"""Utilities for anonymous telemetry."""
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import requests
+
+
+def analytics_default() -> bool:
+    """Return ``True`` when ``EVENTS_ENABLED`` is set to a truthy value."""
+    val = os.environ.get("EVENTS_ENABLED")
+    return str(val).lower() in {"1", "true", "yes", "y"}
+
+
+def record_event(name: str, payload: dict[str, Any], *, enabled: bool = False) -> None:
+    """Send ``payload`` to ``EVENTS_URL`` when ``enabled`` is ``True``."""
+    if not enabled:
+        return
+    url = os.environ.get("EVENTS_URL")
+    if not url:
+        return
+    token = os.environ.get("EVENTS_TOKEN")
+    headers = {}
+    if token:
+        headers["apikey"] = token
+        headers["Authorization"] = f"Bearer {token}"
+    dev_src = (
+        os.environ.get("GIT_AUTHOR_EMAIL")
+        or os.environ.get("EMAIL")
+        or os.environ.get("USER")
+        or "unknown"
+    )
+    developer = uuid.uuid5(uuid.NAMESPACE_DNS, dev_src).hex
+    data = {"name": name, "developer": developer, **payload}
+    try:
+        requests.post(url, headers=headers, json=data, timeout=5)
+    except Exception:
+        pass
+
+
+__all__ = ["analytics_default", "record_event"]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import uuid
+
+import telemetry
+
+
+def test_record_event_skips_when_disabled(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    called = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called.append(True)
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    telemetry.record_event("name", {"a": 1}, enabled=False)
+    assert not called
+
+
+def test_record_event_posts(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    monkeypatch.setenv("EVENTS_TOKEN", "tok")
+    monkeypatch.setenv("USER", "alice")
+    sent = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        sent["url"] = url
+        sent["headers"] = headers
+        sent["data"] = json
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    telemetry.record_event("name", {"a": 1}, enabled=True)
+
+    assert sent["url"] == "https://example.com"
+    expected_dev = uuid.uuid5(uuid.NAMESPACE_DNS, "alice").hex
+    assert sent["data"] == {"name": "name", "a": 1, "developer": expected_dev}
+    assert sent["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_record_event_requires_url(monkeypatch):
+    called = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called.append(True)
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    monkeypatch.delenv("EVENTS_URL", raising=False)
+    telemetry.record_event("name", {"a": 1}, enabled=True)
+
+    assert not called
+
+
+def test_record_event_empty_url(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "")
+    called = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called.append(True)
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    telemetry.record_event("name", {"a": 1}, enabled=True)
+
+    assert not called
+
+
+def test_record_event_accepts_invalid_timestamps(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    sent = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        sent.update({"url": url, "data": json})
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    telemetry.record_event(
+        "ai-do",
+        {"end_ts": "not-a-number", "exit_code": 0},
+        enabled=True,
+    )
+
+    assert sent["data"]["end_ts"] == "not-a-number"
+
+
+def test_analytics_default(monkeypatch):
+    monkeypatch.setenv("EVENTS_ENABLED", "yes")
+    assert telemetry.analytics_default() is True
+    monkeypatch.setenv("EVENTS_ENABLED", "0")
+    assert telemetry.analytics_default() is False


### PR DESCRIPTION
## Summary
- add new `telemetry` module with `analytics_default` and `record_event`
- re-export telemetry helpers via `cli_common`
- update CLI scripts to import telemetry helpers from the new module
- add tests for telemetry helpers

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687312dd6a808326a64ac0c71cfaa461