### PR TITLE
Implement registry cache TTL

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -89,9 +89,11 @@ pip package that provides it. Recipe packages go under the `recipes` section.
 The file must conform to
 [plugin-registry.schema.json](../plugin-registry.schema.json). The CLI fetches
 this file from `https://raw.githubusercontent.com/d0tTino/d0tTino/main/plugin-registry.json`
-and caches it in `~/.cache/d0ttino/plugin_registry.json`. Override the URL with
-`PLUGIN_REGISTRY_URL` during development to test your own registry. Pass
-`--update` to the helper to refresh the cached copy.
+and caches it in `~/.cache/d0ttino/plugin_registry.json` along with a timestamp.
+The helper skips network requests when the cached data is newer than 24 hours
+(configurable via the `PLUGIN_REGISTRY_TTL` environment variable). Override the
+URL with `PLUGIN_REGISTRY_URL` during development to test your own registry and
+pass `--update` to force a fresh download.
 
 Example entry:
 

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 from typing import Dict, List, Optional
 
 import requests
@@ -55,6 +56,9 @@ DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/d0tTino/d0tTino/main/p
 # Cache file for the remote registry
 CACHE_PATH = Path.home() / ".cache" / "d0ttino" / "plugin_registry.json"
 
+# Default TTL for the cached registry (24 hours)
+DEFAULT_CACHE_TTL = int(os.environ.get("PLUGIN_REGISTRY_TTL", "86400"))
+
 # Logger for plug-in management utilities
 logger = logging.getLogger(__name__)
 
@@ -91,7 +95,9 @@ def _fetch_registry(url: str) -> Dict[str, object] | None:
         fetched = resp.json()
         if isinstance(fetched, dict) and _valid_registry(fetched):
             CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-            CACHE_PATH.write_text(json.dumps(fetched))
