### PR TITLE
Add optional GUI feature for tests

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,0 +1,12 @@
+# Desktop GUI
+
+The Tauri application offers a minimal interface for sending prompts and running recipes.
+
+## Usage
+
+1. Start the backend with `uvicorn api:app --reload`.
+2. Launch the desktop app with `cargo tauri dev`.
+3. Type a prompt or drag a text file onto the window to load it automatically.
+4. Choose a recipe from the list and execute it.
+
+Dropped files trigger the `prompt-file` event and populate the prompt field.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,9 +2,21 @@
 name = "ume_tauri"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
+
+[features]
+default = ["gui"]
+gui = ["tauri", "tauri-build"]
 
 [dependencies]
-tauri = { version = "1", features = ["http-all"] }
+tauri = { version = "1", optional = true, features = ["http-all"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }
+
+[build-dependencies]
+tauri-build = { version = "1", optional = true }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(feature = "gui")]
+    tauri_build::build();
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,0 +1,55 @@
+pub mod commands {
+    use reqwest::Client;
+    use serde::Deserialize;
+    use std::{fs, path::PathBuf};
+
+    #[derive(Deserialize)]
+    struct PlanResponse {
+        steps: Option<Vec<String>>,
+    }
+
+    pub async fn plan(goal: String) -> Result<Vec<String>, String> {
+        let client = Client::new();
+        let resp = client
+            .post("http://localhost:8000/api/plan")
+            .json(&serde_json::json!({ "goal": goal }))
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        let plan: PlanResponse = resp.json().await.map_err(|e| e.to_string())?;
+        Ok(plan.steps.unwrap_or_default())
+    }
+
+    pub async fn exec(goal: String) -> Result<String, String> {
+        let client = Client::new();
+        let resp = client
+            .get("http://localhost:8000/api/exec")
+            .query(&[("goal", goal)])
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        resp.text().await.map_err(|e| e.to_string())
+    }
+
+    pub async fn list_recipes() -> Result<Vec<String>, String> {
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../scripts/recipes/plugins");
+        let mut names = Vec::new();
+        for entry in fs::read_dir(base).map_err(|e| e.to_string())? {
+            let entry = entry.map_err(|e| e.to_string())?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("py") {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    if stem != "__init__" {
+                        names.push(stem.to_string());
+                    }
+                }
+            }
+        }
+        names.sort();
+        Ok(names)
+    }
+
+    pub async fn open_prompt_file(path: String) -> Result<String, String> {
+        fs::read_to_string(path).map_err(|e| e.to_string())
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,39 +1,58 @@
-use reqwest::Client;
-use serde::Deserialize;
+#[cfg(feature = "gui")]
+use std::fs;
+#[cfg(feature = "gui")]
+use tauri::{FileDropEvent, Manager, RunEvent, WindowEvent};
 
-#[derive(Deserialize)]
-struct PlanResponse {
-    steps: Option<Vec<String>>,
-}
-
+#[cfg(feature = "gui")]
 #[tauri::command]
 async fn plan(goal: String) -> Result<Vec<String>, String> {
-    let client = Client::new();
-    let resp = client
-        .post("http://localhost:8000/api/plan")
-        .json(&serde_json::json!({ "goal": goal }))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    let plan: PlanResponse = resp.json().await.map_err(|e| e.to_string())?;
-    Ok(plan.steps.unwrap_or_default())
+    ume_tauri::commands::plan(goal).await
 }
 
+#[cfg(feature = "gui")]
 #[tauri::command]
 async fn exec(goal: String) -> Result<String, String> {
-    let client = Client::new();
-    let resp = client
-        .get("http://localhost:8000/api/exec")
-        .query(&[("goal", goal)])
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    resp.text().await.map_err(|e| e.to_string())
+    ume_tauri::commands::exec(goal).await
 }
 
+#[cfg(feature = "gui")]
+#[tauri::command]
+async fn list_recipes() -> Result<Vec<String>, String> {
+    ume_tauri::commands::list_recipes().await
+}
+
+#[cfg(feature = "gui")]
+#[tauri::command]
+async fn open_prompt_file(path: String) -> Result<String, String> {
+    ume_tauri::commands::open_prompt_file(path).await
+}
+
+#[cfg(feature = "gui")]
 fn main() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![plan, exec])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .invoke_handler(tauri::generate_handler![
+            plan,
+            exec,
+            list_recipes,
+            open_prompt_file,
+        ])
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        .run(|app_handle, event| match event {
+            RunEvent::WindowEvent { label, event, .. } => {
+                if let WindowEvent::FileDrop(FileDropEvent::Dropped(paths)) = event {
+                    if let Some(path) = paths.get(0) {
+                        if let Ok(content) = fs::read_to_string(path) {
+                            if let Some(window) = app_handle.get_window(&label) {
+                                let _ = window.emit("prompt-file", content);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        });
 }
+
+#[cfg(not(feature = "gui"))]
+fn main() {}

--- a/src-tauri/tests/commands.rs
+++ b/src-tauri/tests/commands.rs
@@ -1,0 +1,18 @@
+use std::io::Write;
+use ume_tauri::commands::{list_recipes, open_prompt_file};
+
+#[tokio::test]
+async fn list_recipes_returns_sample() {
+    let recipes = list_recipes().await.expect("list");
+    assert!(recipes.contains(&"sample".to_string()));
+}
+
+#[tokio::test]
+async fn open_prompt_file_reads_content() {
+    let mut file = tempfile::NamedTempFile::new().expect("tempfile");
+    writeln!(file, "hello").unwrap();
+    let content = open_prompt_file(file.path().display().to_string())
+        .await
+        .expect("read file");
+    assert_eq!(content.trim_end(), "hello");
+}

--- a/src-tauri/tests/window.rs
+++ b/src-tauri/tests/window.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "gui")]
 use tauri::Manager;
 
+#[cfg(feature = "gui")]
 #[tauri::test]
 async fn main_window_title() {
     let context = tauri::generate_context!();


### PR DESCRIPTION
## Summary
- make Tauri optional behind a `gui` feature
- gate build script and window tests on the `gui` feature
- expose command wrappers in `main.rs` when GUI is enabled
- adjust integration tests to run without Tauri

## Testing
- `ruff check .`
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features -q`


------
https://chatgpt.com/codex/tasks/task_e_68802feaca408326910be50224809c65