### PR TITLE
Add metrics subcommand to ai_cli

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -87,3 +87,13 @@ EVENTS_URL=https://example.com ai-cli stats
 
 The command displays the total number of recorded runs, the overall success
 rate, and the average latency in milliseconds.
+
+## Viewing Aggregated Metrics
+
+Run `ai-cli metrics` to fetch weekly totals of successful `ai-do` runs:
+
+```bash
+EVENTS_URL=https://example.com ai-cli metrics
+```
+
+The output mirrors `nsm_stats.py` and prints `developer,week,count` CSV rows.

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -151,6 +151,24 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_metrics(args: argparse.Namespace) -> int:
+    """Show weekly totals of successful ai-do runs."""
+    source = args.source or os.environ.get("EVENTS_URL")
+    if not source:
+        print("EVENTS_URL or source required", file=sys.stderr)
+        return 1
+    try:
+        events = list(nsm_stats.iter_events(source))
+    except Exception as exc:  # noqa: BLE001
+        print(f"failed to fetch events: {exc}", file=sys.stderr)
+        return 1
+    counts = nsm_stats.aggregate_successful_runs(events)
+    for dev in sorted(counts):
+        for week in sorted(counts[dev]):
+            print(f"{dev},{week},{counts[dev][week]}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     analytics = build_analytics_parser()
 
@@ -214,6 +232,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     stats.set_defaults(func=_cmd_stats)
 
+    metrics = sub.add_parser(
+        "metrics",
+        help="Show weekly north star metrics from EVENTS_URL",
+    )
+    metrics.add_argument(
+        "source",
+        nargs="?",
+        default=None,
+        help="EVENTS_URL or path to local file",
+    )
+    metrics.set_defaults(func=_cmd_metrics)
+
     return parser
 
 
@@ -251,6 +281,11 @@ def plugin_main(argv: Optional[List[str]] = None) -> int:
 
 def sources_main(argv: Optional[List[str]] = None) -> int:
     argv = ["sources", *(argv or [])]
+    return main(argv)
+
+
+def metrics_main(argv: Optional[List[str]] = None) -> int:
+    argv = ["metrics", *(argv or [])]
     return main(argv)
 
 

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -378,3 +378,32 @@ def test_stats_fetches_events(monkeypatch):
         rc = ai_cli.main(["stats"])
     assert rc == 0
     assert called["url"] == "https://example.com/events"
+
+
+def test_metrics_subcommand(monkeypatch):
+    events = [
+        {"name": "ai-do", "exit_code": 0, "developer": "alice", "end_ts": 1693516800},
+        {"name": "ai-do", "exit_code": 0, "developer": "bob", "end_ts": 1693603200},
+    ]
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    monkeypatch.setattr(ai_cli.nsm_stats, "iter_events", lambda src: iter(events))
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["metrics"])
+    assert rc == 0
+    expected = ai_cli.nsm_stats.aggregate_successful_runs(events)
+    lines = out.getvalue().splitlines()
+    exp_lines = []
+    for dev in sorted(expected):
+        for week in sorted(expected[dev]):
+            exp_lines.append(f"{dev},{week},{expected[dev][week]}")
+    assert lines == exp_lines
+
+
+def test_metrics_requires_url(monkeypatch):
+    monkeypatch.delenv("EVENTS_URL", raising=False)
+    monkeypatch.setattr(ai_cli.nsm_stats, "iter_events", lambda src: iter(()))
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        rc = ai_cli.main(["metrics"])
+    assert rc == 1


### PR DESCRIPTION
## Summary
- add `metrics` subcommand to `ai_cli` for weekly north star metrics
- document `ai-cli metrics` usage
- cover new command in tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e2bf08808326a1f85c7ccc2b2df4