### PR TITLE
Add weekly metrics upload and retrieval

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -52,6 +52,7 @@ Example environment configuration:
 export EVENTS_URL=https://example.supabase.co/rest/v1/events
 export EVENTS_TOKEN=your-anon-key
 export EVENTS_ENABLED=true
+export NSM_URL=https://example.supabase.co/rest/v1/nsm
 ```
 
 ### Environment Variables
@@ -59,10 +60,11 @@ export EVENTS_ENABLED=true
 - `EVENTS_URL` – Supabase REST endpoint to insert rows into the `events` table.
 - `EVENTS_TOKEN` – API key (anon or service role) used for authentication.
 - `EVENTS_ENABLED` – when set to a truthy value, enables event recording.
+- `NSM_URL` – endpoint used by `nsm_upload.py` to store weekly aggregates.
 
 ## Upload Aggregated Statistics
 
-Use `nsm_upload.py` to compute weekly totals and send them to `EVENTS_URL`:
+Use `nsm_upload.py` to compute weekly totals and send them to `NSM_URL`:
 
 ```bash
 python scripts/nsm_upload.py events.json
@@ -70,7 +72,7 @@ python scripts/nsm_upload.py events.json
 
 Provide a path or URL with raw NDJSON events. The script aggregates successful
 `ai-do` runs per developer using `nsm_stats.aggregate_successful_runs()` and
-posts the resulting JSON to `EVENTS_URL`. Authentication via `EVENTS_TOKEN` is
+posts the resulting JSON to `NSM_URL`. Authentication via `EVENTS_TOKEN` is
 supported just like `record_event`.
 
 ## Tracking the North Star Metric
@@ -97,10 +99,11 @@ rate, and the average latency in milliseconds.
 
 ## Viewing Aggregated Metrics
 
-Run `ai-cli metrics` to fetch weekly totals of successful `ai-do` runs:
+Run `ai-cli metrics` to fetch weekly totals of successful `ai-do` runs.
+Use `--aggregates-url` (or set `NSM_URL`) to read precomputed totals:
 
 ```bash
-EVENTS_URL=https://example.com ai-cli metrics
+NSM_URL=https://example.com/nsm ai-cli metrics --aggregates-url https://example.com/nsm
 ```
 
 The output mirrors `nsm_stats.py` and prints `developer,week,count` CSV rows.

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -17,6 +17,7 @@ from scripts.cli_common import (
     read_prompt,
     build_analytics_parser,
 )
+import requests
 from scripts import cli_actions
 from telemetry import analytics_default
 import time
@@ -153,16 +154,29 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 def _cmd_metrics(args: argparse.Namespace) -> int:
     """Show weekly totals of successful ai-do runs."""
-    source = args.source or os.environ.get("EVENTS_URL")
-    if not source:
-        print("EVENTS_URL or source required", file=sys.stderr)
-        return 1
-    try:
-        events = list(nsm_stats.iter_events(source))
-    except Exception as exc:  # noqa: BLE001
-        print(f"failed to fetch events: {exc}", file=sys.stderr)
-        return 1
-    counts = nsm_stats.aggregate_successful_runs(events)
+    if args.aggregates_url:
+        url = args.aggregates_url or os.environ.get("NSM_URL")
+        if not url:
+            print("NSM_URL or --aggregates-url required", file=sys.stderr)
+            return 1
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            counts = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            print(f"failed to fetch aggregates: {exc}", file=sys.stderr)
+            return 1
+    else:
+        source = args.source or os.environ.get("EVENTS_URL")
+        if not source:
+            print("EVENTS_URL or source required", file=sys.stderr)
+            return 1
+        try:
+            events = list(nsm_stats.iter_events(source))
+        except Exception as exc:  # noqa: BLE001
+            print(f"failed to fetch events: {exc}", file=sys.stderr)
+            return 1
+        counts = nsm_stats.aggregate_successful_runs(events)
     for dev in sorted(counts):
         for week in sorted(counts[dev]):
             print(f"{dev},{week},{counts[dev][week]}")
