### PR TITLE
Send telemetry events to Supabase

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -24,12 +24,13 @@ or pass `--analytics` to individual commands to opt into sending events.
    ```bash
    supabase db shell <<'SQL'
    create extension if not exists "uuid-ossp";
-   create table if not exists events (
-       id uuid primary key default uuid_generate_v4(),
-       payload jsonb
-   );
-   SQL
-   ```
+ create table if not exists events (
+      id uuid primary key default uuid_generate_v4(),
+      payload jsonb
+  );
+  SQL
+  ```
+   The API accepts objects with a `payload` field containing the event JSON.
 4. Copy the anonymous API key from `.env` and point the scripts at the REST
    endpoint:
    ```bash
@@ -52,6 +53,12 @@ export EVENTS_URL=https://example.supabase.co/rest/v1/events
 export EVENTS_TOKEN=your-anon-key
 export EVENTS_ENABLED=true
 ```
+
+### Environment Variables
+
+- `EVENTS_URL` – Supabase REST endpoint to insert rows into the `events` table.
+- `EVENTS_TOKEN` – API key (anon or service role) used for authentication.
+- `EVENTS_ENABLED` – when set to a truthy value, enables event recording.
 
 ## Upload Aggregated Statistics
 

--- a/telemetry.py
+++ b/telemetry.py
@@ -26,10 +26,11 @@ def record_event(name: str, payload: dict[str, Any], *, enabled: bool = False) -
     if not url:
         return False
     token = os.environ.get("EVENTS_TOKEN")
-    headers = {}
+    headers = {"Content-Type": "application/json"}
     if token:
         headers["apikey"] = token
         headers["Authorization"] = f"Bearer {token}"
+    headers.setdefault("Prefer", "return=minimal")
     dev_src = (
         os.environ.get("GIT_AUTHOR_EMAIL")
         or os.environ.get("EMAIL")
@@ -37,7 +38,7 @@ def record_event(name: str, payload: dict[str, Any], *, enabled: bool = False) -
         or "unknown"
     )
     developer = uuid.uuid5(uuid.NAMESPACE_DNS, dev_src).hex
-    data = {"name": name, "developer": developer, **payload}
+    data = {"payload": {"name": name, "developer": developer, **payload}}
     try:
         response = requests.post(url, headers=headers, json=data, timeout=5)
     except Exception as exc:  # noqa: BLE001

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -312,10 +312,11 @@ def test_plan_posts_event(monkeypatch):
     assert rc == 0
     assert sent["url"] == "https://example.com"
     assert sent["headers"]["Authorization"] == "Bearer tok"
-    assert sent["data"]["name"] == "ai-cli-plan"
-    assert sent["data"]["goal"] == "goal"
-    assert sent["data"]["step_count"] == 1
-    assert "latency_ms" in sent["data"]
+    payload = sent["data"]["payload"]
+    assert payload["name"] == "ai-cli-plan"
+    assert payload["goal"] == "goal"
+    assert payload["step_count"] == 1
+    assert "latency_ms" in payload
 
 
 def test_do_posts_event(monkeypatch, tmp_path):
@@ -348,11 +349,12 @@ def test_do_posts_event(monkeypatch, tmp_path):
     log = tmp_path / "log.txt"
     rc = ai_cli.main(["do", "goal", "--log", str(log), "--analytics"])
     assert rc == 0
-    assert sent["data"]["name"] == "ai-cli-do"
-    assert sent["data"]["goal"] == "goal"
-    assert sent["data"]["exit_code"] == 0
-    assert sent["data"]["step_count"] == 1
-    assert "latency_ms" in sent["data"]
+    payload = sent["data"]["payload"]
+    assert payload["name"] == "ai-cli-do"
+    assert payload["goal"] == "goal"
+    assert payload["exit_code"] == 0
+    assert payload["step_count"] == 1
+    assert "latency_ms" in payload
 
 
 def test_stats_fetches_events(monkeypatch):

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -38,7 +38,9 @@ def test_record_event_posts(monkeypatch):
 
     assert sent["url"] == "https://example.com"
     expected_dev = uuid.uuid5(uuid.NAMESPACE_DNS, "alice").hex
-    assert sent["data"] == {"name": "name", "a": 1, "developer": expected_dev}
+    assert sent["data"] == {
+        "payload": {"name": "name", "a": 1, "developer": expected_dev}
+    }
     assert sent["headers"]["Authorization"] == "Bearer tok"
 
 
@@ -87,7 +89,7 @@ def test_record_event_accepts_invalid_timestamps(monkeypatch):
         enabled=True,
     )
 
-    assert sent["data"]["end_ts"] == "not-a-number"
+    assert sent["data"]["payload"]["end_ts"] == "not-a-number"
 
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -44,7 +44,9 @@ def test_record_event_posts(monkeypatch):
 
     assert sent["url"] == "https://example.com"
     expected_dev = uuid.uuid5(uuid.NAMESPACE_DNS, "alice").hex
-    assert sent["data"] == {"name": "name", "a": 1, "developer": expected_dev}
+    assert sent["data"] == {
+        "payload": {"name": "name", "a": 1, "developer": expected_dev}
+    }
     assert sent["headers"]["Authorization"] == "Bearer tok"
     assert success is True
 
@@ -96,7 +98,7 @@ def test_record_event_accepts_invalid_timestamps(monkeypatch):
         enabled=True,
     )
 
-    assert sent["data"]["end_ts"] == "not-a-number"
+    assert sent["data"]["payload"]["end_ts"] == "not-a-number"
     assert success is True
 
 


### PR DESCRIPTION
## Summary
- wrap telemetry event payloads for Supabase
- clarify Supabase API usage in telemetry docs
- update tests for new telemetry format

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e2c1ec408326ac5b0f6a193a042b