### PR TITLE
Add Tauri API commands and task UI

### DIFF
--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -8,7 +8,7 @@ export default function Home() {
   const [palette, setPalette] = useState('');
   const [status, setStatus] = useState('');
   const [goal, setGoal] = useState('');
-  const [steps, setSteps] = useState([]);
+  const [tasks, setTasks] = useState([]);
   const [logs, setLogs] = useState('');
 
   useEffect(() => {
@@ -34,6 +34,16 @@ export default function Home() {
       .catch(() => setResponse('error'));
   };
 
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (ev) => setPrompt(ev.target.result);
+      reader.readAsText(file);
+    }
+  };
+
   const applyPalette = () => {
     fetch('/api/palette', {
       method: 'POST',
@@ -51,7 +61,7 @@ export default function Home() {
       body: JSON.stringify({ goal })
     })
       .then((res) => res.json())
-      .then((data) => setSteps(data.steps || []));
+      .then((data) => setTasks(data.steps || []));
   };
 
   const runExec = () => {
@@ -76,6 +86,9 @@ export default function Home() {
       )}
       <div>
         <input value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="prompt" />
+        <div onDrop={handleDrop} onDragOver={(e) => e.preventDefault()} style={{ border: '1px dashed #ccc', padding: '0.5em', marginTop: '0.5em' }}>
+          Drag prompt file here
+        </div>
         <button onClick={sendPrompt}>Send</button>
         {response && <p>{response}</p>}
       </div>
@@ -88,8 +101,12 @@ export default function Home() {
         <input value={goal} onChange={(e) => setGoal(e.target.value)} placeholder="goal" />
         <button onClick={getPlan}>Plan</button>
         <button onClick={runExec}>Run</button>
-        {steps.length > 0 && (
-          <pre>{steps.join('\n')}</pre>
+        {tasks.length > 0 && (
+          <ul>
+            {tasks.map((t, i) => (
+              <li key={i}>{t}</li>
+            ))}
+          </ul>
         )}
         {logs && (
           <pre>{logs}</pre>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 tauri = { version = "1", features = ["http-all"] }
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,39 @@
+use reqwest::Client;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct PlanResponse {
+    steps: Option<Vec<String>>,
+}
+
+#[tauri::command]
+async fn plan(goal: String) -> Result<Vec<String>, String> {
+    let client = Client::new();
+    let resp = client
+        .post("http://localhost:8000/api/plan")
+        .json(&serde_json::json!({ "goal": goal }))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let plan: PlanResponse = resp.json().await.map_err(|e| e.to_string())?;
+    Ok(plan.steps.unwrap_or_default())
+}
+
+#[tauri::command]
+async fn exec(goal: String) -> Result<String, String> {
+    let client = Client::new();
+    let resp = client
+        .get("http://localhost:8000/api/exec")
+        .query(&[("goal", goal)])
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    resp.text().await.map_err(|e| e.to_string())
+}
+
 fn main() {
     tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![plan, exec])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
## Summary
- call the `/api/plan` and `/api/exec` endpoints from new Tauri commands
- enable async HTTP requests with new deps
- display a task list in the dashboard
- support drag-and-drop prompt files

## Testing
- `npm run lint`
- `ruff check .`
- `pytest -k test_tauri -q`

------
https://chatgpt.com/codex/tasks/task_e_687ece42a1a48326b407198e990b6047