### PR TITLE
Add dnf/pacman support to installer

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,10 +46,13 @@ is available:
 brew install curl unzip git
 ```
 
-Debian based distributions use `apt-get` if present:
+Debian based distributions use `apt-get` if present. Fedora and Arch systems
+are detected automatically when `dnf` or `pacman` exist:
 
 ```bash
 sudo apt-get install curl unzip git
+sudo dnf install curl unzip git     # Fedora
+sudo pacman -S curl unzip git       # Arch
 ```
 
 If neither package manager is detected you'll need to install the tools
@@ -171,9 +174,10 @@ sudo bash scripts/setup-wsl.sh
 
 ### Troubleshooting package managers
 
-The installer looks for Homebrew on macOS and `apt-get` on Debian-based
-distributions to install missing tools automatically. If the command is not
-found, install the package manager manually and ensure it is on your `PATH`.
+The installer looks for Homebrew on macOS and uses `apt-get`, `dnf` or
+`pacman` on Linux to install missing tools automatically. If none of these
+commands are found, install a package manager manually and ensure it is on your
+`PATH`.
 
 - **Homebrew missing** – install it with:
 

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -36,10 +36,21 @@ ensure_deps() {
                 echo "Install Homebrew from https://brew.sh and run: brew install ${missing[*]}" >&2
                 exit 1
             fi
-        elif [[ $OSTYPE == linux* ]] && command -v apt-get >/dev/null 2>&1; then
-            echo "Installing ${missing[*]} with apt-get" >&2
-            sudo apt-get update
-            sudo apt-get install -y "${missing[@]}"
+        elif [[ $OSTYPE == linux* ]]; then
+            if command -v apt-get >/dev/null 2>&1; then
+                echo "Installing ${missing[*]} with apt-get" >&2
+                sudo apt-get update
+                sudo apt-get install -y "${missing[@]}"
+            elif command -v dnf >/dev/null 2>&1; then
+                echo "Installing ${missing[*]} with dnf" >&2
+                sudo dnf install -y "${missing[@]}"
+            elif command -v pacman >/dev/null 2>&1; then
+                echo "Installing ${missing[*]} with pacman" >&2
+                sudo pacman -S --noconfirm "${missing[@]}"
+            else
+                echo "Missing ${missing[*]}. Please install them and re-run this script." >&2
+                exit 1
+            fi
         else
             echo "Missing ${missing[*]}. Please install them and re-run this script." >&2
             exit 1

--- a/tests/test_install_common.py
+++ b/tests/test_install_common.py
@@ -4,6 +4,11 @@ import subprocess
 from pathlib import Path
 
 
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def test_install_common_runs_without_ostype(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     repo = tmp_path / "repo"
@@ -38,3 +43,107 @@ def test_install_common_runs_without_ostype(tmp_path: Path) -> None:
     assert "setup_hooks" in lines
     assert "install_fonts" in lines
     assert "sync_palettes" in lines
+
+
+def test_install_common_installs_missing_deps_dnf(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_dnf"
+    repo.mkdir()
+
+    scripts_dir = repo / "scripts"
+    helpers_dir = scripts_dir / "helpers"
+    helpers_dir.mkdir(parents=True)
+
+    shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+
+    log = tmp_path / "install.log"
+    (scripts_dir / "setup-hooks.sh").write_text(
+        f"#!/usr/bin/env bash\necho setup_hooks >> '{log}'\n", encoding="utf-8"
+    )
+    (helpers_dir / "install_fonts.sh").write_text(
+        f"#!/usr/bin/env bash\necho install_fonts >> '{log}'\n", encoding="utf-8"
+    )
+    (helpers_dir / "sync_palettes.sh").write_text(
+        f"#!/usr/bin/env bash\necho sync_palettes >> '{log}'\n", encoding="utf-8"
+    )
+    for f in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
+        f.chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    dnf_log = tmp_path / "dnf.log"
+    create_exe(
+        bin_dir / "dnf",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{dnf_log}'\nif [[ $1 == install ]]; then\n  shift\n  for pkg in \"$@\"; do\n    /bin/touch '{bin_dir}'/$pkg\n    /bin/chmod 755 '{bin_dir}'/$pkg\n  done\nfi\n",
+    )
+    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n\"$@\"\n")
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+
+    env = os.environ.copy()
+    env.update({
+        "OSTYPE": "linux-gnu",
+        "PATH": str(bin_dir),
+    })
+
+    subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
+
+    lines = dnf_log.read_text().splitlines()
+    assert any("install" in line for line in lines)
+    assert any("curl" in line for line in lines)
+    assert any("unzip" in line for line in lines)
+    assert any("git" in line for line in lines)
+
+
+def test_install_common_installs_missing_deps_pacman(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_pacman"
+    repo.mkdir()
+
+    scripts_dir = repo / "scripts"
+    helpers_dir = scripts_dir / "helpers"
+    helpers_dir.mkdir(parents=True)
+
+    shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+
+    log = tmp_path / "install.log"
+    (scripts_dir / "setup-hooks.sh").write_text(
+        f"#!/usr/bin/env bash\necho setup_hooks >> '{log}'\n", encoding="utf-8"
+    )
+    (helpers_dir / "install_fonts.sh").write_text(
+        f"#!/usr/bin/env bash\necho install_fonts >> '{log}'\n", encoding="utf-8"
+    )
+    (helpers_dir / "sync_palettes.sh").write_text(
+        f"#!/usr/bin/env bash\necho sync_palettes >> '{log}'\n", encoding="utf-8"
+    )
+    for f in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
+        f.chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    pac_log = tmp_path / "pacman.log"
+    create_exe(
+        bin_dir / "pacman",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{pac_log}'\nif [[ $1 == -S ]]; then\n  shift\n  if [[ $1 == --noconfirm ]]; then\n    shift\n  fi\n  for pkg in \"$@\"; do\n    /bin/touch '{bin_dir}'/$pkg\n    /bin/chmod 755 '{bin_dir}'/$pkg\n  done\nfi\n",
+    )
+    create_exe(bin_dir / "sudo", "#!/usr/bin/env bash\n\"$@\"\n")
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+
+    env = os.environ.copy()
+    env.update({
+        "OSTYPE": "linux-gnu",
+        "PATH": str(bin_dir),
+    })
+
+    subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
+
+    lines = pac_log.read_text().splitlines()
+    assert any("-S" in line for line in lines)
+    assert any("curl" in line for line in lines)
+    assert any("unzip" in line for line in lines)
+    assert any("git" in line for line in lines)


### PR DESCRIPTION
## Summary
- detect dnf and pacman package managers in `install_common.sh`
- document Linux package manager detection in installation guide
- test dnf/pacman support

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687332d9703883268e833bf59547fc1f