### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - "8081:8080"
 
   api:
-    image: python:3.11-slim
+    build: .
     working_dir: /app
     command: uvicorn api:app --host 0.0.0.0 --port 8000
     volumes:

--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -91,6 +91,18 @@ The React dashboard connects to the same host, typically started with
 `pnpm dev` on <http://localhost:3000>. The Tauri build uses the same
 React code so both environments share a consistent interface.
 
+### Docker image
+
+Build the container image and launch the API with Docker Compose:
+
+```bash
+docker-compose build api
+docker-compose up api
+```
+
+The compose file uses the repository `Dockerfile` which installs
+`requirements.txt` and runs `uvicorn api:app` on port 8000.
+
 ### Legacy Streamlit interface
 
 Earlier versions provided a Streamlit UI located at `ui/web_app.py`. It remains


### PR DESCRIPTION
## Summary
- add Dockerfile for Python API
- build API service using our Dockerfile
- document container usage

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c6a1bc288326a61126940fb10250