### PR TITLE
Add NATS telemetry option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Local LLM utilities"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["dspy==2.6.27", "requests"]
+dependencies = ["dspy==2.6.27", "requests", "nats-py"]
 
 [project.optional-dependencies]
 test = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ httpx
 fastapi
 uvicorn
 jsonschema
+nats-py

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Any
 
 from llm import router
 from llm.backends import initialize
@@ -20,11 +20,23 @@ from scripts.cli_common import (
 import requests
 from scripts import cli_actions
 from telemetry import analytics_default
+from ume import events as ume_events
+import logging
 import time
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 initialize()
+
+
+def _publish_event(args: argparse.Namespace, name: str, payload: dict[str, Any]) -> None:
+    """Record analytics and publish to NATS when configured."""
+    cli_actions.record_event_logged(name, payload, enabled=args.analytics)
+    if args.analytics and getattr(args, "nats_url", None):
+        try:
+            ume_events.publish_event(args.nats_url, name, payload)
+        except Exception as exc:  # noqa: BLE001
+            logging.debug("Failed to publish NATS event: %s", exc)
 
 
 def _cmd_send(args: argparse.Namespace) -> int:
@@ -33,16 +45,12 @@ def _cmd_send(args: argparse.Namespace) -> int:
         output = router.send_prompt(prompt, local=args.local, model=args.model)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)
-        cli_actions.record_event_logged(
-            "ai-cli-send", {"exit_code": 1}, enabled=args.analytics
-        )
+        _publish_event(args, "ai-cli-send", {"exit_code": 1})
         return 1
     sys.stdout.write(output)
     if not output.endswith("\n"):
         sys.stdout.write("\n")
-    cli_actions.record_event_logged(
-        "ai-cli-send", {"exit_code": 0}, enabled=args.analytics
-    )
+    _publish_event(args, "ai-cli-send", {"exit_code": 0})
     return 0
 
 
@@ -52,7 +60,8 @@ def _cmd_plan(args: argparse.Namespace) -> int:
     for step in steps:
         print(step)
     end = time.time()
-    cli_actions.record_event_logged(
+    _publish_event(
+        args,
         "ai-cli-plan",
         {
             "goal": args.goal,
@@ -61,7 +70,6 @@ def _cmd_plan(args: argparse.Namespace) -> int:
             "end_ts": end,
             "latency_ms": int((end - start) * 1000),
         },
-        enabled=args.analytics,
     )
     return 0
 
@@ -76,6 +84,7 @@ def _cmd_do(args: argparse.Namespace) -> int:
         log_path=args.log,
         analytics=args.analytics,
         payload={"goal": args.goal, "step_count": len(steps)},
+        nats_url=args.nats_url,
     )
 
 
@@ -93,10 +102,12 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
         steps,
         log_path=args.log,
         analytics=args.analytics,
+        nats_url=args.nats_url,
     )
     end = time.time()
     if exit_code == 0:
