### PR TITLE
Fix fake_record returns in tests

### DIFF
--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -67,10 +67,6 @@ def test_send_records_event(monkeypatch):
     def fake_record(name, payload, *, enabled=False):
         recorded.append((name, payload, enabled))
         return True
-        return True
-        return True
-        return True
-        return True
 
     monkeypatch.setattr(ai_cli, "record_event", fake_record)
     out = io.StringIO()
@@ -87,6 +83,7 @@ def test_plan_records_event(monkeypatch):
 
     def fake_record(name, payload, *, enabled=False):
         recorded.append((name, payload, enabled))
+        return True
 
     monkeypatch.setattr(ai_cli, "record_event", fake_record)
     out = io.StringIO()
@@ -119,6 +116,7 @@ def test_do_records_event(monkeypatch, tmp_path):
 
     def fake_record(name, payload, *, enabled=False):
         recorded.append((name, payload, enabled))
+        return True
 
     monkeypatch.setattr(ai_cli, "record_event", fake_record)
     log = tmp_path / "log.txt"
@@ -150,6 +148,7 @@ def test_do_records_failure(monkeypatch, tmp_path):
 
     def fake_record(name, payload, *, enabled=False):
         recorded.append((name, payload, enabled))
+        return True
 
     monkeypatch.setattr(ai_cli, "record_event", fake_record)
     log = tmp_path / "log.txt"
@@ -200,6 +199,7 @@ def test_recipe_records_event(monkeypatch, tmp_path):
 
     def fake_record(name, payload, *, enabled=False):
         recorded.append((name, payload, enabled))
+        return True
 
     monkeypatch.setattr(ai_cli, "record_event", fake_record)
     log = tmp_path / "log.txt"

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -145,7 +145,6 @@ def test_main_records_event(monkeypatch, tmp_path):
     def fake_record(name, payload, *, enabled=False):
         recorded.append((name, payload, enabled))
         return True
-        return True
 
     monkeypatch.setattr(ai_do, "record_event", fake_record)
     log = tmp_path / "log.txt"
@@ -178,6 +177,7 @@ def test_main_records_failure(monkeypatch, tmp_path):
 
     def fake_record(name, payload, *, enabled=False):
         recorded.append((name, payload, enabled))
+        return True
 
     monkeypatch.setattr(ai_do, "record_event", fake_record)
     log = tmp_path / "log.txt"


### PR DESCRIPTION
## Summary
- clean up duplicated `return True` statements in tests
- ensure `fake_record` stubs consistently return a single `True`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d22f775708326bc0b44656fff4beb