### PR TITLE
Use twine for recipe uploads

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -123,7 +123,8 @@ Use `--dest` to specify a custom download directory:
 python -m scripts.plugins recipes sync --dest /tmp/recipe_pkgs
 ```
 
-Use `recipes publish` to upload a built recipe package to a registry:
+Use `recipes publish` to upload a built recipe package to a registry. The helper
+invokes `twine upload` under the hood, so make sure `twine` is installed:
 
 ```bash
 python -m scripts.plugins recipes publish dist/my_recipe-0.1-py3-none-any.whl --url https://example.com/simple

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -301,7 +301,7 @@ def _cmd_publish_recipes(args: argparse.Namespace) -> int:
             [
                 sys.executable,
                 "-m",
-                "pip",
+                "twine",
                 "upload",
                 "--repository-url",
                 url,

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -325,6 +325,7 @@ def test_recipe_publish(monkeypatch):
     )
     assert rc == 0
     assert called["cmd"][0] == sys.executable
+    assert "twine" in called["cmd"]
     assert "upload" in called["cmd"]
     assert "--repository-url" in called["cmd"]
     assert "https://example.com/simple" in called["cmd"]


### PR DESCRIPTION
## Summary
- use `twine upload` instead of `pip upload` in plugins helper
- update the recipe publish test
- document the `twine upload` requirement in plugin docs

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828742b6e88326a74670bcc215b3f1