### PR TITLE
Add install dry-run output check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Dry run install script
         run: |
-          bash install.sh --dry-run
+          bash install.sh --dry-run | sed "s#${PWD}/##" > install_output.txt
+          diff -u tests/expected/install_dry_run_${{ matrix.os }}.txt install_output.txt
           bash scripts/install_common.sh --dry-run
         shell: bash

--- a/tests/expected/install_dry_run_macos-latest.txt
+++ b/tests/expected/install_dry_run_macos-latest.txt
@@ -1,0 +1,1 @@
+Dry run: pwsh -NoLogo -NoProfile -File scripts/helpers/install_common.ps1 --dry-run

--- a/tests/expected/install_dry_run_ubuntu-latest.txt
+++ b/tests/expected/install_dry_run_ubuntu-latest.txt
@@ -1,0 +1,1 @@
+Dry run: pwsh -NoLogo -NoProfile -File scripts/helpers/install_common.ps1 --dry-run

--- a/tests/expected/install_dry_run_windows-latest.txt
+++ b/tests/expected/install_dry_run_windows-latest.txt
@@ -1,0 +1,1 @@
+Dry run: pwsh -NoLogo -NoProfile -File scripts/helpers/install_common.ps1 --dry-run


### PR DESCRIPTION
## Summary
- run `install.sh --dry-run` in CI for all OSes and diff against expected output
- add expected output files for Ubuntu, macOS and Windows

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -n auto --cov=. --cov-report=xml --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_e_6880e2c0047c8326b7997c826370e1c7