### PR TITLE
Add pre-commit with ruff and mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.5
+    hooks:
+      - id: ruff
+        args: [check, .]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.17.0
+    hooks:
+      - id: mypy
+        args: [--install-types, --non-interactive]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ is considered complex.
 `ai-do` exits with the code of the first failing command, making it suitable for
 automation scripts.
 
-Next, install the Git hooks so `pre-commit` runs automatically:
+Next, install the Git hooks so `pre-commit` runs automatically. The script
+invokes `pre-commit install` after the common setup:
 
 ```bash
 ./install.sh
@@ -103,7 +104,9 @@ Next, install the Git hooks so `pre-commit` runs automatically:
 
 `install.sh` sets up the hooks for you. It detects your platform and calls
 `scripts/setup-hooks.ps1` on Windows or `scripts/setup-hooks.sh` elsewhere so
-`pre-commit` runs on each commit.
+`pre-commit` runs on each commit. The hook uses `.pre-commit-config.yaml` to
+run `ruff check` and `mypy` automatically.
+Install the development dependencies with `pip install -r requirements-dev.txt` before running the hook or tests.
 
 You can then run the test suite to verify the configuration:
 
@@ -155,8 +158,8 @@ Additional guides:
 Run `scripts/setup-hooks.sh` to enable the local hooks automatically
 (equivalent to running `git config core.hooksPath .githooks`). `install.sh`
 and `bootstrap.ps1` call the appropriate script for you (`scripts/setup-hooks.ps1`
-on Windows and `scripts/setup-hooks.sh` elsewhere), so you usually don't need to
-run it manually:
+on Windows and `scripts/setup-hooks.sh` elsewhere) and then execute
+`pre-commit install`, so you usually don't need to run it manually:
 
 ```bash
 ./scripts/setup-hooks.sh
@@ -164,9 +167,10 @@ run it manually:
 
 Once enabled, the `pre-commit` hook first runs `winget upgrade --all` and then
 automatically exports your current `winget` package list to
-`winget-packages.json` whenever you commit on Windows. Be sure to commit the
-updated file so your package list stays in sync. On Linux or WSL the export is
-skipped unless `winget` is available.
+`winget-packages.json` whenever you commit on Windows. In addition, it invokes
+`pre-commit` to run `ruff` and `mypy` as defined in `.pre-commit-config.yaml`.
+Be sure to commit the updated file so your package list stays in sync. On Linux
+or WSL the export is skipped unless `winget` is available.
 
 If the hook is disabled, run the following commands manually to upgrade and
 export your package list:
@@ -220,11 +224,12 @@ pytest -n auto || pytest
 ## Contributing
 
 Run `ruff` and `mypy` before committing to ensure the code is lint and type
-error free:
+error free. You can run them directly or via `pre-commit`:
 
 ```bash
 ruff check .
 mypy --install-types --non-interactive
+pre-commit run --files <changed files>
 ```
 
 After fixing any errors, rerun the commands and verify they report zero issues.

--- a/install.sh
+++ b/install.sh
@@ -64,4 +64,9 @@ if $dry_run; then
     echo "Dry run: ${cmd[*]}"
 else
     "${cmd[@]}"
+    if command -v pre-commit >/dev/null 2>&1; then
+        pre-commit install
+    else
+        echo "pre-commit not found; skipping hook installation" >&2
+    fi
 fi


### PR DESCRIPTION
## Summary
- create a `.pre-commit-config.yaml` with ruff and mypy
- install hooks via `pre-commit install` in `install.sh`
- document the hook workflow and mention dev dependencies in the README

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882874405cc83269be20c8b784fe8d0