### PR TITLE
Add plugin subcommand to ai-cli

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -43,26 +43,27 @@ See `llm/backends/plugins/sample.py` for a full example.
 
 ## Managing Plug-ins
 
-Use the `plugins` helper to install or remove third-party backends and recipes.
+Use the `ai-cli plugin` subcommand or the `plugins` helper to install or remove
+third-party backends and recipes.
 
 ```bash
 # List available plug-ins
-python -m scripts.plugins backends list
+ai-cli plugin backends list
 
 # Install a plug-in
-python -m scripts.plugins backends install sample
+ai-cli plugin backends install sample
 
 # Remove a plug-in
-python -m scripts.plugins backends remove sample
+ai-cli plugin backends remove sample
 ```
 
 Recipe packages are managed via the `recipes` subcommand:
 
 ```bash
-python -m scripts.plugins recipes list
-python -m scripts.plugins recipes install echo
-python -m scripts.plugins recipes remove echo
-python -m scripts.plugins recipes sync
+ai-cli plugin recipes list
+ai-cli plugin recipes install echo
+ai-cli plugin recipes remove echo
+ai-cli plugin recipes sync
 ```
 
 `recipes sync` downloads and installs the recipe packages listed in the

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 from llm import router
 from llm.backends import load_backends
-from scripts import ai_exec, ai_do, recipes
+from scripts import ai_exec, ai_do, recipes, plugins
 from scripts.cli_common import execute_steps, read_prompt
 from telemetry import record_event, analytics_default
 import time
@@ -108,6 +108,10 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
     return exit_code
 
 
+def _cmd_plugin(args: argparse.Namespace) -> int:
+    return plugins.main(args.plugin_args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     analytics = argparse.ArgumentParser(add_help=False)
     analytics.add_argument(
@@ -142,6 +146,10 @@ def build_parser() -> argparse.ArgumentParser:
     recipe.add_argument("--log", type=Path, default=Path("ai_do.log"), help="Log file path (default: %(default)s)")
     recipe.set_defaults(func=_cmd_recipe)
 
+    plugin = sub.add_parser("plugin", help="Manage plug-ins")
+    plugin.add_argument("plugin_args", nargs=argparse.REMAINDER)
+    plugin.set_defaults(func=_cmd_plugin)
+
     return parser
 
 
@@ -169,6 +177,11 @@ def send_main(argv: Optional[List[str]] = None) -> int:
 
 def recipe_main(argv: Optional[List[str]] = None) -> int:
     argv = ["recipe", *(argv or [])]
+    return main(argv)
+
+
+def plugin_main(argv: Optional[List[str]] = None) -> int:
+    argv = ["plugin", *(argv or [])]
     return main(argv)
 
 

--- a/tests/test_ai_cli_plugins.py
+++ b/tests/test_ai_cli_plugins.py
@@ -1,0 +1,41 @@
+import contextlib
+import io
+
+from scripts import ai_cli
+
+
+def test_plugin_list_delegates(monkeypatch):
+    called = {}
+
+    def fake_main(argv):
+        called['argv'] = argv
+        return 0
+
+    monkeypatch.setattr(ai_cli.plugins, 'main', fake_main)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(['plugin', 'backends', 'list'])
+    assert rc == 0
+    assert called['argv'] == ['backends', 'list']
+
+
+def test_plugin_install_delegates(monkeypatch):
+    called = {}
+    def fake_main(argv):
+        called['argv'] = argv
+        return 0
+    monkeypatch.setattr(ai_cli.plugins, 'main', fake_main)
+    rc = ai_cli.main(['plugin', 'backends', 'install', 'x'])
+    assert rc == 0
+    assert called['argv'] == ['backends', 'install', 'x']
+
+
+def test_plugin_remove_delegates(monkeypatch):
+    called = {}
+    def fake_main(argv):
+        called['argv'] = argv
+        return 0
+    monkeypatch.setattr(ai_cli.plugins, 'main', fake_main)
+    rc = ai_cli.main(['plugin', 'backends', 'remove', 'x'])
+    assert rc == 0
+    assert called['argv'] == ['backends', 'remove', 'x']


### PR DESCRIPTION
## Summary
- add `plugin` subcommand to ai-cli
- show new examples in documentation
- test plugin subcommand delegation to `scripts.plugins`

## Testing
- `ruff check scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873193d5a10832696a52d2aaf83eda1