@@ -234,13 +248,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     metrics = sub.add_parser(
         "metrics",
-        help="Show weekly north star metrics from EVENTS_URL",
+        help="Show weekly north star metrics",
     )
     metrics.add_argument(
         "source",
         nargs="?",
         default=None,
         help="EVENTS_URL or path to local file",
+    )
+    metrics.add_argument(
+        "--aggregates-url",
+        dest="aggregates_url",
+        default=None,
+        help="URL for precomputed weekly aggregates (default: NSM_URL)",
     )
     metrics.set_defaults(func=_cmd_metrics)
 

--- a/scripts/nsm_upload.py
+++ b/scripts/nsm_upload.py
@@ -20,6 +20,11 @@ def main(argv: Iterable[str] | None = None) -> int:
         default=os.environ.get("EVENTS_URL"),
         help="EVENTS_URL or path to local file",
     )
+    parser.add_argument(
+        "--dest",
+        default=os.environ.get("NSM_URL"),
+        help="URL to post weekly aggregates (default: NSM_URL or EVENTS_URL)",
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
     if not args.source:
         parser.error("source or EVENTS_URL required")
@@ -27,9 +32,9 @@ def main(argv: Iterable[str] | None = None) -> int:
     events = list(nsm_stats.iter_events(args.source))
     counts = nsm_stats.aggregate_successful_runs(events)
 
-    url = os.environ.get("EVENTS_URL")
+    url = args.dest or os.environ.get("NSM_URL") or os.environ.get("EVENTS_URL")
     if not url:
-        parser.error("EVENTS_URL required for upload")
+        parser.error("destination URL required for upload")
     token = os.environ.get("EVENTS_TOKEN")
     headers = {}
     if token:

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -402,6 +402,31 @@ def test_metrics_subcommand(monkeypatch):
     assert lines == exp_lines
 
 
+def test_metrics_aggregates_url(monkeypatch):
+    monkeypatch.setenv("NSM_URL", "https://example.com/nsm")
+    called = {}
+
+    def fake_get(url, timeout=None):
+        called["url"] = url
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"alice": {"2023-W01": 2}}
+
+        return Resp()
+
+    monkeypatch.setattr(ai_cli.requests, "get", fake_get)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["metrics", "--aggregates-url", "https://example.com/nsm"])
+    assert rc == 0
+    assert called["url"] == "https://example.com/nsm"
+    assert out.getvalue().splitlines() == ["alice,2023-W01,2"]
+
+
 def test_metrics_requires_url(monkeypatch):
     monkeypatch.delenv("EVENTS_URL", raising=False)
     monkeypatch.setattr(ai_cli.nsm_stats, "iter_events", lambda src: iter(()))

--- a/tests/test_nsm_upload.py
+++ b/tests/test_nsm_upload.py
@@ -20,14 +20,14 @@ def test_nsm_upload_posts_counts(monkeypatch):
         sent["json"] = json
 
     monkeypatch.setattr(nsm_upload.requests, "post", fake_post)
-    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    monkeypatch.setenv("NSM_URL", "https://example.com/nsm")
     monkeypatch.setenv("EVENTS_TOKEN", "tok")
 
     rc = nsm_upload.main(["dummy.json"])
     expected = nsm_stats.aggregate_successful_runs(events)
 
     assert rc == 0
-    assert sent["url"] == "https://example.com"
+    assert sent["url"] == "https://example.com/nsm"
     assert sent["json"] == expected
     assert sent["headers"]["Authorization"] == "Bearer tok"
 
@@ -39,6 +39,6 @@ def test_nsm_upload_handles_error(monkeypatch):
         raise RuntimeError("nope")
 
     monkeypatch.setattr(nsm_upload.requests, "post", fake_post)
-    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    monkeypatch.setenv("NSM_URL", "https://example.com/nsm")
     rc = nsm_upload.main(["dummy.json"])
     assert rc == 1


### PR DESCRIPTION
## Summary
- extend `nsm_upload.py` with `--dest` for posting weekly aggregates
- allow `ai-cli metrics` to fetch aggregates via `--aggregates-url`
- document new `NSM_URL` environment variable and usage
- add tests for new options

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881908139b48326aee5839506f23718