### PR TITLE
Refactor CLI analytics into shared helper

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -6,19 +6,18 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
-import logging
 from pathlib import Path
 from typing import List, Optional
 
 from llm import router
 from llm.backends import initialize
-from scripts import ai_exec, ai_do, recipes, plugins
+from scripts import ai_exec, recipes, plugins
 from scripts.cli_common import (
-    execute_steps,
     read_prompt,
     build_analytics_parser,
 )
-from telemetry import record_event, analytics_default
+from scripts import cli_actions
+from telemetry import analytics_default
 import time
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -32,16 +31,16 @@ def _cmd_send(args: argparse.Namespace) -> int:
         output = router.send_prompt(prompt, local=args.local, model=args.model)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)
-        success = record_event("ai-cli-send", {"exit_code": 1}, enabled=args.analytics)
-        if not success:
-            logging.debug("Failed to record telemetry")
+        cli_actions.record_event_logged(
+            "ai-cli-send", {"exit_code": 1}, enabled=args.analytics
+        )
         return 1
     sys.stdout.write(output)
     if not output.endswith("\n"):
         sys.stdout.write("\n")
-    success = record_event("ai-cli-send", {"exit_code": 0}, enabled=args.analytics)
-    if not success:
-        logging.debug("Failed to record telemetry")
+    cli_actions.record_event_logged(
+        "ai-cli-send", {"exit_code": 0}, enabled=args.analytics
+    )
     return 0
 
 
@@ -51,7 +50,7 @@ def _cmd_plan(args: argparse.Namespace) -> int:
     for step in steps:
         print(step)
     end = time.time()
