### PR TITLE
Update CI to install jsonschema earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test]' pytest-cov
+          pip install -e '.[test]' pytest-cov jsonschema
       - name: Run ruff
         run: ruff check .
       - name: Run mypy
@@ -104,7 +104,7 @@ jobs:
       - name: Install dependencies with extras
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test,lmql,guidance]' textual
+          pip install -e '.[test,lmql,guidance]' textual jsonschema
       - name: Install runtime requirements
         run: pip install -r requirements.txt jsonschema
       - name: Run tests with extras


### PR DESCRIPTION
## Summary
- install `jsonschema` alongside test dependencies in CI

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68818356f0b08326add76139f634d9b1