### PR TITLE
Update registry sync for recipes

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -9,6 +9,6 @@
     "lmql": "d0ttino-lmql-plugin"
   },
   "recipes": {
-    "echo": "https://example.com/packages/d0ttino-echo-recipe.tar.gz"
+    "echo": "d0ttino-echo-recipe"
   }
 }

--- a/scripts/update_registry.py
+++ b/scripts/update_registry.py
@@ -41,9 +41,13 @@ def sync_registry(data: dict[str, object]) -> bool:
     Returns ``True`` if ``data`` was modified.
     """
     expected_plugins = plugins.PLUGIN_REGISTRY
+    expected_recipes = plugins.RECIPE_REGISTRY
     changed = False
     if data.get("plugins") != expected_plugins:
         data["plugins"] = expected_plugins
+        changed = True
+    if data.get("recipes") != expected_recipes:
+        data["recipes"] = expected_recipes
         changed = True
     return changed
 

--- a/tests/test_plugin_registry_sync.py
+++ b/tests/test_plugin_registry_sync.py
@@ -13,3 +13,7 @@ def test_plugin_registry_up_to_date() -> None:
         "plugin-registry.json is outdated. "
         "Run 'python scripts/update_registry.py' and commit the result."
     )
+    assert data.get("recipes") == plugins.RECIPE_REGISTRY, (
+        "plugin-registry.json is outdated. "
+        "Run 'python scripts/update_registry.py' and commit the result."
+    )

--- a/tests/test_update_registry.py
+++ b/tests/test_update_registry.py
@@ -1,0 +1,15 @@
+import json
+
+from scripts import update_registry, plugins
+
+
+def test_update_registry_check_recipes(tmp_path, monkeypatch):
+    data = {"plugins": plugins.PLUGIN_REGISTRY, "recipes": {"echo": "old"}}
+    reg = tmp_path / "plugin-registry.json"
+    reg.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(update_registry, "REGISTRY_PATH", reg)
+    orig_load = update_registry.load_registry
+    monkeypatch.setattr(update_registry, "load_registry", lambda path=reg: orig_load(path))
+    rc = update_registry.main(["--check"])
+    assert rc == 1
+    assert json.loads(reg.read_text(encoding="utf-8")) == data


### PR DESCRIPTION
## Summary
- update builtin registry sync to manage recipes
- keep plugin-registry.json in sync with builtin recipe registry
- check recipes in plugin registry sync tests
- test update_registry --check fails when recipes are outdated

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e1282d7083268187bcba8f6dfc55