### PR TITLE
Refactor API state lock to asyncio

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -4,7 +4,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any
-from threading import RLock
+
 
 from fastapi import FastAPI, HTTPException
 from contextlib import asynccontextmanager
@@ -23,30 +23,30 @@ from scripts import ai_exec
 backends.load_backends()
 
 STATE_PATH = Path(os.environ.get("API_STATE_PATH", REPO_ROOT / "api_state.json"))
-STATE_LOCK = RLock()
+STATE_LOCK = asyncio.Lock()
 
 
-def _load_state() -> dict[str, Any]:
-    with STATE_LOCK:
+async def _load_state() -> dict[str, Any]:
+    async with STATE_LOCK:
         if STATE_PATH.exists():
             with STATE_PATH.open("r", encoding="utf-8") as f:
                 return json.load(f)
         return {"queries": 0, "nodes": [], "edges": []}
 
 
-def _save_state(state: dict[str, Any]) -> None:
-    with STATE_LOCK:
+async def _save_state(state: dict[str, Any]) -> None:
+    async with STATE_LOCK:
         STATE_PATH.write_text(json.dumps(state), encoding="utf-8")
 
 
-def record_prompt(prompt: str) -> None:
-    state = _load_state()
+async def record_prompt(prompt: str) -> None:
+    state = await _load_state()
     state["queries"] += 1
     node_id = state["queries"]
     state["nodes"].append({"id": node_id, "text": prompt})
     if node_id > 1:
         state["edges"].append({"source": node_id - 1, "target": node_id})
-    _save_state(state)
+    await _save_state(state)
 
 
 def _get_remote_json(url: str) -> dict[str, Any] | None:
@@ -65,23 +65,23 @@ def _get_remote_json(url: str) -> dict[str, Any] | None:
         raise HTTPException(status_code=503, detail=str(exc))
 
 
-def get_stats() -> dict[str, int]:
+async def get_stats() -> dict[str, int]:
     if UME_API_URL:
         result = _get_remote_json(f"{UME_API_URL}/dashboard/stats")
         if result is not None:
             return result
 
-    state = _load_state()
+    state = await _load_state()
     return {"queries": state["queries"], "memory": len(state["nodes"])}
 
 
-def get_graph() -> dict[str, list]:
+async def get_graph() -> dict[str, list]:
     if UME_API_URL:
         result = _get_remote_json(f"{UME_API_URL}/graph")
         if result is not None:
             return result
 
-    state = _load_state()
+    state = await _load_state()
     return {"nodes": state["nodes"], "edges": state["edges"]}
 
 # list of curated sources loaded on startup
@@ -114,8 +114,7 @@ async def health() -> dict[str, str]:
 
 @app.post("/api/prompt")
 async def prompt(req: PromptRequest) -> dict[str, str]:
-    with STATE_LOCK:
-        record_prompt(req.prompt)
+    await record_prompt(req.prompt)
     result = send_prompt(req.prompt, local=req.local)
     return {"response": result}
 
@@ -151,11 +150,11 @@ async def exec_stream(goal: str):
 
 @app.get("/api/stats")
 async def stats() -> dict[str, int]:
-    return get_stats()
+    return await get_stats()
 
 @app.get("/api/graph")
 async def graph() -> dict[str, list]:
-    return get_graph()
+    return await get_graph()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual launch

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -3,6 +3,8 @@ import pytest
 pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
+import httpx
+import asyncio
 import importlib
 import os
 import sys
@@ -222,3 +224,21 @@ def test_graph_remote_timeout(monkeypatch, tmp_path):
         resp = client.get('/api/graph')
         assert resp.status_code == 200
         assert resp.json() == {'nodes': [], 'edges': []}
+
+
+@pytest.mark.asyncio
+async def test_prompt_concurrent(tmp_path):
+    app = load_app(state_path=tmp_path / 'state.json')
+    async with httpx.AsyncClient(
+        base_url="http://test",
+        transport=httpx.ASGITransport(app=app),
+    ) as client:
+        responses = await asyncio.gather(
+            client.post('/api/prompt', json={'prompt': 'one'}),
+            client.post('/api/prompt', json={'prompt': 'two'}),
+        )
+
+    assert all(r.status_code == 200 for r in responses)
+    with TestClient(app) as sync_client:
+        stats_resp = sync_client.get('/api/stats')
+        assert stats_resp.json() == {'queries': 2, 'memory': 2}


### PR DESCRIPTION
## Summary
- switch API state lock to asyncio.Lock
- make state helper functions async
- update API route handlers for new async helpers
- add a concurrent prompt test

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb3c7c58083269dd7027d0324705b