### PR TITLE
Connect Tauri commands to dashboard

### DIFF
--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -87,24 +87,36 @@ export default function Home() {
   };
 
   const getPlan = () => {
-    fetch('/api/plan', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ goal })
-    })
-      .then((res) => res.json())
-      .then((data) => setTasks(data.steps || []));
+    if (window && window.__TAURI__) {
+      invoke('plan', { goal })
+        .then((steps) => setTasks(steps))
+        .catch(() => setTasks([]));
+    } else {
+      fetch('/api/plan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ goal })
+      })
+        .then((res) => res.json())
+        .then((data) => setTasks(data.steps || []));
+    }
   };
 
   const runExec = () => {
     setLogs('');
-    const es = new EventSource(`/api/exec?goal=${encodeURIComponent(goal)}`);
-    es.onmessage = (e) => {
-      setLogs((prev) => prev + e.data + '\n');
-    };
-    es.onerror = () => {
-      es.close();
-    };
+    if (window && window.__TAURI__) {
+      invoke('exec', { goal })
+        .then((out) => setLogs(out))
+        .catch(() => setLogs('error'));
+    } else {
+      const es = new EventSource(`/api/exec?goal=${encodeURIComponent(goal)}`);
+      es.onmessage = (e) => {
+        setLogs((prev) => prev + e.data + '\n');
+      };
+      es.onerror = () => {
+        es.close();
+      };
+    }
   };
 
   const runRecipe = () => {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 build = "build.rs"
 
 [features]
-default = ["gui"]
-gui = ["tauri", "tauri-build", "tokio"]
+default = []
+gui = ["tauri", "tauri-build"]
 
 [dependencies]
 tauri = { version = "1", optional = true, features = ["http-all"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["process"], optional = true }
+tokio = { version = "1", features = ["process"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,6 +9,11 @@
     "version": "0.1.0"
   },
   "tauri": {
+    "allowlist": {
+      "http": {
+        "all": true
+      }
+    },
     "windows": [
       {
         "title": "UME Dashboard",

--- a/src-tauri/tests/commands.rs
+++ b/src-tauri/tests/commands.rs
@@ -65,3 +65,19 @@ async fn run_recipe_executes_sample() {
     assert!(out.contains("$ echo hello"));
     assert!(out.contains("hello"));
 }
+
+#[tokio::test]
+async fn list_recipes_detects_new_file() {
+    use std::fs;
+    use std::path::Path;
+
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../scripts/recipes/plugins");
+    let file = dir.join("temp_test.py");
+    fs::write(&file, "# temp").expect("write file");
+
+    let recipes = list_recipes().await.expect("list");
+    fs::remove_file(&file).expect("cleanup");
+
+    assert!(recipes.contains(&"temp_test".to_string()));
+}


### PR DESCRIPTION
## Summary
- connect the Plan and Exec buttons to call Tauri commands when running in the desktop app
- test recipe detection with a temporary plugin file
- make GUI optional so `cargo test` builds without GTK libs
- allow HTTP requests in Tauri config

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68829aa148c48326b85e1bb5691015fe