### PR TITLE
Add connection error handling

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 from threading import RLock
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 import requests
@@ -49,18 +49,24 @@ def record_prompt(prompt: str) -> None:
 
 def get_stats() -> dict[str, int]:
     if UME_API_URL:
-        resp = requests.get(f"{UME_API_URL}/dashboard/stats")
-        resp.raise_for_status()
-        return resp.json()
+        try:
+            resp = requests.get(f"{UME_API_URL}/dashboard/stats")
+            resp.raise_for_status()
+            return resp.json()
+        except requests.exceptions.RequestException as exc:
+            raise HTTPException(status_code=503, detail=str(exc))
     state = _load_state()
     return {"queries": state["queries"], "memory": len(state["nodes"])}
 
 
 def get_graph() -> dict[str, list]:
     if UME_API_URL:
-        resp = requests.get(f"{UME_API_URL}/graph")
-        resp.raise_for_status()
-        return resp.json()
+        try:
+            resp = requests.get(f"{UME_API_URL}/graph")
+            resp.raise_for_status()
+            return resp.json()
+        except requests.exceptions.RequestException as exc:
+            raise HTTPException(status_code=503, detail=str(exc))
     state = _load_state()
     return {"nodes": state["nodes"], "edges": state["edges"]}
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -114,6 +114,30 @@ def test_graph_remote(monkeypatch, tmp_path):
     assert calls == ['http://ume/graph']
 
 
+def test_stats_remote_connection_error(monkeypatch, tmp_path):
+    def fake_get(url):
+        raise requests.exceptions.ConnectionError('boom')
+
+    monkeypatch.setenv('UME_API_URL', 'http://ume')
+    monkeypatch.setattr(requests, 'get', fake_get)
+    app = load_app(state_path=tmp_path / 'state.json')
+    client = TestClient(app)
+    resp = client.get('/api/stats')
+    assert resp.status_code == 503
+
+
+def test_graph_remote_connection_error(monkeypatch, tmp_path):
+    def fake_get(url):
+        raise requests.exceptions.ConnectionError('boom')
+
+    monkeypatch.setenv('UME_API_URL', 'http://ume')
+    monkeypatch.setattr(requests, 'get', fake_get)
+    app = load_app(state_path=tmp_path / 'state.json')
+    client = TestClient(app)
+    resp = client.get('/api/graph')
+    assert resp.status_code == 503
+
+
 def test_prompt(tmp_path):
     calls = []
     def fake(prompt: str, local: bool = False):


### PR DESCRIPTION
## Summary
- avoid crashing when remote stats or graph endpoints fail
- test that API returns 503 on connection errors

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874665eea58832688df05d3980d430e