### PR TITLE
Add metrics alias test and telemetry logging

### DIFF
--- a/telemetry.py
+++ b/telemetry.py
@@ -9,6 +9,9 @@ import logging
 import requests
 
 
+logger = logging.getLogger(__name__)
+
+
 def analytics_default() -> bool:
     """Return ``True`` when ``EVENTS_ENABLED`` is set to a truthy value."""
     val = os.environ.get("EVENTS_ENABLED")
@@ -41,10 +44,15 @@ def record_event(name: str, payload: dict[str, Any], *, enabled: bool = False) -
     data = {"payload": {"name": name, "developer": developer, **payload}}
     try:
         response = requests.post(url, headers=headers, json=data, timeout=5)
+        success = response.status_code // 100 == 2
     except Exception as exc:  # noqa: BLE001
-        logging.warning("Failed to record telemetry event: %s", exc)
-        return False
-    return response.status_code // 100 == 2
+        logger.warning("Failed to record telemetry event: %s", exc)
+        success = False
+
+    latency = payload.get("latency_ms") or payload.get("duration_ms")
+    source = payload.get("model_source", "unknown")
+    logger.info("%s: source=%s latency_ms=%s", name, source, latency)
+    return success
 
 
 __all__ = ["analytics_default", "record_event"]

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -434,3 +434,23 @@ def test_metrics_requires_url(monkeypatch):
     with contextlib.redirect_stderr(err):
         rc = ai_cli.main(["metrics"])
     assert rc == 1
+
+
+def test_metrics_main(monkeypatch):
+    events = [
+        {"name": "ai-do", "exit_code": 0, "developer": "alice", "end_ts": 1693516800},
+        {"name": "ai-do", "exit_code": 0, "developer": "bob", "end_ts": 1693603200},
+    ]
+    monkeypatch.setenv("EVENTS_URL", "https://example.com")
+    monkeypatch.setattr(ai_cli.nsm_stats, "iter_events", lambda src: iter(events))
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.metrics_main([])
+    assert rc == 0
+    expected = ai_cli.nsm_stats.aggregate_successful_runs(events)
+    lines = out.getvalue().splitlines()
+    exp_lines = []
+    for dev in sorted(expected):
+        for week in sorted(expected[dev]):
+            exp_lines.append(f"{dev},{week},{expected[dev][week]}")
+    assert lines == exp_lines


### PR DESCRIPTION
## Summary
- log telemetry event source and latency
- add metrics_main test coverage
- log telemetry errors with module logger

## Testing
- `ruff check telemetry.py scripts/ai_cli.py tests/test_ai_cli.py`
- `mypy telemetry.py scripts/ai_cli.py tests/test_ai_cli.py`
- `pytest -q tests/test_ai_cli.py -k test_metrics_main`


------
https://chatgpt.com/codex/tasks/task_e_6882a45b39a0832692c39191fc093272