### PR TITLE
Add registry update flag

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -78,7 +78,8 @@ The file must conform to
 [plugin-registry.schema.json](../plugin-registry.schema.json). The CLI fetches
 this file from `https://raw.githubusercontent.com/d0tTino/d0tTino/main/plugin-registry.json`
 and caches it in `~/.cache/d0ttino/plugin_registry.json`. Override the URL with
-`PLUGIN_REGISTRY_URL` during development to test your own registry.
+`PLUGIN_REGISTRY_URL` during development to test your own registry. Pass
+`--update` to the helper to refresh the cached copy.
 
 Example entry:
 


### PR DESCRIPTION
## Summary
- allow forcing a fresh plugin registry download via `--update`
- document how to refresh the cached registry
- ensure registry cache refresh works in tests
- test CLI wiring for the update flag

## Testing
- `ruff check scripts/plugins.py tests/test_plugin_registry.py tests/test_plugins_script.py`
- `mypy --install-types --non-interactive scripts/plugins.py tests/test_plugin_registry.py tests/test_plugins_script.py`
- `pytest tests/test_plugin_registry.py tests/test_plugins_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873193dd3588326bef10c45c285a611