### PR TITLE
Load curated sources on API startup

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -16,6 +16,7 @@ import asyncio
 from llm import backends
 from llm.router import send_prompt
 from scripts.thm import apply_palette, REPO_ROOT
+from ume import load_sources
 from scripts import ai_exec
 
 backends.load_backends()
@@ -84,6 +85,16 @@ def get_graph() -> dict[str, list]:
 
 app = FastAPI()
 UME_API_URL = os.environ.get("UME_API_URL")
+
+# list of curated sources loaded on startup
+SOURCES: list[dict[str, Any]] = []
+
+
+@app.on_event("startup")
+def _load_sources() -> None:
+    """Populate :data:`SOURCES` from ``metadata/sources.json``."""
+    global SOURCES
+    SOURCES = load_sources()
 
 class PromptRequest(BaseModel):
     prompt: str
@@ -156,4 +167,5 @@ __all__ = [
     "get_graph",
     "plan",
     "exec_stream",
+    "SOURCES",
 ]

--- a/tests/test_ume.py
+++ b/tests/test_ume.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import json
+import ume
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_load_sources() -> None:
+    expected = json.loads((REPO_ROOT / "metadata" / "sources.json").read_text(encoding="utf-8"))
+    assert ume.load_sources() == expected

--- a/ume/__init__.py
+++ b/ume/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCES_JSON = REPO_ROOT / "metadata" / "sources.json"
+
+
+def load_sources(path: Path = SOURCES_JSON) -> list[dict[str, Any]]:
+    """Return the list of source dictionaries from ``path``."""
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+__all__ = ["load_sources", "SOURCES_JSON"]


### PR DESCRIPTION
## Summary
- add an `ume` module with `load_sources()` to parse metadata/sources.json
- load curated sources when starting the FastAPI app
- expose loaded sources via `api.SOURCES`
- test that `ume.load_sources()` returns the JSON contents

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2b074b248326809c48d366fe7217