### PR TITLE
Improve sources markdown generation

### DIFF
--- a/scripts/generate_sources_md.py
+++ b/scripts/generate_sources_md.py
@@ -7,7 +7,6 @@ from typing import Iterable, cast
 
 import json
 from pathlib import Path
-from typing import Iterable, cast
 
 
 SOURCES_JSON = Path("metadata/sources.json")
@@ -33,8 +32,15 @@ def generate_markdown(sources: list[dict[str, object]]) -> str:
         for src in categories[category]:
             tags_list = cast(Iterable[str], src.get("tags", []))
             tags = ", ".join(tags_list)
-
             license = src.get("license", "Unknown")
+
+            details = [f"*License:* {license}", f"*Tags:* {tags}"]
+            api_type = src.get("api_type")
+            if api_type:
+                details.append(f"*API:* {api_type}")
+            stars = src.get("stars")
+            if stars:
+                details.append(f"*Stars:* {stars}")
 
             lines.append(
                 f"- [{src['name']}]({src['url']}) — " + " — ".join(details)

--- a/tests/test_generate_sources_md.py
+++ b/tests/test_generate_sources_md.py
@@ -8,3 +8,19 @@ def test_awesome_sources_md_up_to_date():
     markdown = generate_sources_md.generate_markdown(sources)
     current = Path("docs/awesome-sources.md").read_text(encoding="utf-8")
     assert markdown == current
+
+
+def test_generate_markdown_details_format():
+    sources = generate_sources_md.load_sources()
+    markdown = generate_sources_md.generate_markdown(sources)
+    lines = markdown.splitlines()
+    for src in sources:
+        expected = f"- [{src['name']}]({src['url']})"
+        # find matching line
+        line_candidate = next(line for line in lines if line.startswith(expected))
+        assert "*License:*" in line_candidate
+        assert "*Tags:*" in line_candidate
+        if 'api_type' in src:
+            assert "*API:*" in line_candidate
+        if 'stars' in src:
+            assert "*Stars:*" in line_candidate


### PR DESCRIPTION
## Summary
- deduplicate imports and compute details in `generate_sources_md.py`
- validate details formatting for each source in tests

## Testing
- `ruff check scripts/generate_sources_md.py tests/test_generate_sources_md.py`
- `mypy scripts/generate_sources_md.py tests/test_generate_sources_md.py`
- `pytest tests/test_generate_sources_md.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9eebd1d48326aae8937b0f88519d