### PR TITLE
Handle optional dependencies gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,13 @@ Then invoke `pytest`:
 pytest
 ```
 
+If you have the `pytest-xdist` plugin installed (included with the `[test]`
+extra) you can run the suite in parallel:
+
+```bash
+pytest -n auto || pytest
+```
+
 ## Contributing
 
 Run `ruff` and `mypy` before committing to ensure the code is lint and type

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,9 @@
 -e .[test]
+# Optional extras to enable full functionality
+# CLI tools and plugin management
+-e .[cli,plugins]
+# Advanced backends
+# -e .[lmql]
+# -e .[guidance]
+# -e .[etl]
 -r requirements.txt

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -1,6 +1,10 @@
 import json
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("jsonschema")
+
 from scripts import validate_sources
 
 


### PR DESCRIPTION
## Summary
- skip validate_sources tests if `jsonschema` isn't installed
- document how to enable `pytest-xdist` parallelization
- list optional extras in `requirements-dev.txt`

## Testing
- `pytest -q`
- `ruff check .`
- `mypy --install-types --non-interactive`


------
https://chatgpt.com/codex/tasks/task_e_687e586b08708326a5ac788449d9462a