### PR TITLE
Extend source validation

### DIFF
--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -38,7 +38,25 @@ def validate(path: Path = SOURCES_JSON, schema_path: Path = SCHEMA_PATH) -> bool
     except jsonschema.ValidationError as exc:
         print(f"{path} failed validation: {exc.message}", file=sys.stderr)
         return False
-    return True
+
+    duplicate = False
+    seen_names: set[str] = set()
+    seen_urls: set[str] = set()
+    for entry in data:
+        name = entry.get("name")
+        url = entry.get("url")
+        if name in seen_names:
+            print(f"{path} has duplicate name: {name}", file=sys.stderr)
+            duplicate = True
+        else:
+            seen_names.add(name)
+        if url in seen_urls:
+            print(f"{path} has duplicate url: {url}", file=sys.stderr)
+            duplicate = True
+        else:
+            seen_urls.add(url)
+
+    return not duplicate
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+from scripts import validate_sources
+
+
+def _write_tmp_sources(path: Path, entries: list[dict]) -> Path:
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+def test_duplicate_name(tmp_path: Path, capsys) -> None:
+    data = [
+        {"name": "A", "url": "https://a.example", "category": "ref", "tags": ["t"], "license": "MIT"},
+        {"name": "A", "url": "https://b.example", "category": "ref", "tags": ["t"], "license": "MIT"},
+    ]
+    src = _write_tmp_sources(tmp_path / "src.json", data)
+    rc = validate_sources.main([str(src)])
+    err = capsys.readouterr().err
+    assert rc != 0
+    assert "duplicate name" in err
+
+
+def test_duplicate_url(tmp_path: Path, capsys) -> None:
+    data = [
+        {"name": "A", "url": "https://a.example", "category": "ref", "tags": ["t"], "license": "MIT"},
+        {"name": "B", "url": "https://a.example", "category": "ref", "tags": ["t"], "license": "MIT"},
+    ]
+    src = _write_tmp_sources(tmp_path / "src.json", data)
+    rc = validate_sources.main([str(src)])
+    err = capsys.readouterr().err
+    assert rc != 0
+    assert "duplicate url" in err


### PR DESCRIPTION
## Summary
- detect duplicate name or url entries in sources
- add tests covering duplicate entries

## Testing
- `ruff check scripts/validate_sources.py tests/test_validate_sources.py`
- `mypy scripts/validate_sources.py tests/test_validate_sources.py --install-types --non-interactive`
- `pytest tests/test_validate_sources.py`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687d319644f083269a8226c3b75e4ddd