### PR TITLE
Add cookiecutter template for plugins

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,3 +1,3 @@
 line-length = 100
 target-version = "py310"
-extend-exclude = ["examples/notebooks"]
+extend-exclude = ["examples/notebooks", "examples/plugin_template"]

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -230,6 +230,19 @@ my_recipe = "my_package.recipes:run"
 See `scripts/recipes/plugins/sample.py` for a simple example.
 An installable package is available under `examples/plugins/sample_recipe`.
 
+## Cookiecutter Template
+
+A cookiecutter project under `examples/plugin_template` generates new
+backend or recipe packages. Install cookiecutter and run the template:
+
+```bash
+pip install cookiecutter
+cookiecutter examples/plugin_template
+```
+
+Answer the prompts to create a minimal package that registers your plug‑in
+via the appropriate entry point.
+
 ## Running a Recipe
 
 Use the ``ai-cli recipe`` subcommand to execute a named recipe. The command

--- a/examples/plugin_template/pyproject.toml
+++ b/examples/plugin_template/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "{{ cookiecutter.project_slug }}"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."{{ cookiecutter.entry_point_group }}"]
+{{ cookiecutter.plugin_name }} = "{{ cookiecutter.package_name }}:run"

--- a/examples/plugin_template/{{cookiecutter.package_name}}/__init__.py
+++ b/examples/plugin_template/{{cookiecutter.package_name}}/__init__.py
@@ -1,0 +1,23 @@
+"""{{ cookiecutter.description }}"""
+
+{%- if cookiecutter.plugin_type == 'backend' %}
+from llm.backends.plugin_sdk import register_backend
+
+
+def run(prompt: str, model: str | None = None) -> str:
+    """Generate a completion for the given prompt."""
+    return "response"
+
+register_backend("{{ cookiecutter.plugin_name }}", run)
+{%- else %}
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(goal: str):
+    """Return shell commands for the given goal."""
+    return [f"echo {goal}"]
+
+register_recipe("{{ cookiecutter.plugin_name }}", run)
+{%- endif %}
+
+__all__ = ["run"]


### PR DESCRIPTION
## Summary
- provide `plugin_template` folder for cookiecutter-generated plugins
- exclude the template from Ruff linting
- document how to use the new template in `docs/plugins.md`

## Testing
- `ruff check .`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6880dd6a94648326a6a3b82f5be009a7