### PR TITLE
Install jsonschema for schema tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ with `python -m scripts.plugins`. For example:
 python -m scripts.plugins backends install openrouter
 ```
 
+For development and testing install everything using the development requirements file:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
 See the [backend plug-in guide](docs/plugins.md) for details. If you
 prefer not to install any extras, install `jsonschema` separately with:
 
@@ -179,13 +185,14 @@ pwsh -File scripts/export-winget.ps1
 
 ## Testing
 
-Install all required packages using the helper file so `pytest` and runtime
+Install all required packages using the development requirements file so `pytest` and runtime
 dependencies like `requests` are available. Running the command below ensures
 every dependency needed for the tests is installed:
 
 ```bash
 pip install -r requirements-dev.txt
 ```
+This installs `jsonschema`, which the schema validation tests require.
 If `pytest` reports missing modules, consult `/tmp/pytest.log` to see which
 packages are required and ensure they are installed.
 To install everything manually use:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@
 # -e .[guidance]
 # -e .[etl]
 -r requirements.txt
+jsonschema


### PR DESCRIPTION
## Summary
- document requirements-dev in README and mention jsonschema for schema tests
- include jsonschema in `requirements-dev.txt`
- keep `jsonschema` optional in `scripts/plugins.py`
- restore test for missing jsonschema warning

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688287436d688326a781945d021c67d5