+            CACHE_PATH.write_text(
+                json.dumps({"timestamp": int(time.time()), "registry": fetched})
+            )
             return fetched
     except requests.exceptions.RequestException as exc:
         logger.warning(
@@ -104,23 +110,44 @@ def _fetch_registry(url: str) -> Dict[str, object] | None:
     return None
 
 
-def load_registry(section: str = "plugins", update: bool = False) -> Dict[str, str]:
+def load_registry(
+    section: str = "plugins", update: bool = False, ttl: int = DEFAULT_CACHE_TTL
+) -> Dict[str, str]:
     """Return the registry section with network → cache → default fallback."""
 
     url = os.environ.get("PLUGIN_REGISTRY_URL", DEFAULT_REGISTRY_URL)
 
-    data: Dict[str, object] | None = None
-    if update or not CACHE_PATH.exists():
-        data = _fetch_registry(url)
+    cached_ts: int | None = None
+    cached_data: Dict[str, object] | None = None
 
-    if data is None and CACHE_PATH.exists():
+    if CACHE_PATH.exists():
         try:
             with CACHE_PATH.open(encoding="utf-8") as fh:
-                cached = json.load(fh)
-            if isinstance(cached, dict) and _valid_registry(cached):
-                data = cached
+                cached_raw = json.load(fh)
+            if (
+                isinstance(cached_raw, dict)
+                and "registry" in cached_raw
+                and "timestamp" in cached_raw
+            ):
+                ts = cached_raw.get("timestamp")
+                reg = cached_raw.get("registry")
+                if isinstance(ts, int) and isinstance(reg, dict) and _valid_registry(reg):
+                    cached_ts = ts
+                    cached_data = reg
+            elif isinstance(cached_raw, dict) and _valid_registry(cached_raw):
+                cached_ts = int(CACHE_PATH.stat().st_mtime)
+                cached_data = cached_raw
         except Exception:
             pass
+
+    data: Dict[str, object] | None = None
+
+    if update or cached_ts is None or time.time() - cached_ts > ttl:
+        data = _fetch_registry(url)
+        if data is None:
+            data = cached_data
+    else:
+        data = cached_data
 
     if isinstance(data, dict):
         mapping = data.get(section) or {}

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -3,6 +3,8 @@ import pytest
 
 pytest.importorskip("requests")
 
+import time
+
 from scripts import plugins
 
 
@@ -27,12 +29,16 @@ def test_fetch_registry_saves_cache(monkeypatch, tmp_path):
 
     data = plugins._fetch_registry("https://example.com")
     assert data == result
-    assert json.loads(cache.read_text()) == result
+    cached = json.loads(cache.read_text())
+    assert isinstance(cached.get("timestamp"), int)
+    assert cached.get("registry") == result
 
 
 def test_load_registry_uses_cache_when_offline(monkeypatch, tmp_path):
     cache = tmp_path / "cache.json"
-    cache.write_text(json.dumps({"plugins": {"y": "pkg"}}))
+    cache.write_text(
+        json.dumps({"timestamp": int(time.time()), "registry": {"plugins": {"y": "pkg"}}})
+    )
     monkeypatch.setattr(plugins, "CACHE_PATH", cache)
 
     def raise_exc(*a, **k):
@@ -102,7 +108,9 @@ def test_load_registry_uses_default_url(monkeypatch, tmp_path):
 
 def test_load_registry_skips_network_with_cache(monkeypatch, tmp_path):
     cache = tmp_path / "cache.json"
-    cache.write_text(json.dumps({"plugins": {"y": "pkg"}}))
+    cache.write_text(
+        json.dumps({"timestamp": int(time.time()), "registry": {"plugins": {"y": "pkg"}}})
+    )
     monkeypatch.setattr(plugins, "CACHE_PATH", cache)
 
     def fail_fetch(url):  # pragma: no cover - should not be called
@@ -110,13 +118,15 @@ def test_load_registry_skips_network_with_cache(monkeypatch, tmp_path):
 
     monkeypatch.setattr(plugins, "_fetch_registry", fail_fetch)
 
-    registry = plugins.load_registry()
+    registry = plugins.load_registry(ttl=3600)
     assert registry == {"y": "pkg"}
 
 
 def test_load_registry_update_forces_fetch(monkeypatch, tmp_path):
     cache = tmp_path / "cache.json"
-    cache.write_text(json.dumps({"plugins": {"y": "pkg"}}))
+    cache.write_text(
+        json.dumps({"timestamp": int(time.time()), "registry": {"plugins": {"y": "pkg"}}})
+    )
     monkeypatch.setattr(plugins, "CACHE_PATH", cache)
 
     called = False
@@ -129,6 +139,28 @@ def test_load_registry_update_forces_fetch(monkeypatch, tmp_path):
     monkeypatch.setattr(plugins, "_fetch_registry", fake_fetch)
 
     registry = plugins.load_registry(update=True)
+    assert called
+    assert registry == {"z": "pkg"}
+
+
+def test_load_registry_fetches_when_cache_expired(monkeypatch, tmp_path):
+    cache = tmp_path / "cache.json"
+    old_ts = int(time.time()) - 100
+    cache.write_text(
+        json.dumps({"timestamp": old_ts, "registry": {"plugins": {"y": "pkg"}}})
+    )
+    monkeypatch.setattr(plugins, "CACHE_PATH", cache)
+
+    called = False
+
+    def fake_fetch(url):
+        nonlocal called
+        called = True
+        return {"plugins": {"z": "pkg"}}
+
+    monkeypatch.setattr(plugins, "_fetch_registry", fake_fetch)
+
+    registry = plugins.load_registry(ttl=10)
     assert called
     assert registry == {"z": "pkg"}
 


### PR DESCRIPTION
## Summary
- cache plugin registry with timestamp
- skip network requests if cache is newer than TTL
- document cache behaviour
- test cache TTL logic

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb3c749c083268d70d8bb646b6924