### PR TITLE
Fix pytest cache cross-OS errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ winget-packages.lock.json
 __pycache__/
 node_modules/
 *.egg-info/
+.pytest_cache/
 .env
 src-tauri/target/
 src-tauri/Cargo.lock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+import os
 from pathlib import Path
 
 if importlib.util.find_spec("llm") is None:
@@ -10,3 +11,26 @@ if importlib.util.find_spec("llm") is None:
         raise ImportError(
             "The 'llm' package could not be imported. Install this repository with 'pip install -e .' before running tests."
         )
+
+
+def pytest_configure(config):
+    """Normalize cached node IDs across operating systems."""
+    if os.name == "nt":
+        return
+    try:
+        nodeids = config.cache.get("cache/nodeids", [])
+    except NotImplementedError:
+        config.cache.set("cache/nodeids", [])
+        return
+
+    normalized = []
+    changed = False
+    for nid in nodeids:
+        if hasattr(nid, "as_posix"):
+            normalized.append(nid.as_posix())
+            changed = True
+        else:
+            normalized.append(str(nid))
+
+    if changed:
+        config.cache.set("cache/nodeids", normalized)


### PR DESCRIPTION
## Summary
- normalize pytest cached nodeids on POSIX
- ignore `.pytest_cache` directory

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d42ae8648326a42adb9240cb16f6