### PR TITLE
Add JSON schema validation for sources

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,7 @@
 set -e
 ruff check .
 if git diff --cached --name-only | grep -q '^metadata/sources.json$'; then
+    python3 scripts/validate_sources.py
     python3 scripts/generate_sources_md.py
     git add docs/awesome-sources.md
 fi

--- a/.github/workflows/sources.yml
+++ b/.github/workflows/sources.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Validate sources.json
+        run: python scripts/validate_sources.py
       - name: Generate docs/awesome-sources.md
         run: python scripts/generate_sources_md.py
       - name: Upload artifact

--- a/metadata/sources.schema.json
+++ b/metadata/sources.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Source Entry",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {"type": "string"},
+      "url": {"type": "string", "format": "uri"},
+      "category": {"type": "string"},
+      "tags": {
+        "type": "array",
+        "items": {"type": "string"}
+      },
+      "license": {"type": "string"}
+    },
+    "required": ["name", "url", "category", "tags", "license"],
+    "additionalProperties": false
+  }
+}

--- a/scripts/generate_sources_md.py
+++ b/scripts/generate_sources_md.py
@@ -19,13 +19,16 @@ def load_sources(path: Path = SOURCES_JSON) -> list[dict[str, object]]:
 def generate_markdown(sources: list[dict[str, object]]) -> str:
     """Return Markdown content for ``sources``."""
     lines: list[str] = ["# Awesome Sources", "", "A curated list of useful resources.", ""]
-    categories: dict[str, list[dict[str, str]]] = {}
+    categories: dict[str, list[dict[str, object]]] = {}
     for item in sources:
-        categories.setdefault(item["category"], []).append(item)
+        category = str(item["category"])
+        categories.setdefault(category, []).append(item)
     for category in sorted(categories):
         lines.append(f"## {category}")
         for src in categories[category]:
-            tags = ", ".join(src.get("tags", []))
+            raw_tags = src.get("tags", [])
+            tags_list = list(raw_tags) if isinstance(raw_tags, list) else []
+            tags = ", ".join(str(t) for t in tags_list)
             license = src.get("license", "Unknown")
             lines.append(
                 f"- [{src['name']}]({src['url']}) — *License:* {license} — *Tags:* {tags}"

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Validate ``metadata/sources.json`` against its JSON schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+from jsonschema import FormatChecker
+
+SCHEMA_PATH = Path("metadata/sources.schema.json")
+SOURCES_JSON = Path("metadata/sources.json")
+
+
+def validate(path: Path = SOURCES_JSON, schema_path: Path = SCHEMA_PATH) -> bool:
+    """Return ``True`` if ``path`` conforms to the schema."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"{path} not found", file=sys.stderr)
+        return False
+    except json.JSONDecodeError as exc:
+        print(f"Failed to parse {path}: {exc}", file=sys.stderr)
+        return False
+
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - schema load failure
+        print(f"Failed to load schema {schema_path}: {exc}", file=sys.stderr)
+        return False
+
+    try:
+        jsonschema.validate(data, schema, format_checker=FormatChecker())
+    except jsonschema.ValidationError as exc:
+        print(f"{path} failed validation: {exc.message}", file=sys.stderr)
+        return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", default=str(SOURCES_JSON))
+    parser.add_argument("--schema", default=str(SCHEMA_PATH))
+    args = parser.parse_args(argv)
+    return 0 if validate(Path(args.path), Path(args.schema)) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sources_schema.py
+++ b/tests/test_sources_schema.py
@@ -1,0 +1,5 @@
+from scripts import validate_sources
+
+
+def test_sources_schema_valid() -> None:
+    assert validate_sources.main([]) == 0


### PR DESCRIPTION
## Summary
- add `metadata/sources.schema.json` describing valid source entries
- validate `sources.json` with new `scripts/validate_sources.py`
- test validation in `tests/test_sources_schema.py`
- enforce validation in pre-commit and CI
- check URL format using jsonschema `FormatChecker`
- fix mypy typing issues in `generate_sources_md.py`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive llm scripts`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68790ec5b25c8326a9f8c3ce7f6d19da