### PR TITLE
Add dry-run support to installer scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Dry run install script
-        run: bash install.sh --dry-run
+        run: |
+          bash install.sh --dry-run
+          bash scripts/install_common.sh --dry-run
         shell: bash

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ install_windows_terminal=false
 install_wsl=false
 setup_wsl=false
 setup_docker=false
+dry_run=false
 docker_image=""
 
 while [[ $# -gt 0 ]]; do
@@ -28,6 +29,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --setup-docker)
             setup_docker=true
+            ;;
+        --dry-run)
+            dry_run=true
             ;;
         --image)
             docker_image=$2
@@ -48,9 +52,16 @@ if $install_wsl; then args+=(--install-wsl); fi
 if $setup_wsl; then args+=(--setup-wsl); fi
 if $setup_docker; then args+=(--setup-docker); fi
 if [[ -n $docker_image ]]; then args+=(--image "$docker_image"); fi
+if $dry_run; then args+=(--dry-run); fi
 
 if command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoLogo -NoProfile -File "$scripts/helpers/install_common.ps1" "${args[@]}"
+    cmd=(pwsh -NoLogo -NoProfile -File "$scripts/helpers/install_common.ps1" "${args[@]}")
 else
-    bash "$scripts/install_common.sh" "${args[@]}"
+    cmd=(bash "$scripts/install_common.sh" "${args[@]}")
+fi
+
+if $dry_run; then
+    echo "Dry run: ${cmd[*]}"
+else
+    "${cmd[@]}"
 fi

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -18,6 +18,14 @@ esac
 
 OSTYPE="${OSTYPE,,}"
 
+run_cmd() {
+    if $dry_run; then
+        echo "$*"
+    else
+        "$@"
+    fi
+}
+
 ensure_deps() {
     local missing=()
     for cmd in "$@"; do
@@ -30,7 +38,7 @@ ensure_deps() {
         if [[ $OSTYPE == darwin* ]]; then
             if command -v brew >/dev/null 2>&1; then
                 echo "Installing ${missing[*]} with Homebrew" >&2
-                brew install "${missing[@]}"
+                run_cmd brew install "${missing[@]}"
             else
                 echo "Missing ${missing[*]}" >&2
                 echo "Install Homebrew from https://brew.sh and run: brew install ${missing[*]}" >&2
@@ -39,14 +47,14 @@ ensure_deps() {
         elif [[ $OSTYPE == linux* ]]; then
             if command -v apt-get >/dev/null 2>&1; then
                 echo "Installing ${missing[*]} with apt-get" >&2
-                sudo apt-get update
-                sudo apt-get install -y "${missing[@]}"
+                run_cmd sudo apt-get update
+                run_cmd sudo apt-get install -y "${missing[@]}"
             elif command -v dnf >/dev/null 2>&1; then
                 echo "Installing ${missing[*]} with dnf" >&2
-                sudo dnf install -y "${missing[@]}"
+                run_cmd sudo dnf install -y "${missing[@]}"
             elif command -v pacman >/dev/null 2>&1; then
                 echo "Installing ${missing[*]} with pacman" >&2
-                sudo pacman -S --noconfirm "${missing[@]}"
+                run_cmd sudo pacman -S --noconfirm "${missing[@]}"
             else
                 echo "Missing ${missing[*]}. Please install them and re-run this script." >&2
                 exit 1
@@ -61,7 +69,11 @@ ensure_deps() {
 run_pwsh() {
     local script=$1
     shift
-    pwsh -NoLogo -NoProfile -File "$scripts/$script" "$@"
+    if $dry_run; then
+        echo pwsh -NoLogo -NoProfile -File "$scripts/$script" "$@"
+    else
+        pwsh -NoLogo -NoProfile -File "$scripts/$script" "$@"
+    fi
 }
 
 install_winget=false
@@ -69,6 +81,7 @@ install_windows_terminal=false
 install_wsl=false
 setup_wsl=false
 setup_docker=false
+dry_run=false
 docker_image=""
 
 while [[ $# -gt 0 ]]; do
@@ -88,6 +101,9 @@ while [[ $# -gt 0 ]]; do
         --setup-docker)
             setup_docker=true
             ;;
+        --dry-run)
+            dry_run=true
+            ;;
         --image)
             docker_image=$2
             shift
@@ -105,9 +121,9 @@ if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == 
     run_pwsh fix-path.ps1
     run_pwsh helpers/install_common.ps1
 else
-    bash "$scripts/setup-hooks.sh"
-    bash "$scripts/helpers/install_fonts.sh"
-    bash "$scripts/helpers/sync_palettes.sh"
+    run_cmd bash "$scripts/setup-hooks.sh"
+    run_cmd bash "$scripts/helpers/install_fonts.sh"
+    run_cmd bash "$scripts/helpers/sync_palettes.sh"
 fi
 
 if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
@@ -121,10 +137,10 @@ if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == 
         run_pwsh setup-docker.ps1 "${args[@]}"
     fi
 else
-    if $setup_wsl; then bash "$scripts/setup-wsl.sh"; fi
+    if $setup_wsl; then run_cmd bash "$scripts/setup-wsl.sh"; fi
     if $setup_docker; then
         args=()
         [[ -n $docker_image ]] && args+=("--image" "$docker_image")
-        bash "$scripts/setup-docker.sh" "${args[@]}"
+        run_cmd bash "$scripts/setup-docker.sh" "${args[@]}"
     fi
 fi

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -21,3 +21,11 @@ def test_install_ps1_dry_run() -> None:
     script = (REPO_ROOT / 'scripts' / 'install.ps1').resolve()
     command = f"[System.Management.Automation.Language.Parser]::ParseFile('{script}',[ref]\$null,[ref]\$null) | Out-Null"
     subprocess.run([pwsh, '-NoLogo', '-NoProfile', '-Command', command], check=True)
+
+
+def test_install_sh_exec_dry_run() -> None:
+    subprocess.run(['/bin/bash', 'install.sh', '--dry-run'], cwd=REPO_ROOT, check=True)
+
+
+def test_install_common_sh_exec_dry_run() -> None:
+    subprocess.run(['/bin/bash', 'scripts/install_common.sh', '--dry-run'], cwd=REPO_ROOT, check=True)


### PR DESCRIPTION
## Summary
- add `--dry-run` flag to `install.sh` and `scripts/install_common.sh`
- echo commands instead of executing when the flag is present
- call new option in workflow CI job
- test running installers with `--dry-run`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_688026256d4c8326bc78c3fce90336c9