### PR TITLE
Add jsonschema to test extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ they are missing:
 ```bash
 pip install -e .[cli,plugins] -r requirements.txt
 ```
-The `[plugins]` extra installs `jsonschema` so you can manage plug-ins
+The `[plugins]` and `[test]` extras install `jsonschema` so you can manage plug-ins
 with `python -m scripts.plugins`. For example:
 
 ```bash
@@ -43,7 +43,7 @@ python -m scripts.plugins backends install openrouter
 ```
 
 See the [backend plug-in guide](docs/plugins.md) for details. If you
-prefer not to install the extras, install `jsonschema` separately with:
+prefer not to install any extras, install `jsonschema` separately with:
 
 ```bash
 pip install jsonschema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ test = [
     "fastapi",
     "uvicorn",
     "httpx",
+    "jsonschema",
 ]
 cli = ["tomli_w", "jsonschema"]
 lmql = ["lmql"]


### PR DESCRIPTION
## Summary
- include jsonschema in the `[test]` optional dependency group
- clarify in README that `[test]` installs jsonschema

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto` *(fails: tests/test_ai_exec.py::test_script_runs)*

------
https://chatgpt.com/codex/tasks/task_e_687d3faeda748326b159f35b489b0264