### PR TITLE
Add shared analytics CLI parser

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -13,7 +13,11 @@ from typing import List, Optional
 from llm import router
 from llm.backends import initialize
 from scripts import ai_exec, ai_do, recipes, plugins
-from scripts.cli_common import execute_steps, read_prompt
+from scripts.cli_common import (
+    execute_steps,
+    read_prompt,
+    build_analytics_parser,
+)
 from telemetry import record_event, analytics_default
 import time
 
@@ -126,13 +130,7 @@ def _cmd_plugin(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    analytics = argparse.ArgumentParser(add_help=False)
-    analytics.add_argument(
-        "--analytics",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Record anonymous usage events",
-    )
+    analytics = build_analytics_parser()
 
     parser = argparse.ArgumentParser(description=__doc__, parents=[analytics])
     sub = parser.add_subparsers(dest="command", required=True)

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -12,7 +12,11 @@ import logging
 
 from scripts import ai_exec
 from llm.backends import initialize
-from scripts.cli_common import execute_steps, send_notification
+from scripts.cli_common import (
+    execute_steps,
+    send_notification,
+    build_analytics_parser,
+)
 from telemetry import record_event, analytics_default
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -45,15 +49,11 @@ def run_recipe(
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    analytics_group = build_analytics_parser()
+    parser = argparse.ArgumentParser(description=__doc__, parents=[analytics_group])
     parser.add_argument("goal", help="High level description of the task")
     parser.add_argument("--config")
     parser.add_argument("--notify", action="store_true", help="Send notification when done")
-    parser.add_argument(
-        "--analytics",
-        action="store_true",
-        help="Record anonymous usage events",
-    )
     parser.add_argument(
         "--log",
         type=Path,
@@ -62,7 +62,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    analytics = args.analytics or analytics_default()
+    analytics = getattr(args, "analytics", analytics_default())
     cfg_path = Path(args.config) if args.config else None
     start = time.time()
     steps = ai_exec.plan(args.goal, config_path=cfg_path, analytics=analytics)

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -14,7 +14,11 @@ import logging
 from llm import router
 from llm.ai_router import get_preferred_models
 from llm.backends import initialize
-from scripts.cli_common import read_prompt, send_notification
+from scripts.cli_common import (
+    read_prompt,
+    send_notification,
+    build_analytics_parser,
+)
 from telemetry import record_event, analytics_default
 import time
 
@@ -73,16 +77,11 @@ def plan(
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    analytics = build_analytics_parser()
+    parser = argparse.ArgumentParser(description=__doc__, parents=[analytics])
     parser.add_argument("goal")
     parser.add_argument("--config")
     parser.add_argument("--notify", action="store_true", help="Send notification when done")
-    parser.add_argument(
-        "--analytics",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Record anonymous usage events",
-    )
     args = parser.parse_args(argv)
     args.analytics = getattr(args, "analytics", analytics_default())
     cfg_path = Path(args.config) if args.config else None

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -1,6 +1,7 @@
 """Shared utilities for CLI modules."""
 from __future__ import annotations
 
+import argparse
 import os
 import shlex
 import subprocess
@@ -64,12 +65,25 @@ def send_notification(message: str) -> None:
     subprocess.run(["ntfy", "send", message], check=False)
 
 
+def build_analytics_parser() -> argparse.ArgumentParser:
+    """Return an argument parser handling the ``--analytics`` flag."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--analytics",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Record anonymous usage events",
+    )
+    return parser
+
+
 
 
 __all__ = [
     "read_prompt",
     "execute_steps",
     "send_notification",
+    "build_analytics_parser",
     "analytics_default",
     "record_event",
 ]


### PR DESCRIPTION
## Summary
- centralize analytics option into `build_analytics_parser`
- use helper across CLI scripts
- keep tests and linters happy

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2b0848a48326a4f555b41ae0b010