### PR TITLE
Add dropped file path support to GUI

### DIFF
--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -14,6 +14,7 @@ export default function Home() {
   const [logs, setLogs] = useState('');
   const [recipes, setRecipes] = useState([]);
   const [selected, setSelected] = useState('');
+  const [promptFile, setPromptFile] = useState('');
 
   useEffect(() => {
     fetch('/api/health')
@@ -30,6 +31,13 @@ export default function Home() {
       invoke('list_recipes').then(setRecipes).catch(() => {});
       listen('prompt-file', (e) => {
         setPrompt(e.payload);
+      }).then((unsub) => {
+        return () => {
+          unsub();
+        };
+      });
+      listen('prompt-file-path', (e) => {
+        setPromptFile(e.payload);
       }).then((unsub) => {
         return () => {
           unsub();
@@ -55,12 +63,16 @@ export default function Home() {
     if (!file) return;
     if (window && window.__TAURI__ && file.path) {
       invoke('open_prompt_file', { path: file.path })
-        .then((content) => setPrompt(content))
+        .then((content) => {
+          setPrompt(content);
+          setPromptFile(file.path);
+        })
         .catch(() => {});
     } else {
       const reader = new FileReader();
       reader.onload = (ev) => setPrompt(ev.target.result);
       reader.readAsText(file);
+      setPromptFile(file.name);
     }
   };
 
@@ -116,6 +128,7 @@ export default function Home() {
         <div onDrop={handleDrop} onDragOver={(e) => e.preventDefault()} style={{ border: '1px dashed #ccc', padding: '0.5em', marginTop: '0.5em' }}>
           Drag prompt file here
         </div>
+        {promptFile && <p>Loaded: {promptFile}</p>}
         <button onClick={sendPrompt}>Send</button>
         {response && <p>{response}</p>}
       </div>

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -10,4 +10,4 @@ The Tauri application offers a minimal interface for sending prompts, reviewing 
 4. Click **Plan** to list the shell commands for your goal.
 5. Hit **Run** to execute the steps or choose a recipe from the drop-down and run it.
 
-Dropped files trigger the `prompt-file` event and populate the prompt field.
+Dropped files trigger the `prompt-file` event and populate the prompt field. The loaded file path is shown below the drop zone so you can confirm which prompt was imported.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -52,6 +52,10 @@ fn main() {
                         if let Ok(content) = fs::read_to_string(path) {
                             if let Some(window) = app_handle.get_window(&label) {
                                 let _ = window.emit("prompt-file", content);
+                                let _ = window.emit(
+                                    "prompt-file-path",
+                                    path.to_string_lossy().to_string(),
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- emit prompt-file-path event from Tauri backend
- display dropped prompt filename in dashboard UI
- document drop zone feedback in GUI docs

## Testing
- `ruff check .`
- `pytest tests/test_tauri.py tests/test_textual_ui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68819081c5b88326bc3e603aaf63ad87