### PR TITLE
Add stub plugin packages and tests

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -160,6 +160,9 @@ Install them directly with `pip` while developing:
 pip install -e examples/plugins/openrouter
 pip install -e examples/plugins/lobechat
 pip install -e examples/plugins/mindbridge
+pip install -e examples/plugins/anthropic
+pip install -e examples/plugins/mistral
+pip install -e examples/plugins/lmql
 pip install -e examples/plugins/echo_recipe
 pip install -e examples/plugins/sample_recipe
 ```

--- a/examples/plugins/anthropic/d0ttino_anthropic_plugin/__init__.py
+++ b/examples/plugins/anthropic/d0ttino_anthropic_plugin/__init__.py
@@ -1,0 +1,4 @@
+"""Anthropic backend plug-in."""
+from llm.backends.plugins import anthropic  # registers on import
+
+__all__ = ["anthropic"]

--- a/examples/plugins/anthropic/pyproject.toml
+++ b/examples/plugins/anthropic/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "d0ttino-anthropic-plugin"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."llm.plugins"]
+anthropic = "d0ttino_anthropic_plugin"

--- a/examples/plugins/lmql/d0ttino_lmql_plugin/__init__.py
+++ b/examples/plugins/lmql/d0ttino_lmql_plugin/__init__.py
@@ -1,0 +1,4 @@
+"""LMQL backend plug-in."""
+from llm.backends.plugins import lmql  # registers on import
+
+__all__ = ["lmql"]

--- a/examples/plugins/lmql/pyproject.toml
+++ b/examples/plugins/lmql/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "d0ttino-lmql-plugin"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."llm.plugins"]
+lmql = "d0ttino_lmql_plugin"

--- a/examples/plugins/mistral/d0ttino_mistral_plugin/__init__.py
+++ b/examples/plugins/mistral/d0ttino_mistral_plugin/__init__.py
@@ -1,0 +1,4 @@
+"""Mistral backend plug-in."""
+from llm.backends.plugins import mistral  # registers on import
+
+__all__ = ["mistral"]

--- a/examples/plugins/mistral/pyproject.toml
+++ b/examples/plugins/mistral/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "d0ttino-mistral-plugin"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."llm.plugins"]
+mistral = "d0ttino_mistral_plugin"

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -208,3 +208,21 @@ def test_load_registry_fetches_with_zero_ttl(monkeypatch, tmp_path):
     registry = plugins.load_registry(ttl=0)
     assert called
     assert registry == {"y": "pkg"}
+
+
+def test_builtin_plugins_present(monkeypatch, tmp_path):
+    monkeypatch.setattr(plugins, "CACHE_PATH", tmp_path / "missing.json")
+
+    def raise_exc(*a, **k):
+        raise plugins.requests.exceptions.RequestException("boom")
+
+    monkeypatch.setattr(plugins.requests, "get", raise_exc)
+
+    registry = plugins.load_registry()
+    expected = {
+        "anthropic": "d0ttino-anthropic-plugin",
+        "mistral": "d0ttino-mistral-plugin",
+        "lmql": "d0ttino-lmql-plugin",
+    }
+    for name, pkg in expected.items():
+        assert registry[name] == pkg


### PR DESCRIPTION
## Summary
- add example stub plugin packages for anthropic, mistral and lmql
- document how to install these plugins
- verify built-in plugin entries in the registry

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -k 'not test_dashboard_lint_and_build and not test_run_ollama_without_dspy' -q`

------
https://chatgpt.com/codex/tasks/task_e_6881615090e0832682c3477aaa5202d4