### PR TITLE
Update lint workflow paths and ruff config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,13 @@ name: Lint
 on:
   push:
     branches: ["**"]
+    paths:
+      - 'scripts/**'
+      - 'metadata/**'
   pull_request:
+    paths:
+      - 'scripts/**'
+      - 'metadata/**'
 
 jobs:
   changes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ where = ["."]
 include = ["llm*", "scripts*", "plugins*"]
 
 [tool.ruff]
-src = ["llm", "scripts", "plugins"]
+src = ["llm", "scripts", "plugins", "api", "ui"]


### PR DESCRIPTION
## Summary
- limit lint workflow to run when scripts or metadata change
- include `api` and `ui` packages in ruff source list

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab6affaa883268b1ea0bd0750dcf9