### PR TITLE
Add plugin and Tauri tests

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }
+hyper = { version = "0.14", features = ["server"] }
 
 [build-dependencies]
 tauri-build = { version = "1", optional = true }

--- a/src-tauri/tests/commands.rs
+++ b/src-tauri/tests/commands.rs
@@ -1,5 +1,30 @@
 use std::io::Write;
-use ume_tauri::commands::{list_recipes, open_prompt_file};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use hyper::{service::{make_service_fn, service_fn}, Body, Method, Request, Response, Server};
+use tokio::task::JoinHandle;
+use ume_tauri::commands::{list_recipes, open_prompt_file, plan, exec};
+
+async fn spawn_server() -> JoinHandle<()> {
+    async fn handler(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+        match (req.method(), req.uri().path()) {
+            (&Method::POST, "/api/plan") => {
+                Ok(Response::new(Body::from("{\"steps\":[\"s\"]}")))
+            }
+            (&Method::GET, "/api/exec") => Ok(Response::new(Body::from("ok"))),
+            _ => Ok(Response::builder().status(404).body(Body::empty()).unwrap()),
+        }
+    }
+
+    let addr: SocketAddr = ([127, 0, 0, 1], 8000).into();
+    let server = Server::bind(&addr).serve(make_service_fn(|_| async {
+        Ok::<_, Infallible>(service_fn(handler))
+    }));
+
+    tokio::spawn(async move {
+        server.await.expect("server error");
+    })
+}
 
 #[tokio::test]
 async fn list_recipes_returns_sample() {
@@ -15,4 +40,17 @@ async fn open_prompt_file_reads_content() {
         .await
         .expect("read file");
     assert_eq!(content.trim_end(), "hello");
+}
+
+#[tokio::test]
+async fn plan_and_exec_use_server() {
+    let srv = spawn_server().await;
+
+    let steps = plan("goal".to_string()).await.expect("plan");
+    assert_eq!(steps, vec!["s".to_string()]);
+
+    let out = exec("goal".to_string()).await.expect("exec");
+    assert_eq!(out, "ok".to_string());
+
+    srv.abort();
 }

--- a/tests/test_ollama_backend.py
+++ b/tests/test_ollama_backend.py
@@ -1,0 +1,66 @@
+import subprocess
+import pytest
+
+from llm import router as ai_router
+from llm.backends.plugins import ollama as plugin
+
+
+def test_ollama_backend_runs_command(monkeypatch):
+    calls = {}
+
+    def fake_run(cmd, capture_output=True, text=True, check=True):
+        calls['cmd'] = cmd
+
+        class Res:
+            stdout = 'ok'
+
+        return Res()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    backend = plugin.OllamaBackend('m')
+    out = backend.run('p')
+
+    assert out == 'ok'
+    assert calls['cmd'] == ['ollama', 'run', 'm', 'p']
+
+
+@pytest.mark.usefixtures('monkeypatch')
+def test_run_ollama_uses_dspy_backend(monkeypatch):
+    pytest.importorskip('dspy')  # ensure dependency present
+
+    calls = []
+
+    class Dummy:
+        def __init__(self, model):
+            calls.append(('init', model))
+
+        def run(self, prompt: str) -> str:
+            calls.append(('run', prompt))
+            return 'dspy'
+
+    monkeypatch.setattr(plugin, 'OllamaDSPyBackend', Dummy)
+    out = ai_router.run_ollama('hi', 'm')
+
+    assert out == 'dspy'
+    assert calls == [('init', 'm'), ('run', 'hi')]
+
+
+def test_run_ollama_without_dspy(monkeypatch):
+    calls = []
+
+    class Dummy:
+        def __init__(self, model):
+            calls.append(('init', model))
+
+        def run(self, prompt: str) -> str:
+            calls.append(('run', prompt))
+            return 'cli'
+
+    monkeypatch.setattr(plugin, 'OllamaDSPyBackend', None)
+    monkeypatch.setattr(plugin, 'OllamaBackend', Dummy)
+
+    out = ai_router.run_ollama('yo', 'm')
+
+    assert out == 'cli'
+    assert calls == [('init', 'm'), ('run', 'yo')]


### PR DESCRIPTION
## Summary
- ensure Ollama backend is covered
- test Tauri commands with a local mock server
- add `hyper` dev dependency for Tauri tests

## Testing
- `ruff check .`
- `pytest tests/test_ollama_backend.py tests/test_tauri.py -q`
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_6880e2c0b3a483268fec244e34e6f666