### PR TITLE
Add tests for ai_cli analytics default

### DIFF
--- a/tests/test_analytics_default.py
+++ b/tests/test_analytics_default.py
@@ -1,0 +1,45 @@
+import io
+import contextlib
+import pytest
+
+pytest.importorskip("requests")
+
+from scripts import ai_cli, cli_actions
+
+
+def test_main_respects_events_enabled(monkeypatch):
+    monkeypatch.setenv("EVENTS_ENABLED", "1")
+    monkeypatch.setattr(ai_cli.router, "send_prompt", lambda *a, **k: "ok")
+
+    recorded = []
+
+    def fake_record(name, payload, *, enabled=False):
+        recorded.append(enabled)
+        return True
+
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["send", "msg"])
+
+    assert rc == 0
+    assert recorded == [True]
+
+
+def test_main_skips_events_without_env(monkeypatch):
+    monkeypatch.delenv("EVENTS_ENABLED", raising=False)
+    monkeypatch.setattr(ai_cli.router, "send_prompt", lambda *a, **k: "ok")
+
+    recorded = []
+
+    def fake_record(name, payload, *, enabled=False):
+        recorded.append(enabled)
+        return True
+
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["send", "msg"])
+
+    assert rc == 0
+    assert recorded == [False]


### PR DESCRIPTION
## Summary
- add a test suite for analytics defaults
- ensure `EVENTS_ENABLED` toggles telemetry in `ai_cli`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive tests/test_analytics_default.py`
- `pytest tests/test_analytics_default.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6881691d204c8326994be35fe2b5a846