### PR TITLE
Add Anthropoic and Mistral backend plugins

### DIFF
--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -18,6 +18,8 @@ OllamaBackend: type[Backend] | None = None
 OpenRouterBackend: type[Backend] | None = None
 LobeChatBackend: type[Backend] | None = None
 MindBridgeBackend: type[Backend] | None = None
+AnthropicBackend: type[Backend] | None = None
+MistralBackend: type[Backend] | None = None
 SuperClaudeBackend: type[Backend] | None = _RealSuperClaudeBackend  # noqa: F811
 
 GeminiDSPyBackend = None
@@ -39,6 +41,8 @@ __all__ = [
     "OpenRouterBackend",
     "LobeChatBackend",
     "MindBridgeBackend",
+    "AnthropicBackend",
+    "MistralBackend",
     "SuperClaudeBackend",
     "GeminiDSPyBackend",
     "OllamaDSPyBackend",

--- a/llm/backends/plugins/anthropic.py
+++ b/llm/backends/plugins/anthropic.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, cast
+
+import requests
+
+from ..plugin_sdk import Backend, register_backend
+
+DEFAULT_BASE_URL = "https://api.anthropic.com/v1"
+
+
+def _extract_text(result: Mapping[str, Any]) -> str:
+    """Return the assistant text from a LiteLLM-style result."""
+    try:
+        choices = result["choices"]
+        first = choices[0]
+        if isinstance(first, dict):
+            if "message" in first:
+                return first["message"].get("content", "")
+            return first.get("text", "")
+    except Exception:  # pragma: no cover - fall back to str()
+        pass
+    return str(result)
+
+
+class AnthropicBackend(Backend):
+    """HTTP client for the Anthropic API."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        self.api_key = os.environ.get("ANTHROPIC_API_KEY")
+        self.base_url = os.environ.get("ANTHROPIC_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+    def run(self, prompt: str) -> str:
+        if not self.api_key:  # pragma: no cover - sanity check
+            raise RuntimeError("ANTHROPIC_API_KEY is not set")
+
+        url = f"{self.base_url}/messages"
+        response = requests.post(
+            url,
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return _extract_text(data)
+
+
+def run_anthropic(prompt: str, model: str | None = None) -> str:
+    """Return Anthropic response for ``prompt`` using ``model``."""
+
+    backend = cast(Any, AnthropicBackend)(model or "")
+    return backend.run(prompt)
+
+
+register_backend("anthropic", run_anthropic)
+
+__all__ = ["AnthropicBackend", "run_anthropic"]

--- a/llm/backends/plugins/mistral.py
+++ b/llm/backends/plugins/mistral.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, cast
+
+import requests
+
+from ..plugin_sdk import Backend, register_backend
+
+DEFAULT_BASE_URL = "https://api.mistral.ai/v1"
+
+
+def _extract_text(result: Mapping[str, Any]) -> str:
+    """Return the assistant text from a LiteLLM-style result."""
+    try:
+        choices = result["choices"]
+        first = choices[0]
+        if isinstance(first, dict):
+            if "message" in first:
+                return first["message"].get("content", "")
+            return first.get("text", "")
+    except Exception:  # pragma: no cover - fall back to str()
+        pass
+    return str(result)
+
+
+class MistralBackend(Backend):
+    """HTTP client for the Mistral API."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        self.api_key = os.environ.get("MISTRAL_API_KEY")
+        self.base_url = os.environ.get("MISTRAL_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+    def run(self, prompt: str) -> str:
+        if not self.api_key:  # pragma: no cover - sanity check
+            raise RuntimeError("MISTRAL_API_KEY is not set")
+
+        url = f"{self.base_url}/chat/completions"
+        response = requests.post(
+            url,
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return _extract_text(data)
+
+
+def run_mistral(prompt: str, model: str | None = None) -> str:
+    """Return Mistral response for ``prompt`` using ``model``."""
+
+    backend = cast(Any, MistralBackend)(model or "")
+    return backend.run(prompt)
+
+
+register_backend("mistral", run_mistral)
+
+__all__ = ["MistralBackend", "run_mistral"]

--- a/llm/router.py
+++ b/llm/router.py
@@ -70,6 +70,26 @@ def run_openrouter(prompt: str, model: str) -> str:
     return func(prompt, model)
 
 
+def run_anthropic(prompt: str, model: str) -> str:
+    """Return Anthropic response for ``prompt`` using ``model`` and registered backend."""
+
+    func = get_backend("anthropic")
+    if func is run_anthropic:
+        from llm.backends.plugins import anthropic as plugin
+        func = plugin.run_anthropic
+    return func(prompt, model)
+
+
+def run_mistral(prompt: str, model: str) -> str:
+    """Return Mistral response for ``prompt`` using ``model`` and registered backend."""
+
+    func = get_backend("mistral")
+    if func is run_mistral:
+        from llm.backends.plugins import mistral as plugin
+        func = plugin.run_mistral
+    return func(prompt, model)
+
+
 def run_superclaude(prompt: str, model: str) -> str:
     """Return SuperClaude response for ``prompt`` using ``model``."""
     backend = cast(Any, SuperClaudeBackend)(model)
@@ -203,6 +223,8 @@ __all__ = [
     "run_gemini",
     "run_ollama",
     "run_openrouter",
+    "run_anthropic",
+    "run_mistral",
     "run_superclaude",
     "create_default_chain",
     "run_langchain",

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -21,6 +21,8 @@ initialize()
 run_gemini = router.run_gemini
 run_ollama = router.run_ollama
 run_openrouter = router.run_openrouter
+run_anthropic = router.run_anthropic
+run_mistral = router.run_mistral
 create_default_chain = router.create_default_chain
 run_langchain = router.run_langchain
 _run_backend = router._run_backend
@@ -83,6 +85,8 @@ __all__ = [
     "run_gemini",
     "run_ollama",
     "run_openrouter",
+    "run_anthropic",
+    "run_mistral",
     "run_langchain",
     "_run_backend",
     "send_prompt",

--- a/tests/test_anthropic_backend.py
+++ b/tests/test_anthropic_backend.py
@@ -1,0 +1,24 @@
+import pytest
+
+pytest.importorskip("requests")
+
+from llm import router as ai_router
+from llm.backends.plugins import anthropic as plugin
+
+
+def test_run_anthropic(monkeypatch):
+    calls = []
+
+    class Dummy:
+        def __init__(self, model):
+            calls.append(("init", model))
+
+        def run(self, prompt: str) -> str:
+            calls.append(("run", prompt))
+            return "anthro"
+
+    monkeypatch.setattr(plugin, "AnthropicBackend", Dummy)
+
+    out = ai_router.run_anthropic("hey", "m")
+    assert out == "anthro"
+    assert calls == [("init", "m"), ("run", "hey")]

--- a/tests/test_mistral_backend.py
+++ b/tests/test_mistral_backend.py
@@ -1,0 +1,24 @@
+import pytest
+
+pytest.importorskip("requests")
+
+from llm import router as ai_router
+from llm.backends.plugins import mistral as plugin
+
+
+def test_run_mistral(monkeypatch):
+    calls = []
+
+    class Dummy:
+        def __init__(self, model):
+            calls.append(("init", model))
+
+        def run(self, prompt: str) -> str:
+            calls.append(("run", prompt))
+            return "mist"
+
+    monkeypatch.setattr(plugin, "MistralBackend", Dummy)
+
+    out = ai_router.run_mistral("hi", "m")
+    assert out == "mist"
+    assert calls == [("init", "m"), ("run", "hi")]


### PR DESCRIPTION
## Summary
- support Anthropic and Mistral LLM backends
- expose new backend helpers in router and CLI
- test that mocked ai_router helpers are called correctly

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880d42958cc832680b12ffb95711fb7