-        cli_actions.record_event_logged(
+        _publish_event(
+            args,
             "ai-cli-recipe",
             {
                 "recipe": args.name,
@@ -107,7 +118,6 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
                 "end_ts": end,
                 "latency_ms": int((end - start) * 1000),
             },
-            enabled=args.analytics,
         )
     return exit_code
 
@@ -186,6 +196,12 @@ def _cmd_metrics(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     analytics = build_analytics_parser()
 
+    analytics.add_argument(
+        "--nats-url",
+        dest="nats_url",
+        default=None,
+        help="NATS server URL for telemetry",
+    )
     parser = argparse.ArgumentParser(description=__doc__, parents=[analytics])
     sub = parser.add_subparsers(dest="command", required=True)
     send = sub.add_parser("send", help="Send a prompt to the LLM backend", parents=[analytics])

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -29,6 +29,7 @@ def run_recipe(
     *,
     log_path: Path,
     analytics: bool = False,
+    nats_url: str | None = None,
 ) -> int:
     """Execute a recipe given steps or a callable and record an event."""
     return cli_actions.run_recipe(
@@ -37,6 +38,7 @@ def run_recipe(
         steps_or_callable,
         log_path=log_path,
         analytics=analytics,
+        nats_url=nats_url,
     )
 
 
@@ -67,6 +69,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             "model_source": "remote" if ai_exec.last_model_remote() else "local",
         },
         duration_key="duration_ms",
+        nats_url=args.nats_url if hasattr(args, "nats_url") else None,
     )
     if args.notify:
         if exit_code == 0:

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -5,6 +5,8 @@ import time
 from pathlib import Path
 from typing import Iterable, Callable, Sequence, Any
 
+from ume import events as ume_events
+
 from scripts.cli_common import execute_steps
 from telemetry import record_event
 
@@ -24,6 +26,7 @@ def run_steps(
     analytics: bool = False,
     payload: dict[str, Any] | None = None,
     duration_key: str = "latency_ms",
+    nats_url: str | None = None,
 ) -> int:
     """Execute ``steps`` and record an analytics event."""
     start = time.time()
@@ -38,6 +41,11 @@ def run_steps(
     if payload:
         data.update(payload)
     record_event_logged(event_name, data, enabled=analytics)
+    if analytics and nats_url:
+        try:
+            ume_events.publish_event(nats_url, event_name, data)
+        except Exception as exc:  # noqa: BLE001
+            logging.debug("Failed to publish NATS event: %s", exc)
     return exit_code
 
 
@@ -48,6 +56,7 @@ def run_recipe(
     *,
     log_path: Path,
     analytics: bool = False,
+    nats_url: str | None = None,
 ) -> int:
     """Execute a recipe and record an analytics event."""
     if callable(steps_or_callable):
@@ -60,6 +69,7 @@ def run_recipe(
         log_path=log_path,
         analytics=analytics,
         payload={"recipe": name, "goal": goal, "step_count": len(steps)},
+        nats_url=nats_url,
     )
 
 __all__ = ["record_event_logged", "run_steps", "run_recipe"]

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -173,12 +173,13 @@ def test_recipe_subcommand(monkeypatch, tmp_path):
     )
     captured = {}
 
-    def fake_run_recipe(name, goal, steps, *, log_path, analytics=False):
+    def fake_run_recipe(name, goal, steps, *, log_path, analytics=False, nats_url=None):
         captured["name"] = name
         captured["goal"] = goal
         captured["steps"] = steps
         captured["log"] = log_path
         captured["analytics"] = analytics
+        captured["nats_url"] = nats_url
         return 0
 
     monkeypatch.setattr(cli_actions, "run_recipe", fake_run_recipe)
@@ -189,6 +190,7 @@ def test_recipe_subcommand(monkeypatch, tmp_path):
     assert captured["goal"] == "goal"
     assert captured["steps"] == ["echo goal"]
     assert captured["log"] == log
+    assert captured["nats_url"] is None
 
 
 def test_recipe_records_event(monkeypatch, tmp_path):
@@ -376,6 +378,30 @@ def test_do_posts_event(monkeypatch, tmp_path):
     assert payload["exit_code"] == 0
     assert payload["step_count"] == 1
     assert "latency_ms" in payload
+
+
+def test_plan_nats_publish(monkeypatch):
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["one"])
+    published = []
+
+    def fake_publish(url, name, payload):
+        published.append((url, name, payload))
+        return True
+
+    monkeypatch.setattr(ai_cli.ume_events, "publish_event", fake_publish)
+    rc = ai_cli.main([
+        "plan",
+        "goal",
+        "--analytics",
+        "--nats-url",
+        "nats://example.com",
+    ])
+
+    assert rc == 0
+    url, name, payload = published[0]
+    assert url == "nats://example.com"
+    assert name == "ai-cli-plan"
+    assert payload["goal"] == "goal"
 
 
 def test_stats_fetches_events(monkeypatch):

--- a/ume/__init__.py
+++ b/ume/__init__.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from . import events
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SOURCES_JSON = REPO_ROOT / "metadata" / "sources.json"
 
@@ -13,4 +15,4 @@ def load_sources(path: Path = SOURCES_JSON) -> list[dict[str, Any]]:
     with path.open(encoding="utf-8") as f:
         return json.load(f)
 
-__all__ = ["load_sources", "SOURCES_JSON"]
+__all__ = ["load_sources", "SOURCES_JSON", "events"]

--- a/ume/events.py
+++ b/ume/events.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from nats.aio.client import Client as NATS
+
+logger = logging.getLogger(__name__)
+
+async def _publish(url: str, subject: str, payload: dict[str, Any]) -> bool:
+    nc = NATS()
+    try:
+        await nc.connect(servers=[url])
+        await nc.publish(subject, json.dumps(payload).encode())
+        await nc.flush()
+        await nc.drain()
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Failed to publish to NATS: %s", exc)
+        return False
+
+
+def publish_event(url: str, name: str, payload: dict[str, Any]) -> bool:
+    """Publish ``payload`` to ``url`` on the ``name`` subject."""
+    return asyncio.run(_publish(url, name, payload))
+
+__all__ = ["publish_event"]


### PR DESCRIPTION
## Summary
- send analytics to NATS when `--nats-url` is supplied
- handle NATS events in `cli_actions.run_steps`
- include new `ume.events` module
- test `--nats-url` flag
- update dependencies for `nats-py`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c9cfdf088326b8b262c6ebc2857e