### PR TITLE
Add recipe commands and GUI support

### DIFF
--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -52,7 +52,12 @@ export default function Home() {
   const handleDrop = (e) => {
     e.preventDefault();
     const file = e.dataTransfer.files[0];
-    if (file) {
+    if (!file) return;
+    if (window && window.__TAURI__ && file.path) {
+      invoke('open_prompt_file', { path: file.path })
+        .then((content) => setPrompt(content))
+        .catch(() => {});
+    } else {
       const reader = new FileReader();
       reader.onload = (ev) => setPrompt(ev.target.result);
       reader.readAsText(file);

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,12 +1,13 @@
 # Desktop GUI
 
-The Tauri application offers a minimal interface for sending prompts and running recipes.
+The Tauri application offers a minimal interface for sending prompts, reviewing planned tasks and running recipes.
 
 ## Usage
 
 1. Start the backend with `uvicorn api:app --reload`.
 2. Launch the desktop app with `cargo tauri dev`.
 3. Type a prompt or drag a text file onto the window to load it automatically.
-4. Choose a recipe from the list and execute it.
+4. Click **Plan** to list the shell commands for your goal.
+5. Hit **Run** to execute the steps or choose a recipe from the drop-down and run it.
 
 Dropped files trigger the `prompt-file` event and populate the prompt field.

--- a/src-tauri/tests/commands.rs
+++ b/src-tauri/tests/commands.rs
@@ -3,7 +3,7 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use hyper::{service::{make_service_fn, service_fn}, Body, Method, Request, Response, Server};
 use tokio::task::JoinHandle;
-use ume_tauri::commands::{list_recipes, open_prompt_file, plan, exec};
+use ume_tauri::commands::{list_recipes, open_prompt_file, plan, exec, run_recipe};
 
 async fn spawn_server() -> JoinHandle<()> {
     async fn handler(req: Request<Body>) -> Result<Response<Body>, Infallible> {
@@ -53,4 +53,15 @@ async fn plan_and_exec_use_server() {
     assert_eq!(out, "ok".to_string());
 
     srv.abort();
+}
+
+#[tokio::test]
+async fn run_recipe_executes_sample() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    std::env::set_var("PYTHONPATH", root);
+    let out = run_recipe("sample".to_string(), "hello".to_string())
+        .await
+        .expect("run recipe");
+    assert!(out.contains("$ echo hello"));
+    assert!(out.contains("hello"));
 }


### PR DESCRIPTION
## Summary
- support dropping files via Tauri command in dashboard
- document how to plan tasks and run recipes
- test recipe execution from Rust

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --features tokio`

------
https://chatgpt.com/codex/tasks/task_e_68817b45dd548326b38c39db00964d6f