### PR TITLE
Update telemetry status handling

### DIFF
--- a/telemetry.py
+++ b/telemetry.py
@@ -39,11 +39,11 @@ def record_event(name: str, payload: dict[str, Any], *, enabled: bool = False) -
     developer = uuid.uuid5(uuid.NAMESPACE_DNS, dev_src).hex
     data = {"name": name, "developer": developer, **payload}
     try:
-        requests.post(url, headers=headers, json=data, timeout=5)
+        response = requests.post(url, headers=headers, json=data, timeout=5)
     except Exception as exc:  # noqa: BLE001
         logging.warning("Failed to record telemetry event: %s", exc)
         return False
-    return True
+    return response.status_code // 100 == 2
 
 
 __all__ = ["analytics_default", "record_event"]

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -28,6 +28,11 @@ def test_record_event_posts(monkeypatch):
         sent["headers"] = headers
         sent["data"] = json
 
+        class Resp:
+            status_code = 200
+
+        return Resp()
+
     monkeypatch.setattr(cli_common.requests, "post", fake_post)
     cli_common.record_event("name", {"a": 1}, enabled=True)
 
@@ -69,6 +74,11 @@ def test_record_event_accepts_invalid_timestamps(monkeypatch):
 
     def fake_post(url, headers=None, json=None, timeout=None):
         sent.update({"url": url, "data": json})
+
+        class Resp:
+            status_code = 200
+
+        return Resp()
 
     monkeypatch.setattr(cli_common.requests, "post", fake_post)
     cli_common.record_event(

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -34,6 +34,11 @@ def test_record_event_posts(monkeypatch):
         sent["headers"] = headers
         sent["data"] = json
 
+        class Resp:
+            status_code = 200
+
+        return Resp()
+
     monkeypatch.setattr(telemetry.requests, "post", fake_post)
     success = telemetry.record_event("name", {"a": 1}, enabled=True)
 
@@ -79,6 +84,11 @@ def test_record_event_accepts_invalid_timestamps(monkeypatch):
     def fake_post(url, headers=None, json=None, timeout=None):
         sent.update({"url": url, "data": json})
 
+        class Resp:
+            status_code = 200
+
+        return Resp()
+
     monkeypatch.setattr(telemetry.requests, "post", fake_post)
     success = telemetry.record_event(
         "ai-do",
@@ -103,6 +113,21 @@ def test_record_event_logs_warning(monkeypatch, caplog):
 
     assert success is False
     assert any("boom" in r.message for r in caplog.records)
+
+
+def test_record_event_non_200_response(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        class Resp:
+            status_code = 500
+
+        return Resp()
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    success = telemetry.record_event("name", {"a": 1}, enabled=True)
+
+    assert success is False
 
 
 def test_analytics_default(monkeypatch):


### PR DESCRIPTION
## Summary
- check response code in `telemetry.record_event`
- adapt telemetry tests for 2xx check
- add non-200 unit test
- update CLI tests to provide response objects

## Testing
- `ruff check telemetry.py tests/test_telemetry.py tests/test_cli_common.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ea6c108a883269c1dcffb7e291535