### PR TITLE
Fix generate_sources_md details generation

### DIFF
--- a/scripts/generate_sources_md.py
+++ b/scripts/generate_sources_md.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Iterable, cast
 
 
 SOURCES_JSON = Path("metadata/sources.json")
@@ -35,16 +36,6 @@ def generate_markdown(sources: list[dict[str, object]]) -> str:
                 details.append(f"*API:* {api_type}")
             stars = src.get("stars")
             if stars is not None:
-                details.append(f"*Stars:* {stars}")
-
-
-            details: list[str] = [f"*License:* {license}", f"*Tags:* {tags}"]
-
-            api_type = src.get("api_type")
-            if api_type:
-                details.append(f"*API:* {api_type}")
-            stars = src.get("stars")
-            if stars:
                 details.append(f"*Stars:* {stars}")
 
             lines.append(


### PR DESCRIPTION
## Summary
- import `Iterable` and `cast`
- remove duplicate `details` block
- maintain license lookup using `src.get('license', 'Unknown')`

## Testing
- `ruff check scripts/generate_sources_md.py`
- `mypy scripts/generate_sources_md.py`
- `pytest tests/test_generate_sources_md.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687aaa2123748326b9777dd2b9cfdcd4