### PR TITLE
Add coverage for sources markdown

### DIFF
--- a/tests/test_generate_sources_md.py
+++ b/tests/test_generate_sources_md.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+
+import pytest
+
 from scripts import generate_sources_md
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -8,7 +11,10 @@ def test_awesome_sources_md_up_to_date():
     sources = generate_sources_md.load_sources()
     markdown = generate_sources_md.generate_markdown(sources)
     current = (REPO_ROOT / "docs" / "awesome-sources.md").read_text(encoding="utf-8")
-    assert markdown == current
+    assert markdown == current, (
+        "docs/awesome-sources.md is outdated. "
+        "Run 'python scripts/generate_sources_md.py' and commit the result."
+    )
 
 
 def test_generate_markdown_details_format():
@@ -25,3 +31,31 @@ def test_generate_markdown_details_format():
 
         expected_line = f"- [{src['name']}]({src['url']}) — {details}"
         assert expected_line in lines
+
+
+def test_generate_markdown_categories_sorted() -> None:
+    sources = generate_sources_md.load_sources()
+    markdown = generate_sources_md.generate_markdown(sources)
+    categories = [line[3:] for line in markdown.splitlines() if line.startswith("## ")]
+    assert categories == sorted(categories)
+
+
+def test_failure_message_on_sources_change(tmp_path: Path) -> None:
+    sources = generate_sources_md.load_sources()
+    sources.append(
+        {
+            "name": "Tmp",
+            "url": "https://example.com",
+            "category": "Zzz",
+            "tags": [],
+            "license": "MIT",
+        }
+    )
+    markdown = generate_sources_md.generate_markdown(sources)
+    current = (REPO_ROOT / "docs" / "awesome-sources.md").read_text(encoding="utf-8")
+    with pytest.raises(AssertionError) as exc:
+        assert markdown == current, (
+            "docs/awesome-sources.md is outdated. "
+            "Run 'python scripts/generate_sources_md.py' and commit the result."
+        )
+    assert "Run 'python scripts/generate_sources_md.py'" in str(exc.value)


### PR DESCRIPTION
## Summary
- assert README generation instructions in tests
- check categories are sorted
- confirm failure message when `sources.json` changes

## Testing
- `ruff check tests/test_generate_sources_md.py`
- `pytest tests/test_generate_sources_md.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e586bb858832688b8bbcd692486d5