### PR TITLE
Add ai-cli stats subcommand

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -67,3 +67,15 @@ hashed developer ID and ISO week, counting only entries where `exit_code` is
 active developer per week” metric. `nsm_upload.py` can read NDJSON logs or fetch
 them from `EVENTS_URL`, compute the totals, and post the aggregated JSON back to
 the server.
+
+## Viewing Basic Stats
+
+Run `ai-cli stats` to retrieve events from `EVENTS_URL` and print a short
+summary:
+
+```bash
+EVENTS_URL=https://example.com ai-cli stats
+```
+
+The command displays the total number of recorded runs, the overall success
+rate, and the average latency in milliseconds.

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+import os
 from pathlib import Path
 from typing import List, Optional
 
 from llm import router
 from llm.backends import initialize
-from scripts import ai_exec, recipes, plugins, query_sources
+from scripts import ai_exec, recipes, plugins, query_sources, nsm_stats
 from scripts.cli_common import (
     read_prompt,
     build_analytics_parser,
@@ -125,6 +126,31 @@ def _cmd_sources(args: argparse.Namespace) -> int:
     return 0 if matches else 1
 
 
+def _cmd_stats(args: argparse.Namespace) -> int:
+    url = os.environ.get("EVENTS_URL")
+    if not url:
+        print("EVENTS_URL is not set", file=sys.stderr)
+        return 1
+    try:
+        events = list(nsm_stats.iter_events(url))
+    except Exception as exc:  # noqa: BLE001
+        print(f"failed to fetch events: {exc}", file=sys.stderr)
+        return 1
+    total = len(events)
+    successes = sum(1 for ev in events if ev.get("exit_code") == 0)
+    success_rate = successes / total * 100 if total else 0.0
+    latencies = []
+    for ev in events:
+        val = ev.get("latency_ms")
+        if isinstance(val, (int, float)):
+            latencies.append(float(val))
+    avg_latency = sum(latencies) / len(latencies) if latencies else 0.0
+    print(f"Total runs: {total}")
+    print(f"Success rate: {success_rate:.1f}%")
+    print(f"Average latency: {avg_latency:.2f} ms")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     analytics = build_analytics_parser()
 
@@ -181,6 +207,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Filter by tag (repeatable)",
     )
     sources.set_defaults(func=_cmd_sources)
+
+    stats = sub.add_parser(
+        "stats",
+        help="Show aggregated event stats from EVENTS_URL",
+    )
+    stats.set_defaults(func=_cmd_stats)
 
     return parser
 

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -260,3 +260,30 @@ def test_sources_subcommand(capsys):
     output = capsys.readouterr().out
     assert rc == 0
     assert "Python Docs" in output
+
+
+def test_stats_subcommand(monkeypatch):
+    events = [
+        {"exit_code": 0, "latency_ms": 100},
+        {"exit_code": 1, "latency_ms": 200},
+        {"exit_code": 0, "latency_ms": 300},
+    ]
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    monkeypatch.setattr(ai_cli.nsm_stats, "iter_events", lambda src: iter(events))
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["stats"])
+    assert rc == 0
+    text = out.getvalue()
+    assert "Total runs: 3" in text
+    assert "Success rate: 66.7%" in text
+    assert "Average latency" in text
+
+
+def test_stats_requires_url(monkeypatch):
+    monkeypatch.delenv("EVENTS_URL", raising=False)
+    monkeypatch.setattr(ai_cli.nsm_stats, "iter_events", lambda src: iter(()))
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        rc = ai_cli.main(["stats"])
+    assert rc == 1


### PR DESCRIPTION
## Summary
- add `stats` subcommand to `ai_cli` for quick telemetry stats
- document the new command in telemetry docs
- test `stats` output with mocked data

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687ece42c2288326914da4b0d5fe0935