### PR TITLE
Refactor generate_markdown

### DIFF
--- a/scripts/generate_sources_md.py
+++ b/scripts/generate_sources_md.py
@@ -20,28 +20,34 @@ def load_sources(path: Path = SOURCES_JSON) -> list[dict[str, object]]:
 
 def generate_markdown(sources: list[dict[str, object]]) -> str:
     """Return Markdown content for ``sources``."""
-    lines: list[str] = ["# Awesome Sources", "", "A curated list of useful resources.", ""]
+    lines: list[str] = [
+        "# Awesome Sources",
+        "",
+        "A curated list of useful resources.",
+        "",
+    ]
+
     categories: dict[str, list[dict[str, object]]] = {}
     for item in sources:
-        category = str(item["category"])
+        categories.setdefault(str(item["category"]), []).append(item)
 
-        categories.setdefault(category, []).append(item)
     for category in sorted(categories):
         lines.append(f"## {category}")
         for src in categories[category]:
             tags = ", ".join(cast(Iterable[str], src.get("tags", [])))
-            details = [f"*License:* {src.get('license', 'Unknown')}", f"*Tags:* {tags}"]
+            details = f"*License:* {src.get('license', 'Unknown')} — *Tags:* {tags}"
+
             api_type = src.get("api_type")
             if api_type:
-                details.append(f"*API:* {api_type}")
+                details += f" — *API:* {api_type}"
+
             stars = src.get("stars")
             if stars is not None:
-                details.append(f"*Stars:* {stars}")
+                details += f" — *Stars:* {stars}"
 
-            lines.append(
-                f"- [{src['name']}]({src['url']}) — " + " — ".join(details)
-            )
+            lines.append(f"- [{src['name']}]({src['url']}) — {details}")
         lines.append("")
+
     return "\n".join(lines).rstrip() + "\n"
 
 

--- a/tests/test_generate_sources_md.py
+++ b/tests/test_generate_sources_md.py
@@ -15,12 +15,12 @@ def test_generate_markdown_details_format():
     markdown = generate_sources_md.generate_markdown(sources)
     lines = markdown.splitlines()
     for src in sources:
-        expected = f"- [{src['name']}]({src['url']})"
-        # find matching line
-        line_candidate = next(line for line in lines if line.startswith(expected))
-        assert "*License:*" in line_candidate
-        assert "*Tags:*" in line_candidate
-        if 'api_type' in src:
-            assert "*API:*" in line_candidate
-        if 'stars' in src:
-            assert "*Stars:*" in line_candidate
+        tags = ", ".join(src.get("tags", []))
+        details = f"*License:* {src.get('license', 'Unknown')} — *Tags:* {tags}"
+        if "api_type" in src:
+            details += f" — *API:* {src['api_type']}"
+        if "stars" in src:
+            details += f" — *Stars:* {src['stars']}"
+
+        expected_line = f"- [{src['name']}]({src['url']}) — {details}"
+        assert expected_line in lines


### PR DESCRIPTION
## Summary
- streamline `generate_markdown`
- simplify test assertions for generated markdown

## Testing
- `ruff check scripts/generate_sources_md.py tests/test_generate_sources_md.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab15cf050832698e988c9654a2f0d