### PR TITLE
Add query_sources CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Key directories:
 - `vscode/` – VS Code user settings
 - `llm/` – prompts and other LLM-related files. The optional `llm/llm_config.json` file stores preferred model names used by `llm.ai_router`. Set the `LLM_CONFIG_PATH` environment variable to override the location. Configure it with Claude model names when using the `superclaude` backend.
 - `scripts/thm.py` – Terminal Harmony Manager for palette and profile sync (installs as `thm` when using `pip install -e .[cli]`)
+- `scripts/query_sources.py` – search `metadata/sources.json` by name or tag (installs as `query-sources` with the `cli` extra)
 - `research-papers/` – space to store research PDFs, links, and notes
 
 Get the fonts, palettes and Git hooks in one step:
@@ -247,6 +248,13 @@ python scripts/generate_sources_md.py
 
 Commit the updated `docs/awesome-sources.md` file. A GitHub Action and the
 pre-commit hook verify that the two files remain in sync.
+
+Query the list from the command line:
+
+```bash
+python scripts/query_sources.py --tag python
+python scripts/query_sources.py --name Docker
+```
 
 ## Telemetry and Metrics
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ ai-do = "scripts.ai_cli:do_main"
 ai-cli = "scripts.ai_cli:main"
 etl = "scripts.etl:main"
 plugins = "scripts.plugins:main"
+query-sources = "scripts.query_sources:main"
 
 [project.entry-points."llm.plugins"]
 # Third-party packages can expose backends here

--- a/scripts/query_sources.py
+++ b/scripts/query_sources.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Search ``metadata/sources.json`` by name or tag."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+SOURCES_JSON = Path("metadata/sources.json")
+
+
+def load_sources(path: Path = SOURCES_JSON) -> List[Dict[str, Any]]:
+    """Return the list of source dictionaries from ``path``."""
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def find_sources(
+    *, name: str | None = None,
+    tag: str | None = None,
+    path: Path = SOURCES_JSON,
+) -> List[Dict[str, Any]]:
+    """Return sources matching ``name`` and/or ``tag``."""
+    sources = load_sources(path)
+    results: List[Dict[str, Any]] = []
+    for src in sources:
+        if name and name.lower() not in str(src.get("name", "")).lower():
+            continue
+        if tag and tag.lower() not in [t.lower() for t in src.get("tags", [])]:
+            continue
+        results.append(src)
+    return results
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", "-n", help="Filter by name substring")
+    parser.add_argument("--tag", "-t", help="Filter by tag")
+    parser.add_argument(
+        "--path",
+        default=str(SOURCES_JSON),
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args(argv)
+    matches = find_sources(name=args.name, tag=args.tag, path=Path(args.path))
+    for item in matches:
+        print(f"{item['name']} - {item['url']}")
+    return 0 if matches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_query_sources.py
+++ b/tests/test_query_sources.py
@@ -1,0 +1,19 @@
+from scripts import query_sources
+
+
+def test_find_by_tag() -> None:
+    results = query_sources.find_sources(tag="python")
+    assert any(r["name"] == "Python Docs" for r in results)
+
+
+def test_find_by_name() -> None:
+    results = query_sources.find_sources(name="Rust")
+    assert len(results) == 1
+    assert results[0]["name"] == "Rust Book"
+
+
+def test_main_returns_zero_and_outputs(capsys) -> None:
+    rc = query_sources.main(["--tag", "docker"])
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert "Docker Documentation" in output


### PR DESCRIPTION
## Summary
- add `scripts/query_sources.py` for querying `metadata/sources.json`
- expose `query-sources` CLI entry point
- document usage in README
- test basic queries

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab15e05dc83269c6e03db122d83ed