### PR TITLE
Add Anthropic, Mistral and LMQL plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -52,6 +52,9 @@ ai-cli plugin backends list
 
 # Install a plug-in
 ai-cli plugin backends install sample
+ai-cli plugin backends install anthropic
+ai-cli plugin backends install mistral
+ai-cli plugin backends install lmql
 
 # Remove a plug-in
 ai-cli plugin backends remove sample
@@ -103,6 +106,17 @@ Example entry:
 }
 ```
 
+Placeholder packages for future backends follow the same format. Entries for
+Anthropic, Mistral and LMQL will look like:
+
+```json
+{
+  "anthropic": "d0ttino-anthropic-plugin",
+  "mistral": "d0ttino-mistral-plugin",
+  "lmql": "d0ttino-lmql-plugin"
+}
+```
+
 Add recipe packages under the `recipes` key:
 
 ```json
@@ -144,6 +158,9 @@ registry:
 python -m scripts.plugins backends install openrouter
 python -m scripts.plugins backends install lobechat
 python -m scripts.plugins backends install mindbridge
+python -m scripts.plugins backends install anthropic
+python -m scripts.plugins backends install mistral
+python -m scripts.plugins backends install lmql
 python -m scripts.plugins recipes install echo
 ```
 

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -3,7 +3,10 @@
     "sample": "d0ttino-sample-plugin",
     "openrouter": "d0ttino-openrouter-plugin",
     "lobechat": "d0ttino-lobechat-plugin",
-    "mindbridge": "d0ttino-mindbridge-plugin"
+    "mindbridge": "d0ttino-mindbridge-plugin",
+    "anthropic": "d0ttino-anthropic-plugin",
+    "mistral": "d0ttino-mistral-plugin",
+    "lmql": "d0ttino-lmql-plugin"
   },
   "recipes": {
     "echo": "https://example.com/packages/d0ttino-echo-recipe.tar.gz"

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -38,6 +38,9 @@ PLUGIN_REGISTRY: Dict[str, str] = {
     "openrouter": "d0ttino-openrouter-plugin",
     "lobechat": "d0ttino-lobechat-plugin",
     "mindbridge": "d0ttino-mindbridge-plugin",
+    "anthropic": "d0ttino-anthropic-plugin",
+    "mistral": "d0ttino-mistral-plugin",
+    "lmql": "d0ttino-lmql-plugin",
 }
 
 # Mapping of recipe name to pip package used as a fallback when a registry


### PR DESCRIPTION
## Summary
- extend the plug-in registry with Anthropic, Mistral and LMQL entries
- document placeholder packages for third-party authors
- show how to install the new plug-ins with the CLI

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802fea52108326a0bb54286a2f0519