### PR TITLE
Add registry TTL env tests and telemetry status checks

### DIFF
--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -4,6 +4,7 @@ import pytest
 pytest.importorskip("requests")
 
 import time
+import importlib
 
 from scripts import plugins
 
@@ -164,3 +165,46 @@ def test_load_registry_fetches_when_cache_expired(monkeypatch, tmp_path):
     assert called
     assert registry == {"z": "pkg"}
 
+
+def test_load_registry_uses_env_ttl(monkeypatch, tmp_path):
+    cache = tmp_path / "cache.json"
+    cache.write_text(
+        json.dumps({"timestamp": int(time.time()) - 5, "registry": {"plugins": {"x": "pkg"}}})
+    )
+    monkeypatch.setenv("PLUGIN_REGISTRY_TTL", "1")
+    reloaded = importlib.reload(plugins)
+    monkeypatch.setattr(reloaded, "CACHE_PATH", cache)
+
+    called = False
+
+    def fake_fetch(url):
+        nonlocal called
+        called = True
+        return {"plugins": {"y": "pkg"}}
+
+    monkeypatch.setattr(reloaded, "_fetch_registry", fake_fetch)
+
+    registry = reloaded.load_registry()
+    assert called
+    assert registry == {"y": "pkg"}
+
+
+def test_load_registry_fetches_with_zero_ttl(monkeypatch, tmp_path):
+    cache = tmp_path / "cache.json"
+    cache.write_text(
+        json.dumps({"timestamp": int(time.time()), "registry": {"plugins": {"x": "pkg"}}})
+    )
+    monkeypatch.setattr(plugins, "CACHE_PATH", cache)
+
+    called = False
+
+    def fake_fetch(url):
+        nonlocal called
+        called = True
+        return {"plugins": {"y": "pkg"}}
+
+    monkeypatch.setattr(plugins, "_fetch_registry", fake_fetch)
+
+    registry = plugins.load_registry(ttl=0)
+    assert called
+    assert registry == {"y": "pkg"}

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -135,3 +135,41 @@ def test_analytics_default(monkeypatch):
     assert telemetry.analytics_default() is True
     monkeypatch.setenv("EVENTS_ENABLED", "0")
     assert telemetry.analytics_default() is False
+
+def test_record_event_success_201(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        class Resp:
+            status_code = 201
+        return Resp()
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    success = telemetry.record_event("name", {}, enabled=True)
+    assert success is True
+
+
+def test_record_event_success_204(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        class Resp:
+            status_code = 204
+        return Resp()
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    success = telemetry.record_event("name", {}, enabled=True)
+    assert success is True
+
+
+def test_record_event_http_error(monkeypatch):
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        class Resp:
+            status_code = 404
+        return Resp()
+
+    monkeypatch.setattr(telemetry.requests, "post", fake_post)
+    success = telemetry.record_event("name", {}, enabled=True)
+    assert success is False


### PR DESCRIPTION
## Summary
- test plugin registry with TTL from env var and zero TTL
- check telemetry success on 2xx codes and failure on 404

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687ece43fdb88326a5283da76436dee4