### PR TITLE
Add Next.js and Tauri build tests

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "lint": "next lint"
   },
   "dependencies": {
     "next": "14.1.4",

--- a/tests/test_dashboard_build.py
+++ b/tests/test_dashboard_build.py
@@ -1,0 +1,29 @@
+import subprocess
+from pathlib import Path
+
+
+def test_dashboard_lint_and_build() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    dashboard_dir = repo_root / "dashboard"
+    subprocess.run(["npm", "install"], cwd=dashboard_dir, check=True)
+
+    result = subprocess.run(
+        ["npm", "run", "lint"],
+        cwd=dashboard_dir,
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout)
+    print(result.stderr)
+    assert result.returncode == 0
+
+    result = subprocess.run(
+        ["npm", "run", "build"],
+        cwd=dashboard_dir,
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout)
+    print(result.stderr)
+    assert result.returncode == 0
+

--- a/tests/test_tauri.py
+++ b/tests/test_tauri.py
@@ -34,3 +34,18 @@ def test_tauri_build_release() -> None:
     print(result.stderr)
     assert result.returncode == 0
 
+
+
+@pytest.mark.skipif(not _has_tauri_deps(), reason="missing Tauri system dependencies")
+def test_tauri_cargo_check() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    manifest = repo_root / "src-tauri" / "Cargo.toml"
+    result = subprocess.run(
+        ["cargo", "check", "--manifest-path", str(manifest)],
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout)
+    print(result.stderr)
+    assert result.returncode == 0
+


### PR DESCRIPTION
## Summary
- add npm build/lint test for dashboard
- add cargo check test for Tauri project
- enable `npm run lint` in dashboard package.json

## Testing
- `ruff check tests/test_dashboard_build.py tests/test_tauri.py`
- `mypy --install-types --non-interactive tests/test_dashboard_build.py tests/test_tauri.py`
- `pytest tests/test_dashboard_build.py tests/test_tauri.py::test_tauri_cargo_check -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3197265883269ee7c580a011b062