### PR TITLE
Add telemetry aggregation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,6 @@ analytics enabled (via `--analytics` or `EVENTS_ENABLED=true`), an event is
 posted to `EVENTS_URL` and counted toward the developer's weekly total.
 Aggregating these numbers highlights adoption trends and guides future
 automation work.
+
+For details on how the weekly totals are calculated, see
+[docs/telemetry.md#tracking-the-north-star-metric](docs/telemetry.md#tracking-the-north-star-metric).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -57,3 +57,13 @@ Provide a path or URL with raw NDJSON events. The script aggregates successful
 `ai-do` runs per developer using `nsm_stats.aggregate_successful_runs()` and
 posts the resulting JSON to `EVENTS_URL`. Authentication via `EVENTS_TOKEN` is
 supported just like `record_event`.
+
+## Tracking the North Star Metric
+
+Each call to `record_event()` writes a JSON payload to `EVENTS_URL`. The
+`nsm_stats.aggregate_successful_runs()` helper groups these raw events by
+hashed developer ID and ISO week, counting only entries where `exit_code` is
+`0`. Summing these weekly totals yields the “successful automated tasks per
+active developer per week” metric. `nsm_upload.py` can read NDJSON logs or fetch
+them from `EVENTS_URL`, compute the totals, and post the aggregated JSON back to
+the server.


### PR DESCRIPTION
## Summary
- document how `record_event` data is grouped in a new `Tracking the North Star Metric` section
- link from the README to this documentation

## Testing
- `pre-commit` *(fails: not run because only documentation was modified)*

------
https://chatgpt.com/codex/tasks/task_e_6873194052308326834ad2b691e5f626