### PR TITLE
Improve plugin registry caching

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -147,6 +147,17 @@ python -m scripts.plugins backends install mindbridge
 python -m scripts.plugins recipes install echo
 ```
 
+### Registry Environment Variables
+
+Configure how the helper script fetches and caches the plug-in registry using
+the following variables:
+
+- `PLUGIN_REGISTRY_URL` – Override the registry URL.
+- `PLUGIN_REGISTRY_TTL` – Cache time-to-live in seconds (defaults to 86400).
+
+The registry is cached at `~/.cache/d0ttino/plugin_registry.json`. Set the TTL
+to `0` to always fetch a fresh copy.
+
 ## Built-in Backends
 
 `llm` includes HTTP clients for OpenRouter, LobeChat and MindBridge. Set the

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -57,7 +57,7 @@ DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/d0tTino/d0tTino/main/p
 CACHE_PATH = Path.home() / ".cache" / "d0ttino" / "plugin_registry.json"
 
 # Default TTL for the cached registry (24 hours)
-DEFAULT_CACHE_TTL = int(os.environ.get("PLUGIN_REGISTRY_TTL", "86400"))
+DEFAULT_CACHE_TTL = max(0, int(os.environ.get("PLUGIN_REGISTRY_TTL", "86400")))
 
 # Logger for plug-in management utilities
 logger = logging.getLogger(__name__)
@@ -116,6 +116,7 @@ def load_registry(
     """Return the registry section with network → cache → default fallback."""
 
     url = os.environ.get("PLUGIN_REGISTRY_URL", DEFAULT_REGISTRY_URL)
+    ttl = max(0, ttl)
 
     cached_ts: int | None = None
     cached_data: Dict[str, object] | None = None
@@ -137,12 +138,18 @@ def load_registry(
             elif isinstance(cached_raw, dict) and _valid_registry(cached_raw):
                 cached_ts = int(CACHE_PATH.stat().st_mtime)
                 cached_data = cached_raw
+        except json.JSONDecodeError:
+            logger.warning("Ignoring corrupt registry cache: %s", CACHE_PATH)
+            try:
+                CACHE_PATH.unlink()
+            except Exception:
+                pass
         except Exception:
             pass
 
     data: Dict[str, object] | None = None
 
-    if update or cached_ts is None or time.time() - cached_ts > ttl:
+    if update or cached_ts is None or ttl == 0 or time.time() - cached_ts > ttl:
         data = _fetch_registry(url)
         if data is None:
             data = cached_data

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,7 @@
 import argparse
 from pathlib import Path
+import json
+import time
 
 import pytest
 
@@ -30,4 +32,65 @@ def test_cmd_sync_recipes_uses_default_dir(monkeypatch, tmp_path):
     assert rc == 0
     for pkg in packages.values():
         assert (tmp_path / pkg).is_file()
+
+
+def test_load_registry_cache_miss(monkeypatch, tmp_path):
+    """Fetching occurs and cache file is written when missing."""
+    cache = tmp_path / "cache.json"
+    monkeypatch.setattr(plugins, "CACHE_PATH", cache)
+
+    result = {"plugins": {"a": "pkg"}}
+
+    class Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return result
+
+    monkeypatch.setattr(plugins.requests, "get", lambda *a, **k: Resp())
+
+    reg = plugins.load_registry()
+    assert reg == {"a": "pkg"}
+    saved = json.loads(cache.read_text())
+    assert saved["registry"] == result
+
+
+def test_load_registry_cache_hit(monkeypatch, tmp_path):
+    """Cached registry is used when TTL has not expired."""
+    cache = tmp_path / "cache.json"
+    now = int(time.time())
+    cache.write_text(json.dumps({"timestamp": now, "registry": {"plugins": {"a": "pkg"}}}))
+    monkeypatch.setattr(plugins, "CACHE_PATH", cache)
+
+    def fail_fetch(url):  # pragma: no cover - should not run
+        raise AssertionError("fetch")
+
+    monkeypatch.setattr(plugins, "_fetch_registry", fail_fetch)
+
+    reg = plugins.load_registry(ttl=3600)
+    assert reg == {"a": "pkg"}
+
+
+def test_load_registry_corrupt_cache(monkeypatch, tmp_path):
+    """Corrupt cache triggers fetch and gets replaced."""
+    cache = tmp_path / "cache.json"
+    cache.write_text("{invalid")
+    monkeypatch.setattr(plugins, "CACHE_PATH", cache)
+
+    result = {"plugins": {"b": "pkg"}}
+
+    class Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return result
+
+    monkeypatch.setattr(plugins.requests, "get", lambda *a, **k: Resp())
+
+    reg = plugins.load_registry()
+    assert reg == {"b": "pkg"}
+    loaded = json.loads(cache.read_text())
+    assert loaded["registry"] == result
 


### PR DESCRIPTION
## Summary
- improve resilience of `scripts.plugins.load_registry` to corrupted cache files
- prevent negative TTL values and support TTL=0 behavior
- add new cache handling tests for load_registry
- document `PLUGIN_REGISTRY_URL` and `PLUGIN_REGISTRY_TTL`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive scripts/plugins.py tests/test_plugins.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802c81e7a08326a2131a720bf2a67c