### PR TITLE
Use cwd when invoking scripts in tests

### DIFF
--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -137,6 +137,7 @@ def test_script_runs(monkeypatch, tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         env=env,
+        cwd=tmp_path,
     )
 
     assert result.returncode == 0

--- a/tests/test_create_hyperv_vm.py
+++ b/tests/test_create_hyperv_vm.py
@@ -38,6 +38,7 @@ def test_create_hyperv_vm_invokes_new_vm(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     assert log_file.read_text().strip()
@@ -83,6 +84,7 @@ def test_create_hyperv_vm_parses_iso_and_cloudinit(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     assert "http://example.com/os.iso" in request_log.read_text()

--- a/tests/test_generate_settings.py
+++ b/tests/test_generate_settings.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 import importlib.util
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 def _load_generate_settings():
     spec = importlib.util.spec_from_file_location(
@@ -16,19 +18,25 @@ def _load_generate_settings():
 
 
 def test_generated_settings_up_to_date(tmp_path):
-    script = Path('windows-terminal/generate_settings.py')
-    base = Path('windows-terminal/settings.base.json')
-    common = Path('windows-terminal/common-profiles.json')
+    script = REPO_ROOT / 'windows-terminal' / 'generate_settings.py'
+    base = REPO_ROOT / 'windows-terminal' / 'settings.base.json'
+    common = REPO_ROOT / 'windows-terminal' / 'common-profiles.json'
     output = tmp_path / 'settings.json'
-    subprocess.run([
-        sys.executable,
-        str(script),
-        str(base),
-        str(output),
-        '--common',
-        str(common),
-    ], check=True)
-    expected = Path('windows-terminal/settings.json').read_text(encoding='utf-8')
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            str(base),
+            str(output),
+            '--common',
+            str(common),
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+    expected = (REPO_ROOT / 'windows-terminal' / 'settings.json').read_text(
+        encoding='utf-8'
+    )
     generated = output.read_text(encoding='utf-8')
     assert generated == expected, (
         "windows-terminal/settings.json is out of date; run generate_settings.py"
@@ -36,7 +44,7 @@ def test_generated_settings_up_to_date(tmp_path):
 
 
 def test_generate_settings_invalid_json(tmp_path: Path) -> None:
-    script = Path("windows-terminal/generate_settings.py")
+    script = REPO_ROOT / "windows-terminal" / "generate_settings.py"
     bad_base = tmp_path / "bad.json"
     bad_base.write_text("{ invalid json", encoding="utf-8")
     output = tmp_path / "out.json"
@@ -49,6 +57,7 @@ def test_generate_settings_invalid_json(tmp_path: Path) -> None:
         ],
         capture_output=True,
         text=True,
+        cwd=tmp_path,
     )
     assert result.returncode == 1
     assert f"Failed to parse JSON from {bad_base}" in result.stderr

--- a/tests/test_install_fonts.py
+++ b/tests/test_install_fonts.py
@@ -3,12 +3,15 @@ import subprocess
 from pathlib import Path
 
 
-def _run_script(env):
+def _run_script(env, cwd: Path):
     script = Path(__file__).resolve().parents[1] / "scripts" / "helpers" / "install_fonts.sh"
-    return subprocess.run([
-        "/bin/bash",
-        str(script)
-    ], env=env, capture_output=True, text=True)
+    return subprocess.run(
+        ["/bin/bash", str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
 
 
 def test_missing_curl(tmp_path):
@@ -19,7 +22,7 @@ def test_missing_curl(tmp_path):
     (stub_bin / "uname").write_text("#!/usr/bin/env bash\necho Linux\n")
     (stub_bin / "uname").chmod(0o755)
     env["PATH"] = str(stub_bin)
-    result = _run_script(env)
+    result = _run_script(env, tmp_path)
     assert result.returncode
     assert "curl is required" in result.stderr
 
@@ -34,6 +37,6 @@ def test_missing_unzip(tmp_path):
     (stub_bin / "uname").write_text("#!/usr/bin/env bash\necho Linux\n")
     (stub_bin / "uname").chmod(0o755)
     env["PATH"] = str(stub_bin)
-    result = _run_script(env)
+    result = _run_script(env, tmp_path)
     assert result.returncode
     assert "unzip is required" in result.stderr

--- a/tests/test_install_llm_tools_ps1.py
+++ b/tests/test_install_llm_tools_ps1.py
@@ -40,6 +40,7 @@ def test_install_llm_tools_uses_pipx(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     assert pipx_log.read_text().strip() == "install gemini-cli"
@@ -74,6 +75,7 @@ def test_install_llm_tools_uses_pip(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     assert pip_log.read_text().strip() == "install --user gemini-cli"

--- a/tests/test_install_windows_terminal.py
+++ b/tests/test_install_windows_terminal.py
@@ -25,6 +25,7 @@ def test_install_windows_terminal_copies_settings(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
     dest = (
         tmp_path

--- a/tests/test_install_wsl.py
+++ b/tests/test_install_wsl.py
@@ -38,6 +38,7 @@ def test_install_wsl_invokes_command(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     assert log_file.read_text().strip() == "--install"

--- a/tests/test_provision_vm.py
+++ b/tests/test_provision_vm.py
@@ -39,6 +39,7 @@ def test_provision_vm_wsl_import(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     args = log_file.read_text().strip().split()
@@ -72,6 +73,7 @@ def test_provision_vm_hyperv(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     contents = ps_log.read_text()

--- a/tests/test_setup_screenshot_env.py
+++ b/tests/test_setup_screenshot_env.py
@@ -26,7 +26,12 @@ def test_setup_screenshot_env_apt(tmp_path: Path) -> None:
     create_exe(bin_dir / "dpkg", "#!/usr/bin/env bash\n:")
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
-    subprocess.run(["/bin/bash", str(REPO_ROOT / "scripts" / "setup-screenshot-env.sh")], check=True, env=env)
+    subprocess.run(
+        ["/bin/bash", str(REPO_ROOT / "scripts" / "setup-screenshot-env.sh")],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
     lines = apt_log.read_text().splitlines()
     assert lines and lines[0] == "update"
     assert any("install" in line for line in lines)
@@ -47,7 +52,12 @@ def test_setup_screenshot_env_pacman(tmp_path: Path) -> None:
     (bin_dir / "bash").symlink_to("/bin/bash")
     env = os.environ.copy()
     env["PATH"] = str(bin_dir)
-    subprocess.run(["/bin/bash", str(REPO_ROOT / "scripts" / "setup-screenshot-env.sh")], check=True, env=env)
+    subprocess.run(
+        ["/bin/bash", str(REPO_ROOT / "scripts" / "setup-screenshot-env.sh")],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
     lines = pac_log.read_text().splitlines()
     assert lines and lines[0].startswith("-Sy")
     assert any("nushell" in line for line in lines)
@@ -65,7 +75,12 @@ def test_setup_screenshot_env_brew(tmp_path: Path) -> None:
     create_exe(bin_dir / "uname", "#!/usr/bin/env bash\necho Darwin\n")
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
-    subprocess.run(["/bin/bash", str(REPO_ROOT / "scripts" / "setup-screenshot-env.sh")], check=True, env=env)
+    subprocess.run(
+        ["/bin/bash", str(REPO_ROOT / "scripts" / "setup-screenshot-env.sh")],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
     lines = brew_log.read_text().splitlines()
     assert any("install" in line for line in lines)
     assert any("nushell" in line for line in lines)
@@ -97,6 +112,7 @@ def test_setup_screenshot_env_ps1(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
     content = winget_log.read_text().splitlines()
     assert content, "winget should be invoked"

--- a/tests/test_setup_winget.py
+++ b/tests/test_setup_winget.py
@@ -40,6 +40,7 @@ def test_setup_winget_installs_packages(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
     lines = winget_log.read_text().splitlines()
     ids = [line.split()[line.split().index("--id") + 1] for line in lines]

--- a/tests/test_setup_wsl.py
+++ b/tests/test_setup_wsl.py
@@ -48,7 +48,12 @@ fi
         "HOME": str(fake_root),
     })
 
-    subprocess.run(["bash", str(REPO_ROOT / "scripts" / "setup-wsl.sh")], check=True, env=env)
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts" / "setup-wsl.sh")],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
 
     bat_link = usr_local_bin / "bat"
     fd_link = usr_local_bin / "fd"
@@ -105,6 +110,7 @@ def test_setup_wsl_requires_sudo(tmp_path):
         env=env,
         capture_output=True,
         text=True,
+        cwd=tmp_path,
     )
 
     assert result.returncode != 0
@@ -130,7 +136,12 @@ def test_setup_wsl_root_without_sudo(tmp_path):
         "PATH": str(bin_dir),
     })
 
-    subprocess.run(["/bin/bash", str(REPO_ROOT / "scripts" / "setup-wsl.sh")], check=True, env=env)
+    subprocess.run(
+        ["/bin/bash", str(REPO_ROOT / "scripts" / "setup-wsl.sh")],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
 
 
 def test_setup_wsl_requires_apt_get(tmp_path):
@@ -160,6 +171,7 @@ def test_setup_wsl_requires_apt_get(tmp_path):
         env=env,
         capture_output=True,
         text=True,
+        cwd=tmp_path,
     )
 
     assert result.returncode != 0
@@ -194,6 +206,7 @@ def test_setup_wsl_starship_install_failure(tmp_path):
         env=env,
         capture_output=True,
         text=True,
+        cwd=tmp_path,
     )
 
     assert result.returncode != 0
@@ -229,6 +242,7 @@ def test_setup_wsl_zoxide_install_failure(tmp_path):
         env=env,
         capture_output=True,
         text=True,
+        cwd=tmp_path,
     )
 
     assert result.returncode != 0

--- a/tests/test_setup_wsl_ps1.py
+++ b/tests/test_setup_wsl_ps1.py
@@ -38,6 +38,7 @@ def test_setup_wsl_ps1_invokes_wsl(tmp_path: Path) -> None:
         ],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     args = log_file.read_text().strip().split()
@@ -65,6 +66,7 @@ def test_setup_wsl_ps1_falls_back_to_bash(tmp_path: Path) -> None:
         [pwsh, "-NoLogo", "-NoProfile", "-File", str(REPO_ROOT / "scripts" / "setup-wsl.ps1")],
         check=True,
         env=env,
+        cwd=tmp_path,
     )
 
     args = log_file.read_text().strip().split()
@@ -95,6 +97,7 @@ def test_setup_wsl_ps1_requires_wsl(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         env=env,
+        cwd=tmp_path,
     )
 
     assert result.returncode != 0

--- a/tests/test_smoke_test.py
+++ b/tests/test_smoke_test.py
@@ -66,6 +66,7 @@ fi
         capture_output=True,
         text=True,
         env=env,
+        cwd=tmp_path,
     )
 
     assert result.returncode == 0

--- a/tests/test_thm.py
+++ b/tests/test_thm.py
@@ -16,6 +16,7 @@ def test_list_palettes_outputs_available_palettes(tmp_path):
         capture_output=True,
         text=True,
         check=True,
+        cwd=tmp_path,
     )
     output = result.stdout.strip().splitlines()
     assert "blacklight" in output
@@ -37,12 +38,17 @@ def test_apply_updates_configs(tmp_path):
 
     env = os.environ.copy()
     env["THM_REPO_ROOT"] = str(dest)
-    subprocess.run([
-        sys.executable,
-        str(script),
-        "apply",
-        "dracula",
-    ], check=True, env=env)
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "apply",
+            "dracula",
+        ],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
 
     import tomllib
     data = tomllib.loads((dest / "starship.toml").read_text())
@@ -74,6 +80,7 @@ def test_apply_unknown_palette_errors(tmp_path):
             [sys.executable, str(script), "apply", "missing"],
             check=True,
             env=env,
+            cwd=tmp_path,
         )
 
 
@@ -103,6 +110,7 @@ def test_apply_missing_starship_errors(tmp_path):
         capture_output=True,
         text=True,
         env=env,
+        cwd=tmp_path,
     )
     assert result.returncode == 1
     assert "starship.toml" in result.stderr
@@ -128,6 +136,7 @@ def test_apply_missing_wt_settings_errors(tmp_path):
         capture_output=True,
         text=True,
         env=env,
+        cwd=tmp_path,
     )
     assert result.returncode == 1
     assert "windows-terminal" in result.stderr or "settings.json" in result.stderr

--- a/tests/test_validate_winget.py
+++ b/tests/test_validate_winget.py
@@ -13,6 +13,7 @@ def test_validate_winget_malformed(tmp_path: Path) -> None:
         [sys.executable, str(REPO_ROOT / "scripts" / "validate_winget.py"), str(bad_json)],
         capture_output=True,
         text=True,
+        cwd=tmp_path,
     )
     assert result.returncode != 0
     assert "Failed to parse" in result.stderr
@@ -28,6 +29,7 @@ def test_validate_winget_success(tmp_path: Path) -> None:
         [sys.executable, str(REPO_ROOT / "scripts" / "validate_winget.py"), str(valid_json)],
         capture_output=True,
         text=True,
+        cwd=tmp_path,
     )
     assert result.returncode == 0
 


### PR DESCRIPTION
## Summary
- ensure subprocess.run calls run from the temporary directory
- keep generated settings test paths absolute

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3195b5588326bc400a2e6e128dd2