-    success = record_event(
+    cli_actions.record_event_logged(
         "ai-cli-plan",
         {
             "goal": args.goal,
@@ -62,32 +61,20 @@ def _cmd_plan(args: argparse.Namespace) -> int:
         },
         enabled=args.analytics,
     )
-    if not success:
-        logging.debug("Failed to record telemetry")
     return 0
 
 
 def _cmd_do(args: argparse.Namespace) -> int:
-    start = time.time()
     steps = ai_exec.plan(
         args.goal, config_path=args.config, analytics=args.analytics
     )
-    exit_code = execute_steps(steps, log_path=args.log)
-    end = time.time()
-    success = record_event(
+    return cli_actions.run_steps(
         "ai-cli-do",
-        {
-            "goal": args.goal,
-            "exit_code": exit_code,
-            "start_ts": start,
-            "end_ts": end,
-            "latency_ms": int((end - start) * 1000),
-        },
-        enabled=args.analytics,
+        steps,
+        log_path=args.log,
+        analytics=args.analytics,
+        payload={"goal": args.goal, "step_count": len(steps)},
     )
-    if not success:
-        logging.debug("Failed to record telemetry")
-    return exit_code
 
 
 def _cmd_recipe(args: argparse.Namespace) -> int:
@@ -98,7 +85,7 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
         return 1
     recipe_func = mapping[args.name]
     steps = recipe_func(args.goal)
-    exit_code = ai_do.run_recipe(
+    exit_code = cli_actions.run_recipe(
         args.name,
         args.goal,
         steps,
@@ -107,7 +94,7 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
     )
     end = time.time()
     if exit_code == 0:
-        success = record_event(
+        cli_actions.record_event_logged(
             "ai-cli-recipe",
             {
                 "recipe": args.name,
@@ -120,8 +107,6 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
             },
             enabled=args.analytics,
         )
-        if not success:
-            logging.debug("Failed to record telemetry")
     return exit_code
 
 

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -7,17 +7,15 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence
-import time
-import logging
 
 from scripts import ai_exec
 from llm.backends import initialize
 from scripts.cli_common import (
-    execute_steps,
     send_notification,
     build_analytics_parser,
 )
-from telemetry import record_event, analytics_default
+from scripts import cli_actions
+from telemetry import analytics_default
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -33,19 +31,13 @@ def run_recipe(
     analytics: bool = False,
 ) -> int:
     """Execute a recipe given steps or a callable and record an event."""
-    if callable(steps_or_callable):
-        steps = list(steps_or_callable(goal))
-    else:
-        steps = list(steps_or_callable)
-    exit_code = execute_steps(steps, log_path=log_path)
-    success = record_event(
-        "ai-do-recipe",
-        {"recipe": name, "goal": goal, "exit_code": exit_code},
-        enabled=analytics,
+    return cli_actions.run_recipe(
+        name,
+        goal,
+        steps_or_callable,
+        log_path=log_path,
+        analytics=analytics,
     )
-    if not success:
-        logging.debug("Failed to record telemetry")
-    return exit_code
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -64,28 +56,23 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     analytics = getattr(args, "analytics", analytics_default())
     cfg_path = Path(args.config) if args.config else None
-    start = time.time()
     steps = ai_exec.plan(args.goal, config_path=cfg_path, analytics=analytics)
-    exit_code = execute_steps(steps, log_path=args.log)
-    end = time.time()
+    exit_code = cli_actions.run_steps(
+        "ai-do",
+        steps,
+        log_path=args.log,
+        analytics=analytics,
+        payload={
+            "goal": args.goal,
+            "model_source": "remote" if ai_exec.last_model_remote() else "local",
+        },
+        duration_key="duration_ms",
+    )
     if args.notify:
         if exit_code == 0:
             send_notification("ai-do completed with exit code 0")
         else:
             send_notification(f"ai-do failed with exit code {exit_code}")
-    success = record_event(
-        "ai-do",
-        {
-            "goal": args.goal,
-            "exit_code": exit_code,
-            "duration_ms": int((end - start) * 1000),
-            "model_source": "remote" if ai_exec.last_model_remote() else "local",
-        },
-        enabled=analytics,
-    )
-    if not success:
-        logging.debug("Failed to record telemetry")
-
     return exit_code
 
 

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -9,7 +9,6 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 from threading import Lock
-import logging
 
 from llm import router
 from llm.ai_router import get_preferred_models
@@ -19,7 +18,8 @@ from scripts.cli_common import (
     send_notification,
     build_analytics_parser,
 )
-from telemetry import record_event, analytics_default
+from scripts import cli_actions
+from telemetry import analytics_default
 import time
 
 _LAST_MODEL_REMOTE = True
@@ -61,7 +61,7 @@ def plan(
         end = time.time()
         with _LAST_MODEL_LOCK:
             _LAST_MODEL_REMOTE = used_remote
-        success = record_event(
+        cli_actions.record_event_logged(
             "ai-exec-plan",
             {
                 "goal": goal,
@@ -72,8 +72,6 @@ def plan(
             },
             enabled=analytics,
         )
-        if not success:
-            logging.debug("Failed to record telemetry")
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Iterable, Callable, Sequence, Any
+
+from scripts.cli_common import execute_steps
+from telemetry import record_event
+
+
+def record_event_logged(name: str, payload: dict[str, Any], *, enabled: bool = False) -> None:
+    """Record an analytics event and log failures."""
+    success = record_event(name, payload, enabled=enabled)
+    if not success:
+        logging.debug("Failed to record telemetry")
+
+
+def run_steps(
+    event_name: str,
+    steps: Iterable[str],
+    *,
+    log_path: Path,
+    analytics: bool = False,
+    payload: dict[str, Any] | None = None,
+    duration_key: str = "latency_ms",
+) -> int:
+    """Execute ``steps`` and record an analytics event."""
+    start = time.time()
+    exit_code = execute_steps(steps, log_path=log_path)
+    end = time.time()
+    data = {
+        "exit_code": exit_code,
+        "start_ts": start,
+        "end_ts": end,
+        duration_key: int((end - start) * 1000),
+    }
+    if payload:
+        data.update(payload)
+    record_event_logged(event_name, data, enabled=analytics)
+    return exit_code
+
+
+def run_recipe(
+    name: str,
+    goal: str,
+    steps_or_callable: Sequence[str] | Callable[[str], Sequence[str]],
+    *,
+    log_path: Path,
+    analytics: bool = False,
+) -> int:
+    """Execute a recipe and record an analytics event."""
+    if callable(steps_or_callable):
+        steps = list(steps_or_callable(goal))
+    else:
+        steps = list(steps_or_callable)
+    return run_steps(
+        "ai-do-recipe",
+        steps,
+        log_path=log_path,
+        analytics=analytics,
+        payload={"recipe": name, "goal": goal, "step_count": len(steps)},
+    )
+
+__all__ = ["record_event_logged", "run_steps", "run_recipe"]

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -6,6 +6,7 @@ import pytest
 pytest.importorskip("requests")
 
 from scripts import ai_cli
+from scripts import cli_actions
 
 
 def test_send_subcommand(monkeypatch):
@@ -68,7 +69,7 @@ def test_send_records_event(monkeypatch):
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr(ai_cli, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
         rc = ai_cli.main(["send", "msg", "--analytics"])
@@ -85,7 +86,7 @@ def test_plan_records_event(monkeypatch):
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr(ai_cli, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
         rc = ai_cli.main(["plan", "goal", "--analytics"])
@@ -118,7 +119,7 @@ def test_do_records_event(monkeypatch, tmp_path):
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr(ai_cli, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     log = tmp_path / "log.txt"
     rc = ai_cli.main(["do", "goal", "--log", str(log), "--analytics"])
 
@@ -150,7 +151,7 @@ def test_do_records_failure(monkeypatch, tmp_path):
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr(ai_cli, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     log = tmp_path / "log.txt"
     rc = ai_cli.main(["do", "goal", "--log", str(log), "--analytics"])
 
@@ -179,7 +180,7 @@ def test_recipe_subcommand(monkeypatch, tmp_path):
         captured["analytics"] = analytics
         return 0
 
-    monkeypatch.setattr(ai_cli.ai_do, "run_recipe", fake_run_recipe)
+    monkeypatch.setattr(cli_actions, "run_recipe", fake_run_recipe)
     log = tmp_path / "log.txt"
     rc = ai_cli.main(["recipe", "dummy", "goal", "--log", str(log)])
     assert rc == 0
@@ -193,15 +194,14 @@ def test_recipe_records_event(monkeypatch, tmp_path):
     monkeypatch.setattr(
         ai_cli.recipes, "discover_recipes", lambda: {"dummy": lambda g: []}
     )
-    monkeypatch.setattr(ai_cli, "execute_steps", lambda *a, **k: 0)
-    monkeypatch.setattr(ai_cli.ai_do, "run_recipe", lambda *a, **k: 0)
+    monkeypatch.setattr(cli_actions, "run_recipe", lambda *a, **k: 0)
     recorded = []
 
     def fake_record(name, payload, *, enabled=False):
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr(ai_cli, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     log = tmp_path / "log.txt"
     rc = ai_cli.main([
         "recipe",

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -6,7 +6,7 @@ import pytest
 
 pytest.importorskip("requests")
 
-from scripts import ai_do, ai_exec
+from scripts import ai_do, ai_exec, cli_actions
 
 
 def test_main_runs_and_logs(monkeypatch, tmp_path):
@@ -146,7 +146,7 @@ def test_main_records_event(monkeypatch, tmp_path):
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr(ai_do, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     log = tmp_path / "log.txt"
     rc = ai_do.main(["goal", "--log", str(log), "--analytics"])
 
@@ -179,7 +179,7 @@ def test_main_records_failure(monkeypatch, tmp_path):
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr(ai_do, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     log = tmp_path / "log.txt"
     rc = ai_do.main(["goal", "--log", str(log), "--analytics"])
 

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 pytest.importorskip("requests")
 
-from scripts import ai_exec
+from scripts import ai_exec, cli_actions
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -94,7 +94,7 @@ def test_plan_records_event(monkeypatch):
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr(ai_exec, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     steps = ai_exec.plan("goal", analytics=True)
     assert steps == ["step"]
     name, payload, enabled = recorded[0]
@@ -195,7 +195,7 @@ def test_main_env_enables_analytics(monkeypatch):
         recorded.append(enabled)
         return True
 
-    monkeypatch.setattr(ai_exec, "record_event", fake_record)
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
         rc = ai_exec.main(["goal"])


### PR DESCRIPTION
## Summary
- add `cli_actions` helper to centralize analytics and execution
- update `ai_cli`, `ai_exec`, and `ai_do` to use the new helpers
- refactor tests to target `cli_actions` functions

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4a2eaaf8832685391cf5199fab10