### PR TITLE
Ensure jsonschema is always available for schema tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ test = [
     "fastapi",
     "uvicorn",
     "httpx",
-    "jsonschema",
+    "jsonschema>=4",
 ]
-cli = ["tomli_w", "jsonschema"]
+cli = ["tomli_w", "jsonschema>=4"]
 lmql = ["lmql"]
 guidance = ["guidance"]
 etl = ["unstructured", "chromadb"]
-plugins = ["jsonschema"]
+plugins = ["jsonschema>=4"]
 
 [project.scripts]
 thm = "scripts.thm:main"

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -1,10 +1,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
-pytest.importorskip("jsonschema")
-
 from scripts import validate_sources
 
 


### PR DESCRIPTION
## Summary
- update test extras to require jsonschema
- ensure schema validator tests are not skipped

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68802626af5c83269d31387e9f59d71f