### PR TITLE
Add sources generation workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 ruff check .
+if git diff --cached --name-only | grep -q '^metadata/sources.json$'; then
+    python3 scripts/generate_sources_md.py
+    git add docs/awesome-sources.md
+fi
 python3 windows-terminal/generate_settings.py \
   windows-terminal/settings.base.json \
   windows-terminal/settings.json \

--- a/.github/workflows/sources.yml
+++ b/.github/workflows/sources.yml
@@ -1,0 +1,28 @@
+name: Generate Sources Markdown
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - metadata/sources.json
+      - .github/workflows/sources.yml
+  pull_request:
+    paths:
+      - metadata/sources.json
+      - .github/workflows/sources.yml
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Generate docs/awesome-sources.md
+        run: python scripts/generate_sources_md.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: awesome-sources-md
+          path: docs/awesome-sources.md


### PR DESCRIPTION
## Summary
- run `scripts/generate_sources_md.py` in CI when `metadata/sources.json` changes
- upload the generated `docs/awesome-sources.md` as an artifact
- auto-generate the file from `pre-commit` when `metadata/sources.json` is staged

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68747b53e0d88326bbcdbce7368b6b44