### PR TITLE
Add Tauri recipe runner

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "next": "14.1.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@tauri-apps/api": "^2.7.0"
   }
 }

--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/tauri';
+import { listen } from '@tauri-apps/api/event';
 
 export default function Home() {
   const [health, setHealth] = useState(null);
@@ -10,6 +12,8 @@ export default function Home() {
   const [goal, setGoal] = useState('');
   const [tasks, setTasks] = useState([]);
   const [logs, setLogs] = useState('');
+  const [recipes, setRecipes] = useState([]);
+  const [selected, setSelected] = useState('');
 
   useEffect(() => {
     fetch('/api/health')
@@ -21,6 +25,17 @@ export default function Home() {
       .then((res) => res.json())
       .then(setStats)
       .catch(() => {});
+
+    if (window && window.__TAURI__) {
+      invoke('list_recipes').then(setRecipes).catch(() => {});
+      listen('prompt-file', (e) => {
+        setPrompt(e.payload);
+      }).then((unsub) => {
+        return () => {
+          unsub();
+        };
+      });
+    }
   }, []);
 
   const sendPrompt = () => {
@@ -75,6 +90,13 @@ export default function Home() {
     };
   };
 
+  const runRecipe = () => {
+    if (!selected || !window.__TAURI__) return;
+    invoke('run_recipe', { name: selected, goal })
+      .then((out) => setLogs(out))
+      .catch(() => setLogs('error'));
+  };
+
   return (
     <div>
       <h1>UME Dashboard</h1>
@@ -97,6 +119,17 @@ export default function Home() {
         <button onClick={applyPalette}>Apply</button>
         {status && <p>{status}</p>}
       </div>
+      {recipes.length > 0 && (
+        <div>
+          <select value={selected} onChange={(e) => setSelected(e.target.value)}>
+            <option value="">Select recipe</option>
+            {recipes.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+          <button onClick={runRecipe}>Run Recipe</button>
+        </div>
+      )}
       <div>
         <input value={goal} onChange={(e) => setGoal(e.target.value)} placeholder="goal" />
         <button onClick={getPlan}>Plan</button>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,13 +6,14 @@ build = "build.rs"
 
 [features]
 default = ["gui"]
-gui = ["tauri", "tauri-build"]
+gui = ["tauri", "tauri-build", "tokio"]
 
 [dependencies]
 tauri = { version = "1", optional = true, features = ["http-all"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["process"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,4 +52,43 @@ pub mod commands {
     pub async fn open_prompt_file(path: String) -> Result<String, String> {
         fs::read_to_string(path).map_err(|e| e.to_string())
     }
+
+    pub async fn run_recipe(name: String, goal: String) -> Result<String, String> {
+        use tokio::process::Command;
+
+        // first get the recipe steps as JSON from a small Python snippet
+        let output = Command::new("python3")
+            .arg("-c")
+            .arg(
+                "import json,sys,scripts.recipes as r;print(json.dumps(r.discover_recipes()[sys.argv[1]](sys.argv[2])))",
+            )
+            .arg(&name)
+            .arg(&goal)
+            .output()
+            .await
+            .map_err(|e| e.to_string())?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).to_string());
+        }
+        let steps: Vec<String> =
+            serde_json::from_slice(&output.stdout).map_err(|e| e.to_string())?;
+
+        let mut log = String::new();
+        for step in steps {
+            log.push_str(&format!("$ {}\n", step));
+            let child = if cfg!(target_os = "windows") {
+                Command::new("cmd").arg("/C").arg(&step).output()
+            } else {
+                Command::new("sh").arg("-c").arg(&step).output()
+            };
+            let res = child.await.map_err(|e| e.to_string())?;
+            log.push_str(&String::from_utf8_lossy(&res.stdout));
+            if !res.status.success() {
+                log.push_str(&String::from_utf8_lossy(&res.stderr));
+            }
+            let code = res.status.code().unwrap_or_default();
+            log.push_str(&format!("(exit {})\n\n", code));
+        }
+        Ok(log)
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -28,6 +28,12 @@ async fn open_prompt_file(path: String) -> Result<String, String> {
 }
 
 #[cfg(feature = "gui")]
+#[tauri::command]
+async fn run_recipe(name: String, goal: String) -> Result<String, String> {
+    ume_tauri::commands::run_recipe(name, goal).await
+}
+
+#[cfg(feature = "gui")]
 fn main() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
@@ -35,6 +41,7 @@ fn main() {
             exec,
             list_recipes,
             open_prompt_file,
+            run_recipe,
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application")


### PR DESCRIPTION
## Summary
- support running recipe commands from the Tauri backend
- expose new `run_recipe` command
- update dashboard UI to list recipes, accept dropped prompt files via Tauri and run recipes
- include @tauri-apps/api dependency

## Testing
- `ruff check api src-tauri scripts llm ui`
- `npx eslint dashboard/pages/index.js`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*
- `pytest tests/test_tauri.py`

------
https://chatgpt.com/codex/tasks/task_e_6880e2be1fe08326ac380236ebc1a1d7