### PR TITLE
Add registry update script and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
           path: coverage.xml
       - name: Verify awesome sources markdown
         run: pytest tests/test_generate_sources_md.py -q
+      - name: Verify plugin registry
+        run: python scripts/update_registry.py --check
 
   extras-tests:
     needs: changes
@@ -109,6 +111,8 @@ jobs:
         run: pip install -r requirements.txt jsonschema
       - name: Run tests with extras
         run: pytest -n auto
+      - name: Verify plugin registry
+        run: python scripts/update_registry.py --check
   install-dry-run:
     needs: changes
     if: needs.changes.outputs.code_changed == 'true'

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,0 +1,46 @@
+name: Update Plugin Registry
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - plugin-registry.json
+      - plugin-registry.schema.json
+      - scripts/plugins.py
+  pull_request:
+    paths:
+      - plugin-registry.json
+      - plugin-registry.schema.json
+      - scripts/plugins.py
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Update registry file
+        run: python scripts/update_registry.py
+      - name: Check for differences
+        id: diff
+        run: |
+          if git diff --quiet plugin-registry.json; then
+            echo "diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "diff=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Commit updated file
+        if: steps.diff.outputs.diff == 'true' && github.event_name == 'pull_request'
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@users.noreply.github.com
+          git add plugin-registry.json
+          git commit -m "Update plugin registry" || exit 0
+          git push
+      - name: Fail if registry differs
+        if: steps.diff.outputs.diff == 'true'
+        run: |
+          echo "::error::plugin-registry.json is outdated. Run 'python scripts/update_registry.py' and commit the result." \
+          && exit 1

--- a/scripts/update_registry.py
+++ b/scripts/update_registry.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate and update plugin-registry.json from built-in defaults."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+from jsonschema import FormatChecker
+
+from scripts import plugins
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_PATH = REPO_ROOT / "plugin-registry.json"
+SCHEMA_PATH = REPO_ROOT / "plugin-registry.schema.json"
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> dict[str, object]:
+    """Return registry data from ``path``."""
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def load_schema(path: Path = SCHEMA_PATH) -> dict[str, object]:
+    """Return JSON schema from ``path``."""
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def validate_registry(data: dict[str, object], schema: dict[str, object]) -> None:
+    """Raise ``jsonschema.ValidationError`` if ``data`` is invalid."""
+    jsonschema.validate(data, schema, format_checker=FormatChecker())
+
+
+def sync_registry(data: dict[str, object]) -> bool:
+    """Update ``data`` with built-in registry values.
+
+    Returns ``True`` if ``data`` was modified.
+    """
+    expected_plugins = plugins.PLUGIN_REGISTRY
+    changed = False
+    if data.get("plugins") != expected_plugins:
+        data["plugins"] = expected_plugins
+        changed = True
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Return non-zero if plugin-registry.json is outdated",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        data = load_registry()
+    except json.JSONDecodeError as exc:
+        print(f"Failed to parse {REGISTRY_PATH}: {exc}", file=sys.stderr)
+        return 1
+
+    schema = load_schema()
+    try:
+        validate_registry(data, schema)
+    except jsonschema.ValidationError as exc:
+        print(f"{REGISTRY_PATH} failed validation: {exc.message}", file=sys.stderr)
+        return 1
+
+    changed = sync_registry(data)
+    if changed:
+        if args.check:
+            print(
+                "plugin-registry.json is outdated. "
+                "Run 'python scripts/update_registry.py' and commit the result.",
+                file=sys.stderr,
+            )
+            return 1
+        REGISTRY_PATH.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_plugin_registry_sync.py
+++ b/tests/test_plugin_registry_sync.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+from scripts import plugins
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REG_PATH = REPO_ROOT / "plugin-registry.json"
+
+
+def test_plugin_registry_up_to_date() -> None:
+    data = json.loads(REG_PATH.read_text(encoding="utf-8"))
+    assert data.get("plugins") == plugins.PLUGIN_REGISTRY, (
+        "plugin-registry.json is outdated. "
+        "Run 'python scripts/update_registry.py' and commit the result."
+    )


### PR DESCRIPTION
## Summary
- add `update_registry.py` utility to keep built-in plugins in sync
- enforce registry check in CI workflows
- create workflow to automatically update the registry
- test that `plugin-registry.json` matches built-in plugin list

## Testing
- `ruff check scripts/update_registry.py tests/test_plugin_registry_sync.py`
- `mypy --install-types --non-interactive scripts/update_registry.py tests/test_plugin_registry_sync.py`
- `pytest tests/test_plugin_registry_sync.py -q`
- `pytest -n auto --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_6882904d5b4c8326a155f43b9ceb56c9