### PR TITLE
Remove unused UME_API_URL

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -56,7 +56,6 @@ def get_graph() -> dict[str, list]:
     return {"nodes": state["nodes"], "edges": state["edges"]}
 
 app = FastAPI()
-UME_API_URL = os.environ.get("UME_API_URL", "http://localhost:8000")
 
 class PromptRequest(BaseModel):
     prompt: str

--- a/docs/ume.md
+++ b/docs/ume.md
@@ -27,7 +27,8 @@ Launch the API and supporting services:
 poetry run python ume_cli.py up
 ```
 
-The API will be available at <http://localhost:8000>.
+The API will be available at <http://localhost:8000>. No environment variable is
+required to specify this base URL.
 
 ## LangGraph Retrieval Demo
 

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -284,7 +284,7 @@ def test_recipe_sync_creates_packages(monkeypatch, tmp_path):
 
         return Res()
 
-    def fake_load(section="plugins"):
+    def fake_load(section="plugins", update=False):
         if section == "recipes":
             return packages
         return {}


### PR DESCRIPTION
## Summary
- remove the unused `UME_API_URL` constant from the FastAPI app
- clarify that the UME API base URL needs no environment variable
- fix recipe sync test to accept the `update` argument

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6873275268108326a0f077165077e471