### PR TITLE
Add backends.initialize cache

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -6,9 +6,10 @@ from collections.abc import Callable
 from typing import Dict
 
 from .loader import discover_plugins, load_backends
-
 from .base import Backend
 from .superclaude import SuperClaudeBackend as _RealSuperClaudeBackend
+
+_INITIALIZED = False
 
 
 _BACKEND_REGISTRY: Dict[str, Callable[[str, str], str]] = {}
@@ -44,6 +45,7 @@ __all__ = [
     "OpenRouterDSPyBackend",
     "LMQLBackend",
     "GuidanceBackend",
+    "initialize",
 ]
 
 
@@ -69,6 +71,14 @@ def available_backends() -> list[str]:
     """Return a list of registered backend names."""
 
     return sorted(_BACKEND_REGISTRY)
+
+
+def initialize() -> None:
+    """Load backends once and cache the result."""
+    global _INITIALIZED
+    if not _INITIALIZED:
+        load_backends()
+        _INITIALIZED = True
 
 
 

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -11,13 +11,13 @@ from pathlib import Path
 from typing import List, Optional
 
 from llm import router
-from llm.backends import load_backends
+from llm.backends import initialize
 from scripts import ai_exec, ai_do, recipes, plugins
 from scripts.cli_common import execute_steps, read_prompt
 from telemetry import record_event, analytics_default
 import time
 
-load_backends()
+initialize()
 
 
 def _cmd_send(args: argparse.Namespace) -> int:

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -11,11 +11,11 @@ import time
 import logging
 
 from scripts import ai_exec
-from llm.backends import load_backends
+from llm.backends import initialize
 from scripts.cli_common import execute_steps, send_notification
 from telemetry import record_event, analytics_default
 
-load_backends()
+initialize()
 
 
 def run_recipe(

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -13,7 +13,7 @@ import logging
 
 from llm import router
 from llm.ai_router import get_preferred_models
-from llm.backends import load_backends
+from llm.backends import initialize
 from scripts.cli_common import read_prompt, send_notification
 from telemetry import record_event, analytics_default
 import time
@@ -26,7 +26,7 @@ def last_model_remote() -> bool:
     with _LAST_MODEL_LOCK:
         return _LAST_MODEL_REMOTE
 
-load_backends()
+initialize()
 
 def plan(
     goal: str, *, config_path: Optional[Path] = None, analytics: bool = False

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -9,14 +9,14 @@ import sys
 
 
 from llm import router
-from llm.backends import available_backends, load_backends
+from llm.backends import available_backends, initialize
 
 DEFAULT_MODEL = router.DEFAULT_MODEL
 DEFAULT_PRIMARY_BACKEND = router.DEFAULT_PRIMARY_BACKEND
 DEFAULT_FALLBACK_BACKEND = router.DEFAULT_FALLBACK_BACKEND
 DEFAULT_COMPLEXITY_THRESHOLD = router.DEFAULT_COMPLEXITY_THRESHOLD
 
-load_backends()
+initialize()
 
 run_gemini = router.run_gemini
 run_ollama = router.run_ollama

--- a/tests/test_backends_initialize.py
+++ b/tests/test_backends_initialize.py
@@ -1,0 +1,18 @@
+from llm import backends
+
+
+def test_initialize_idempotent(monkeypatch):
+    calls = []
+
+    def fake_load() -> None:
+        calls.append(True)
+
+    monkeypatch.setattr(backends, "load_backends", fake_load)
+    # Reset initialization flag
+    monkeypatch.setattr(backends, "_INITIALIZED", False)
+
+    backends.initialize()
+    backends.initialize()
+    backends.initialize()
+
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- add `initialize()` helper in `llm.backends` that caches backend loading
- switch CLI modules to use `initialize()` instead of `load_backends()`
- test that calling `initialize()` repeatedly loads backends only once

## Testing
- `pytest tests/test_backends_initialize.py -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_687332d9237c8326a002b9afd73890d2