### PR TITLE
Add ai-cli sources category and filter tests

### DIFF
--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -263,6 +263,27 @@ def test_sources_subcommand(capsys):
     assert "Python Docs" in output
 
 
+def test_sources_filter_category(capsys):
+    rc = ai_cli.main(["sources", "--category", "DevOps"])
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert "Docker Documentation" in output
+
+
+def test_sources_name_and_tag_filters(capsys):
+    rc = ai_cli.main(["sources", "--name", "fastapi", "--tag", "python"])
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert "FastAPI" in output
+
+
+def test_sources_no_matches(capsys):
+    rc = ai_cli.main(["sources", "--category", "missing"])
+    output = capsys.readouterr().out
+    assert rc == 1
+    assert output == ""
+
+
 def test_stats_subcommand(monkeypatch):
     events = [
         {"exit_code": 0, "latency_ms": 100},


### PR DESCRIPTION
## Summary
- expand coverage for `ai-cli sources`
- verify category filtering, no-match handling, and combined name+tag filters

## Testing
- `ruff check tests/test_ai_cli.py`
- `mypy tests/test_ai_cli.py`
- `pytest tests/test_ai_cli.py::test_sources_subcommand`
- `pytest tests/test_ai_cli.py::test_sources_filter_category tests/test_ai_cli.py::test_sources_name_and_tag_filters tests/test_ai_cli.py::test_sources_no_matches`

------
https://chatgpt.com/codex/tasks/task_e_6882e535aabc83268461aafd01650ecd