### PR TITLE
Add GitHub token support for enrichment

### DIFF
--- a/.github/workflows/enrich-sources.yml
+++ b/.github/workflows/enrich-sources.yml
@@ -19,6 +19,8 @@ jobs:
           pip install requests
       - name: Enrich sources.json
         run: python scripts/enrich_sources.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check for differences
         id: diff
         run: |

--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ API information:
 python scripts/enrich_sources.py
 ```
 
+Set `GITHUB_TOKEN` to a personal access token to avoid GitHub API rate
+limits when enriching sources.
+
 After editing the JSON file regenerate the Markdown list with:
 
 ```bash

--- a/scripts/enrich_sources.py
+++ b/scripts/enrich_sources.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any, List
@@ -36,8 +37,12 @@ def fetch_github_stars(url: str) -> int | None:
     if not match:
         return None
     api_url = f"https://api.github.com/repos/{match.group(1)}/{match.group(2)}"
+    headers = None
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers = {"Authorization": f"Bearer {token}"}
     try:
-        resp = requests.get(api_url, timeout=5)
+        resp = requests.get(api_url, headers=headers, timeout=5)
         resp.raise_for_status()
         data = resp.json()
         stars = data.get("stargazers_count")

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -12,6 +12,8 @@ pytest.importorskip("requests")
 
 from scripts import ai_exec
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_plan_uses_primary(monkeypatch):
     calls = []
@@ -121,7 +123,9 @@ def test_script_runs(monkeypatch, tmp_path: Path) -> None:
     (stub_dir / "dspy" / "__init__.py").write_text("raise ImportError('stub')")
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = f"{stub_dir}:{env.get('PYTHONPATH', '')}"
+    env["PYTHONPATH"] = (
+        f"{REPO_ROOT}:{stub_dir}:{env.get('PYTHONPATH', '')}"
+    )
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()

--- a/tests/test_enrich_sources.py
+++ b/tests/test_enrich_sources.py
@@ -14,7 +14,7 @@ def test_enrich_sources_adds_fields(monkeypatch):
         def json():
             return {"stargazers_count": 42}
 
-    def fake_get(url, *, timeout):
+    def fake_get(url, *, timeout, headers=None):
         assert url == "https://api.github.com/repos/owner/api"
         assert timeout == 5
         return FakeResponse()


### PR DESCRIPTION
## Summary
- allow `enrich_sources.py` to use a `GITHUB_TOKEN`
- document the token in README
- pass the token in the enrichment workflow
- update tests for new header handling

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3fae69c08326b5552d143f10aa30