### PR TITLE
Add build/test/deploy recipe examples

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -279,8 +279,17 @@ loader can discover it. The loader iterates
 my_recipe = "my_package.recipes:run"
 ```
 
-See `scripts/recipes/plugins/sample.py` for a simple example.
+See `scripts/recipes/plugins/sample.py` for a simple example. Additional
+examples for common automation tasks are provided in the same directory with
+`build`, `test` and `deploy` recipes.
 An installable package is available under `examples/plugins/sample_recipe`.
+Publish a built wheel with `recipes publish` and sync recipes from a registry
+with `recipes sync`:
+
+```bash
+python -m scripts.plugins recipes publish dist/build_recipe-0.1-py3-none-any.whl --url https://example.com/simple
+python -m scripts.plugins recipes sync
+```
 
 ## Cookiecutter Template
 
@@ -303,4 +312,5 @@ it returns interactively.
 
 ```bash
 ai-cli recipe sample "Show my goal"
+ai-cli recipe build "Project"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ query-sources = "scripts.query_sources:main"
 
 [project.entry-points."d0ttino.recipes"]
 sample = "scripts.recipes.plugins.sample:run"
+build = "scripts.recipes.plugins.build:run"
+test = "scripts.recipes.plugins.test:run"
+deploy = "scripts.recipes.plugins.deploy:run"
 
 
 [tool.setuptools.packages.find]

--- a/scripts/recipes/plugins/build.py
+++ b/scripts/recipes/plugins/build.py
@@ -1,0 +1,16 @@
+"""Build recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(goal: str) -> List[str]:
+    """Return a command that echoes the build goal."""
+    return [f"echo build {goal}"]
+
+
+register_recipe("build", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/deploy.py
+++ b/scripts/recipes/plugins/deploy.py
@@ -1,0 +1,16 @@
+"""Deploy recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(goal: str) -> List[str]:
+    """Return a command that echoes the deploy goal."""
+    return [f"echo deploy {goal}"]
+
+
+register_recipe("deploy", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/test.py
+++ b/scripts/recipes/plugins/test.py
@@ -1,0 +1,16 @@
+"""Test recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(goal: str) -> List[str]:
+    """Return a command that echoes the test goal."""
+    return [f"echo test {goal}"]
+
+
+register_recipe("test", run)
+
+__all__ = ["run"]

--- a/tests/test_recipe_plugins.py
+++ b/tests/test_recipe_plugins.py
@@ -14,6 +14,12 @@ def test_discover_recipes_finds_builtin_sample():
     mapping = recipes.discover_recipes()
     assert "sample" in mapping
     assert mapping["sample"]("goal") == ["echo goal"]
+    assert "build" in mapping
+    assert mapping["build"]("app") == ["echo build app"]
+    assert "test" in mapping
+    assert mapping["test"]("app") == ["echo test app"]
+    assert "deploy" in mapping
+    assert mapping["deploy"]("app") == ["echo deploy app"]
 
 
 def test_discover_recipes_loads_entry_points(monkeypatch):


### PR DESCRIPTION
## Summary
- add build, test and deploy recipes
- expose new recipes through entry points
- document how to sync and publish recipe packages
- test that new recipes are discovered and callable

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c949bb64832690a5c2af730929f2