### PR TITLE
Add coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test]'
+          pip install -e '.[test]' pytest-cov
       - name: Run ruff
         run: ruff check .
       - name: Run mypy
@@ -74,7 +74,12 @@ jobs:
       - name: Install runtime requirements
         run: pip install -r requirements.txt
       - name: Run tests
-        run: pytest -n auto
+        run: pytest -n auto --cov=. --cov-report=xml --cov-fail-under=80
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: coverage.xml
       - name: Verify awesome sources markdown
         run: pytest tests/test_generate_sources_md.py -q
 


### PR DESCRIPTION
## Summary
- compute coverage in CI using `pytest --cov`
- fail if coverage goes below 80%
- upload coverage report for each matrix OS

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto --cov=. --cov-report=xml --cov-fail-under=80`

------
https://chatgpt.com/codex/tasks/task_e_68802fec9c4883268dd124edf9199bd4