### PR TITLE
Fix ai_exec analytics default

### DIFF
--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -80,6 +80,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--analytics",
         action="store_true",
+        default=argparse.SUPPRESS,
         help="Record anonymous usage events",
     )
     args = parser.parse_args(argv)

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -177,3 +177,24 @@ def test_last_model_remote_thread_safety(monkeypatch):
     assert results["local"] == (["local-step"], False)
     assert ai_exec.last_model_remote() is False
 
+
+def test_main_env_enables_analytics(monkeypatch):
+    monkeypatch.setenv("EVENTS_ENABLED", "1")
+    monkeypatch.setattr(ai_exec.router, "run_gemini", lambda *a, **k: "step")
+    monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "step")
+    monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
+
+    recorded = []
+
+    def fake_record(name, payload, *, enabled=False):
+        recorded.append(enabled)
+        return True
+
+    monkeypatch.setattr(ai_exec, "record_event", fake_record)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_exec.main(["goal"])
+    assert rc == 0
+    assert out.getvalue().splitlines() == ["step"]
+    assert recorded == [True]
+


### PR DESCRIPTION
## Summary
- set argparse.SUPPRESS default for --analytics in ai_exec
- fallback to analytics_default when argument omitted
- test analytics default via EVENTS_ENABLED env var

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687d22f79c9c8326b11384eaf3820ca0