### PR TITLE
Add source enrichment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,14 @@ links are unreachable.
 ## Awesome sources
 
 Add new resources to `metadata/sources.json` using `name`, `url` and
-`category` fields. After editing the JSON file regenerate the Markdown list
-with:
+`category` fields. Optionally enrich the entries with GitHub star counts and
+API information:
+
+```bash
+python scripts/enrich_sources.py
+```
+
+After editing the JSON file regenerate the Markdown list with:
 
 ```bash
 python scripts/generate_sources_md.py

--- a/docs/awesome-sources.md
+++ b/docs/awesome-sources.md
@@ -6,7 +6,7 @@ A curated list of useful resources.
 - [Docker Documentation](https://docs.docker.com/) — *License:* Apache-2.0 — *Tags:* docker, devops
 
 ## Framework
-- [FastAPI](https://fastapi.tiangolo.com/) — *License:* MIT — *Tags:* python, web
+- [FastAPI](https://github.com/tiangolo/fastapi) — *License:* MIT — *Tags:* python, web — *API:* REST — *Stars:* 87359
 
 ## Learning
 - [Rust Book](https://doc.rust-lang.org/book/) — *License:* MIT — *Tags:* rust, learning

--- a/metadata/sources.json
+++ b/metadata/sources.json
@@ -3,28 +3,42 @@
     "name": "Python Docs",
     "url": "https://docs.python.org/3/",
     "category": "Reference",
-    "tags": ["python", "reference"],
+    "tags": [
+      "python",
+      "reference"
+    ],
     "license": "PSF"
   },
   {
     "name": "FastAPI",
-    "url": "https://fastapi.tiangolo.com/",
+    "url": "https://github.com/tiangolo/fastapi",
     "category": "Framework",
-    "tags": ["python", "web"],
-    "license": "MIT"
+    "tags": [
+      "python",
+      "web"
+    ],
+    "license": "MIT",
+    "api_type": "REST",
+    "stars": 87359
   },
   {
     "name": "Rust Book",
     "url": "https://doc.rust-lang.org/book/",
     "category": "Learning",
-    "tags": ["rust", "learning"],
+    "tags": [
+      "rust",
+      "learning"
+    ],
     "license": "MIT"
   },
   {
     "name": "Docker Documentation",
     "url": "https://docs.docker.com/",
     "category": "DevOps",
-    "tags": ["docker", "devops"],
+    "tags": [
+      "docker",
+      "devops"
+    ],
     "license": "Apache-2.0"
   }
 ]

--- a/scripts/enrich_sources.py
+++ b/scripts/enrich_sources.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Enrich metadata/sources.json with additional information."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, List
+
+import requests
+
+SOURCES_JSON = Path("metadata/sources.json")
+
+
+def load_sources(path: Path = SOURCES_JSON) -> List[dict[str, Any]]:
+    """Return the list of source dictionaries from ``path``."""
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def infer_api_type(url: str) -> str | None:
+    """Guess the API type based on the URL."""
+    lower = url.lower()
+    if "graphql" in lower:
+        return "GraphQL"
+    if "api" in lower:
+        return "REST"
+    return None
+
+
+def fetch_github_stars(url: str) -> int | None:
+    """Return the GitHub star count for ``url`` if applicable."""
+    match = re.search(r"github\.com/([^/]+)/([^/]+)", url)
+    if not match:
+        return None
+    api_url = f"https://api.github.com/repos/{match.group(1)}/{match.group(2)}"
+    try:
+        resp = requests.get(api_url, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        stars = data.get("stargazers_count")
+        if isinstance(stars, int):
+            return stars
+    except requests.RequestException:
+        return None
+    return None
+
+
+def enrich_sources(sources: List[dict[str, Any]]) -> None:
+    """Update ``sources`` in-place with additional details."""
+    for item in sources:
+        api_type = item.get("api_type") or infer_api_type(str(item.get("url", "")))
+        if api_type:
+            item["api_type"] = api_type
+        if "stars" not in item:
+            stars = fetch_github_stars(str(item.get("url", "")))
+            if stars is not None:
+                item["stars"] = stars
+
+
+def save_sources(sources: List[dict[str, Any]], path: Path = SOURCES_JSON) -> None:
+    path.write_text(json.dumps(sources, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: List[str] | None = None) -> int:
+    sources = load_sources()
+    enrich_sources(sources)
+    save_sources(sources)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_sources_md.py
+++ b/scripts/generate_sources_md.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast, Iterable
 
 SOURCES_JSON = Path("metadata/sources.json")
 OUTPUT_MD = Path("docs/awesome-sources.md")
@@ -19,16 +20,25 @@ def load_sources(path: Path = SOURCES_JSON) -> list[dict[str, object]]:
 def generate_markdown(sources: list[dict[str, object]]) -> str:
     """Return Markdown content for ``sources``."""
     lines: list[str] = ["# Awesome Sources", "", "A curated list of useful resources.", ""]
-    categories: dict[str, list[dict[str, str]]] = {}
+    categories: dict[str, list[dict[str, object]]] = {}
     for item in sources:
-        categories.setdefault(item["category"], []).append(item)
+        category = cast(str, item["category"])
+        categories.setdefault(category, []).append(item)
     for category in sorted(categories):
         lines.append(f"## {category}")
         for src in categories[category]:
-            tags = ", ".join(src.get("tags", []))
+            tags_list = cast(Iterable[str], src.get("tags", []))
+            tags = ", ".join(tags_list)
             license = src.get("license", "Unknown")
+            details = [f"*License:* {license}", f"*Tags:* {tags}"]
+            api_type = src.get("api_type")
+            if api_type:
+                details.append(f"*API:* {api_type}")
+            stars = src.get("stars")
+            if stars is not None:
+                details.append(f"*Stars:* {stars}")
             lines.append(
-                f"- [{src['name']}]({src['url']}) — *License:* {license} — *Tags:* {tags}"
+                f"- [{src['name']}]({src['url']}) — " + " — ".join(details)
             )
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"


### PR DESCRIPTION
## Summary
- add `scripts/enrich_sources.py` to fetch GitHub stars and infer API type
- store new fields like `stars` and `api_type` in `metadata/sources.json`
- update `scripts/generate_sources_md.py` to show stars and API type
- regenerate `docs/awesome-sources.md`
- document enrichment process in `README.md`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68790ec67c5483269117a95815e46835