### PR TITLE
Ensure sources schema tests always run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run mypy
         run: mypy --install-types --non-interactive
       - name: Install runtime requirements
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt jsonschema
       - name: Run tests
         run: pytest -n auto --cov=. --cov-report=xml --cov-fail-under=80
       - name: Upload coverage report
@@ -98,7 +98,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e '.[test,lmql,guidance]' textual
       - name: Install runtime requirements
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt jsonschema
       - name: Run tests with extras
         run: pytest -n auto
   install-dry-run:

--- a/tests/test_sources_schema.py
+++ b/tests/test_sources_schema.py
@@ -1,9 +1,4 @@
-import pytest
-
-pytest.importorskip("jsonschema")
-
 from scripts import validate_sources
-
 
 def test_sources_schema_valid() -> None:
     assert validate_sources.main([]) == 0


### PR DESCRIPTION
## Summary
- run `tests/test_sources_schema.py` without skipping jsonschema checks
- install jsonschema explicitly in CI

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d42a0de88326be1b6b61dfb7c809