### PR TITLE
Add sources enrichment workflow

### DIFF
--- a/.github/workflows/enrich-sources.yml
+++ b/.github/workflows/enrich-sources.yml
@@ -1,0 +1,37 @@
+name: Enrich Sources
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+      - name: Enrich sources.json
+        run: python scripts/enrich_sources.py
+      - name: Check for differences
+        id: diff
+        run: |
+          if git diff --quiet metadata/sources.json; then
+            echo "diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "diff=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Commit updated file
+        if: steps.diff.outputs.diff == 'true'
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@users.noreply.github.com
+          git add metadata/sources.json docs/awesome-sources.md
+          git commit -m "Update enriched sources" || exit 0
+          git push

--- a/docs/awesome-sources.md
+++ b/docs/awesome-sources.md
@@ -6,7 +6,7 @@ A curated list of useful resources.
 - [Docker Documentation](https://docs.docker.com/) — *License:* Apache-2.0 — *Tags:* docker, devops
 
 ## Framework
-- [FastAPI](https://github.com/tiangolo/fastapi) — *License:* MIT — *Tags:* python, web
+- [FastAPI](https://github.com/tiangolo/fastapi) — *License:* MIT — *Tags:* python, web — *API:* REST — *Stars:* 87420
 
 ## Learning
 - [Rust Book](https://doc.rust-lang.org/book/) — *License:* MIT — *Tags:* rust, learning

--- a/metadata/sources.json
+++ b/metadata/sources.json
@@ -17,7 +17,9 @@
       "python",
       "web"
     ],
-    "license": "MIT"
+    "license": "MIT",
+    "api_type": "REST",
+    "stars": 87420
   },
   {
     "name": "Rust Book",

--- a/metadata/sources.schema.json
+++ b/metadata/sources.schema.json
@@ -13,6 +13,8 @@
         "items": {"type": "string"}
       },
       "license": {"type": "string"}
+      ,"api_type": {"type": "string"}
+      ,"stars": {"type": "integer", "minimum": 0}
     },
     "required": ["name", "url", "category", "tags", "license"],
     "additionalProperties": false


### PR DESCRIPTION
## Summary
- enrich `metadata/sources.json` weekly
- allow new `api_type` and `stars` fields in schema
- regenerate documentation

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687ab6a935408326ac2b680a61b3b117