### PR TITLE
Respect update flag for plugin registry

### DIFF
--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -109,7 +109,9 @@ def load_registry(section: str = "plugins", update: bool = False) -> Dict[str, s
 
     url = os.environ.get("PLUGIN_REGISTRY_URL", DEFAULT_REGISTRY_URL)
 
-    data: Dict[str, object] | None = _fetch_registry(url)
+    data: Dict[str, object] | None = None
+    if update or not CACHE_PATH.exists():
+        data = _fetch_registry(url)
 
     if data is None and CACHE_PATH.exists():
         try:

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -99,3 +99,36 @@ def test_load_registry_uses_default_url(monkeypatch, tmp_path):
     registry = plugins.load_registry()
     assert registry == {"z": "pkg"}
 
+
+def test_load_registry_skips_network_with_cache(monkeypatch, tmp_path):
+    cache = tmp_path / "cache.json"
+    cache.write_text(json.dumps({"plugins": {"y": "pkg"}}))
+    monkeypatch.setattr(plugins, "CACHE_PATH", cache)
+
+    def fail_fetch(url):  # pragma: no cover - should not be called
+        raise AssertionError("network called")
+
+    monkeypatch.setattr(plugins, "_fetch_registry", fail_fetch)
+
+    registry = plugins.load_registry()
+    assert registry == {"y": "pkg"}
+
+
+def test_load_registry_update_forces_fetch(monkeypatch, tmp_path):
+    cache = tmp_path / "cache.json"
+    cache.write_text(json.dumps({"plugins": {"y": "pkg"}}))
+    monkeypatch.setattr(plugins, "CACHE_PATH", cache)
+
+    called = False
+
+    def fake_fetch(url):
+        nonlocal called
+        called = True
+        return {"plugins": {"z": "pkg"}}
+
+    monkeypatch.setattr(plugins, "_fetch_registry", fake_fetch)
+
+    registry = plugins.load_registry(update=True)
+    assert called
+    assert registry == {"z": "pkg"}
+


### PR DESCRIPTION
## Summary
- avoid fetching registry if cache exists and `--update` isn't used
- ensure tests verify network is not contacted when using cached registry

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea6c0823083268b822d8f683976a0