### PR TITLE
Add recipe sync tests and docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -67,7 +67,18 @@ ai-cli plugin recipes sync
 ```
 
 `recipes sync` downloads and installs the recipe packages listed in the
-registry into `scripts/recipes/packages` so they can be used offline.
+registry into `scripts/recipes/packages` so they can be used offline. Run the
+helper directly to sync packages to the default location:
+
+```bash
+python -m scripts.plugins recipes sync
+```
+
+Use `--dest` to specify a custom download directory:
+
+```bash
+python -m scripts.plugins recipes sync --dest /tmp/recipe_pkgs
+```
 
 ### Adding Your Plug-in
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,30 @@
+import argparse
+from pathlib import Path
+
+from scripts import plugins
+
+
+def test_cmd_sync_recipes_uses_default_dir(monkeypatch, tmp_path):
+    packages = {"echo": "echo-pkg", "foo": "foo-pkg"}
+
+    def fake_run(cmd, *a, **k):
+        dest = Path(cmd[cmd.index("--target") + 1])
+        pkg = cmd[-1]
+        (dest / pkg).write_text("installed")
+
+        class Res:
+            returncode = 0
+
+        return Res()
+
+    monkeypatch.setattr(plugins, "load_registry", lambda section="plugins", update=False: packages)
+    monkeypatch.setattr(plugins.subprocess, "run", fake_run)
+    monkeypatch.setattr(plugins, "RECIPE_DOWNLOAD_DIR", tmp_path)
+
+    args = argparse.Namespace(dest=None, update=False)
+    rc = plugins._cmd_sync_recipes(args)
+    assert rc == 0
+    for pkg in packages.values():
+        assert (tmp_path / pkg).is_file()
+
+


### PR DESCRIPTION
## Summary
- add `_cmd_sync_recipes` test ensuring downloads use `RECIPE_DOWNLOAD_DIR`
- document how to run `recipes sync` and specify a custom destination

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest tests/test_plugins.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742e8a406c832693a8f5fc3816ba1f