### PR TITLE
Add recipe publish command

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -106,6 +106,7 @@ ai-cli plugin recipes list
 ai-cli plugin recipes install echo
 ai-cli plugin recipes remove echo
 ai-cli plugin recipes sync
+ai-cli plugin recipes publish dist/my_recipe-0.1-py3-none-any.whl --url https://example.com/simple
 ```
 
 `recipes sync` downloads and installs the recipe packages listed in the
@@ -121,6 +122,14 @@ Use `--dest` to specify a custom download directory:
 ```bash
 python -m scripts.plugins recipes sync --dest /tmp/recipe_pkgs
 ```
+
+Use `recipes publish` to upload a built recipe package to a registry:
+
+```bash
+python -m scripts.plugins recipes publish dist/my_recipe-0.1-py3-none-any.whl --url https://example.com/simple
+```
+
+Set `PLUGIN_REGISTRY_UPLOAD_URL` to configure the default upload target.
 
 ### Adding Your Plug-in
 

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -290,6 +290,34 @@ def _cmd_sync_recipes(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_publish_recipes(args: argparse.Namespace) -> int:
+    """Upload a recipe package to a registry."""
+    url = args.url or os.environ.get("PLUGIN_REGISTRY_UPLOAD_URL")
+    if not url:
+        print("Upload URL required (--url or PLUGIN_REGISTRY_UPLOAD_URL)", file=sys.stderr)
+        return 1
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "upload",
+                "--repository-url",
+                url,
+                args.path,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return 0
+    except subprocess.CalledProcessError as exc:
+        if exc.stderr:
+            print(exc.stderr, file=sys.stderr, end="")
+        return exc.returncode
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -335,6 +363,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory to install downloaded packages",
     )
     r_sync.set_defaults(func=_cmd_sync_recipes)
+
+    r_publish = recipe_sub.add_parser(
+        "publish", help="Upload a recipe package to a registry"
+    )
+    r_publish.add_argument("path", help="Path to recipe package")
+    r_publish.add_argument(
+        "--url",
+        default=os.environ.get("PLUGIN_REGISTRY_UPLOAD_URL"),
+        help="Registry URL for upload (default: PLUGIN_REGISTRY_UPLOAD_URL)",
+    )
+    r_publish.set_defaults(func=_cmd_publish_recipes)
 
     return parser
 

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -300,3 +300,33 @@ def test_recipe_sync_creates_packages(monkeypatch, tmp_path):
     for pkg in packages.values():
         assert (tmp_path / pkg).is_file()
 
+
+def test_recipe_publish(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, *a, **k):
+        called["cmd"] = cmd
+
+        class Res:
+            returncode = 0
+
+        return Res()
+
+    monkeypatch.setattr(plugins.subprocess, "run", fake_run)
+
+    rc = plugins.main(
+        [
+            "recipes",
+            "publish",
+            "package.whl",
+            "--url",
+            "https://example.com/simple",
+        ]
+    )
+    assert rc == 0
+    assert called["cmd"][0] == sys.executable
+    assert "upload" in called["cmd"]
+    assert "--repository-url" in called["cmd"]
+    assert "https://example.com/simple" in called["cmd"]
+    assert "package.whl" in called["cmd"]
+


### PR DESCRIPTION
## Summary
- add `recipes publish` action in scripts/plugins.py to upload recipe packages
- document publishing in docs/plugins.md
- test the new publish action

## Testing
- `ruff check scripts/plugins.py tests/test_plugins_script.py`
- `pytest tests/test_plugins_script.py::test_recipe_publish -q`

------
https://chatgpt.com/codex/tasks/task_e_6881940a4e2083269f9887a8009b7e2a