### PR TITLE
Switch to FastAPI lifespan

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from threading import RLock
 
 from fastapi import FastAPI, HTTPException
+from contextlib import asynccontextmanager
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 import requests
@@ -83,18 +84,19 @@ def get_graph() -> dict[str, list]:
     state = _load_state()
     return {"nodes": state["nodes"], "edges": state["edges"]}
 
-app = FastAPI()
-UME_API_URL = os.environ.get("UME_API_URL")
-
 # list of curated sources loaded on startup
 SOURCES: list[dict[str, Any]] = []
 
 
-@app.on_event("startup")
-def _load_sources() -> None:
-    """Populate :data:`SOURCES` from ``metadata/sources.json``."""
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Load curated sources during application startup."""
     global SOURCES
     SOURCES = load_sources()
+    yield
+
+app = FastAPI(lifespan=lifespan)
+UME_API_URL = os.environ.get("UME_API_URL")
 
 class PromptRequest(BaseModel):
     prompt: str

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -29,33 +29,33 @@ def load_app(send_prompt=lambda p, local=False: f"resp-{p}", apply_palette=lambd
 
 def test_health(tmp_path):
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.get('/api/health')
-    assert resp.status_code == 200
-    assert resp.json() == {'status': 'ok'}
+    with TestClient(app) as client:
+        resp = client.get('/api/health')
+        assert resp.status_code == 200
+        assert resp.json() == {'status': 'ok'}
 
 
 def test_stats_local(tmp_path):
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.get('/api/stats')
-    assert resp.status_code == 200
-    assert resp.json() == {'queries': 0, 'memory': 0}
+    with TestClient(app) as client:
+        resp = client.get('/api/stats')
+        assert resp.status_code == 200
+        assert resp.json() == {'queries': 0, 'memory': 0}
 
 
 
 def test_graph_local(tmp_path):
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.post('/api/prompt', json={'prompt': 'one'})
-    assert resp.status_code == 200
-    resp = client.post('/api/prompt', json={'prompt': 'two'})
-    assert resp.status_code == 200
-    resp = client.get('/api/graph')
-    assert resp.status_code == 200
-    data = resp.json()
-    assert len(data['nodes']) == 2
-    assert len(data['edges']) == 1
+    with TestClient(app) as client:
+        resp = client.post('/api/prompt', json={'prompt': 'one'})
+        assert resp.status_code == 200
+        resp = client.post('/api/prompt', json={'prompt': 'two'})
+        assert resp.status_code == 200
+        resp = client.get('/api/graph')
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data['nodes']) == 2
+        assert len(data['edges']) == 1
 
 
 def test_stats_remote(monkeypatch, tmp_path):
@@ -79,11 +79,11 @@ def test_stats_remote(monkeypatch, tmp_path):
     monkeypatch.setenv('UME_API_URL', 'http://ume')
     monkeypatch.setattr(requests, 'get', fake_get)
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.get('/api/stats')
-    assert resp.status_code == 200
-    assert resp.json() == {'queries': 1, 'memory': 2}
-    assert calls == [('http://ume/dashboard/stats', 5)]
+    with TestClient(app) as client:
+        resp = client.get('/api/stats')
+        assert resp.status_code == 200
+        assert resp.json() == {'queries': 1, 'memory': 2}
+        assert calls == [('http://ume/dashboard/stats', 5)]
 
 
 def test_graph_remote(monkeypatch, tmp_path):
@@ -107,11 +107,11 @@ def test_graph_remote(monkeypatch, tmp_path):
     monkeypatch.setenv('UME_API_URL', 'http://ume')
     monkeypatch.setattr(requests, 'get', fake_get)
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.get('/api/graph')
-    assert resp.status_code == 200
-    assert resp.json() == {'nodes': ['n1'], 'edges': ['e1']}
-    assert calls == [('http://ume/graph', 5)]
+    with TestClient(app) as client:
+        resp = client.get('/api/graph')
+        assert resp.status_code == 200
+        assert resp.json() == {'nodes': ['n1'], 'edges': ['e1']}
+        assert calls == [('http://ume/graph', 5)]
 
 
 def test_stats_remote_connection_error(monkeypatch, tmp_path):
@@ -121,9 +121,9 @@ def test_stats_remote_connection_error(monkeypatch, tmp_path):
     monkeypatch.setenv('UME_API_URL', 'http://ume')
     monkeypatch.setattr(requests, 'get', fake_get)
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.get('/api/stats')
-    assert resp.status_code == 503
+    with TestClient(app) as client:
+        resp = client.get('/api/stats')
+        assert resp.status_code == 503
 
 
 def test_graph_remote_connection_error(monkeypatch, tmp_path):
@@ -133,9 +133,9 @@ def test_graph_remote_connection_error(monkeypatch, tmp_path):
     monkeypatch.setenv('UME_API_URL', 'http://ume')
     monkeypatch.setattr(requests, 'get', fake_get)
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.get('/api/graph')
-    assert resp.status_code == 503
+    with TestClient(app) as client:
+        resp = client.get('/api/graph')
+        assert resp.status_code == 503
 
 
 def test_prompt(tmp_path):
@@ -144,11 +144,11 @@ def test_prompt(tmp_path):
         calls.append(prompt)
         return 'ok-' + prompt
     app = load_app(send_prompt=fake, state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.post('/api/prompt', json={'prompt': 'hello'})
-    assert resp.status_code == 200
-    assert resp.json() == {'response': 'ok-hello'}
-    assert calls == ['hello']
+    with TestClient(app) as client:
+        resp = client.post('/api/prompt', json={'prompt': 'hello'})
+        assert resp.status_code == 200
+        assert resp.json() == {'response': 'ok-hello'}
+        assert calls == ['hello']
 
 
 def test_palette(tmp_path):
@@ -156,11 +156,11 @@ def test_palette(tmp_path):
     def fake(name: str, repo_root: Path):
         calls.append(name)
     app = load_app(apply_palette=fake, state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.post('/api/palette', json={'name': 'dracula'})
-    assert resp.status_code == 200
-    assert resp.json() == {'status': 'applied'}
-    assert calls == ['dracula']
+    with TestClient(app) as client:
+        resp = client.post('/api/palette', json={'name': 'dracula'})
+        assert resp.status_code == 200
+        assert resp.json() == {'status': 'applied'}
+        assert calls == ['dracula']
 
 
 def test_prompt_real_modules(monkeypatch, tmp_path):
@@ -177,19 +177,19 @@ def test_prompt_real_modules(monkeypatch, tmp_path):
         del sys.modules['api']
     api = importlib.import_module('api')
     monkeypatch.setattr(api, 'send_prompt', fake)
-    client = TestClient(api.app)
-    resp = client.post('/api/prompt', json={'prompt': 'hello'})
-    assert resp.status_code == 200
-    assert resp.json() == {'response': 'ok-hello'}
-    assert calls == ['hello']
+    with TestClient(api.app) as client:
+        resp = client.post('/api/prompt', json={'prompt': 'hello'})
+        assert resp.status_code == 200
+        assert resp.json() == {'response': 'ok-hello'}
+        assert calls == ['hello']
 
 
 def test_exec_stream(monkeypatch, tmp_path):
     monkeypatch.setattr(ai_exec, 'plan', lambda goal: ['echo hi'])
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    with client.stream('GET', '/api/exec', params={'goal': 'echo hi'}) as r:
-        lines = [line for line in r.iter_lines() if line]
+    with TestClient(app) as client:
+        with client.stream('GET', '/api/exec', params={'goal': 'echo hi'}) as r:
+            lines = [line for line in r.iter_lines() if line]
 
     assert 'data: $ echo hi' in lines
     assert 'data: hi' in lines
@@ -204,10 +204,10 @@ def test_stats_remote_timeout(monkeypatch, tmp_path):
 
     monkeypatch.setattr(requests, 'get', fake_get)
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.get('/api/stats')
-    assert resp.status_code == 200
-    assert resp.json() == {'queries': 0, 'memory': 0}
+    with TestClient(app) as client:
+        resp = client.get('/api/stats')
+        assert resp.status_code == 200
+        assert resp.json() == {'queries': 0, 'memory': 0}
 
 
 def test_graph_remote_timeout(monkeypatch, tmp_path):
@@ -218,7 +218,7 @@ def test_graph_remote_timeout(monkeypatch, tmp_path):
 
     monkeypatch.setattr(requests, 'get', fake_get)
     app = load_app(state_path=tmp_path / 'state.json')
-    client = TestClient(app)
-    resp = client.get('/api/graph')
-    assert resp.status_code == 200
-    assert resp.json() == {'nodes': [], 'edges': []}
+    with TestClient(app) as client:
+        resp = client.get('/api/graph')
+        assert resp.status_code == 200
+        assert resp.json() == {'nodes': [], 'edges': []}


### PR DESCRIPTION
## Summary
- update API to use FastAPI lifespan context
- adjust tests for lifespan handling

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest tests/test_api_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e49931fd88326b1f1179763282f7e