### PR TITLE
Add NATS telemetry support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ httpx
 fastapi
 uvicorn
 jsonschema
+nats-py

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -7,6 +7,7 @@ from typing import Iterable, Callable, Sequence, Any
 
 from scripts.cli_common import execute_steps
 from telemetry import record_event
+from ume.events import publish_event_sync
 
 
 def record_event_logged(name: str, payload: dict[str, Any], *, enabled: bool = False) -> None:
@@ -14,6 +15,7 @@ def record_event_logged(name: str, payload: dict[str, Any], *, enabled: bool = F
     success = record_event(name, payload, enabled=enabled)
     if not success:
         logging.debug("Failed to record telemetry")
+    publish_event_sync(name, payload, enabled=enabled)
 
 
 def run_steps(

--- a/tests/test_ai_cli_nats.py
+++ b/tests/test_ai_cli_nats.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from scripts import ai_cli
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import ume.events as events
+
+
+class FakeNATS:
+    def __init__(self):
+        self.published = []
+
+    async def connect(self, servers=None):
+        pass
+
+    async def publish(self, subject, data):
+        self.published.append((subject, data))
+
+    async def flush(self):
+        pass
+
+    async def drain(self):
+        pass
+
+
+def test_ai_cli_publishes_event(monkeypatch):
+    monkeypatch.setattr(ai_cli.router, "send_prompt", lambda *a, **k: "ok")
+
+    fake = FakeNATS()
+
+    async def fake_connect(url=events.DEFAULT_NATS_URL):
+        return fake
+
+    monkeypatch.setattr(events, "_connect", fake_connect)
+    rc = ai_cli.main(["send", "msg", "--analytics"])
+    assert rc == 0
+    subject, data = fake.published[0]
+    assert subject == events.DEFAULT_SUBJECT
+    assert b"ai-cli-send" in data

--- a/tests/test_ume_events.py
+++ b/tests/test_ume_events.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import ume.events as events
+
+
+class FakeNATS:
+    def __init__(self):
+        self.published = []
+        self.connected = []
+        self.drained = False
+
+    async def connect(self, servers=None):
+        self.connected.append(servers)
+
+    async def publish(self, subject, data):
+        self.published.append((subject, data))
+
+    async def flush(self):
+        pass
+
+    async def drain(self):
+        self.drained = True
+
+    async def subscribe(self, subject):
+        self.subscribed = subject
+        return FakeSub()
+
+
+class FakeSub:
+    def __init__(self):
+        self.messages = [FakeMsg(b"{\"a\": 1}")]
+
+    async def next_msg(self):
+        if self.messages:
+            return self.messages.pop(0)
+        raise asyncio.CancelledError
+
+    async def unsubscribe(self):
+        self.unsub = True
+
+
+class FakeMsg:
+    def __init__(self, data):
+        self.data = data
+
+
+def test_publish_event_sync(monkeypatch):
+    fake = FakeNATS()
+
+    async def fake_connect(url=events.DEFAULT_NATS_URL):
+        fake.url = url
+        return fake
+
+    monkeypatch.setattr(events, "_connect", fake_connect)
+    success = events.publish_event_sync("test", {"x": 2}, enabled=True)
+    assert success is True
+    assert fake.published == [
+        (events.DEFAULT_SUBJECT, b'{"name": "test", "x": 2}')
+    ]
+    assert fake.drained is True
+
+
+@pytest.mark.asyncio
+async def test_iter_events(monkeypatch):
+    fake = FakeNATS()
+
+    async def fake_connect(url=events.DEFAULT_NATS_URL):
+        return fake
+
+    monkeypatch.setattr(events, "_connect", fake_connect)
+    gen = events.iter_events()
+    event = await gen.__anext__()
+    assert event == {"a": 1}
+    await gen.aclose()

--- a/ume/events.py
+++ b/ume/events.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, AsyncIterator
+
+from nats.aio.client import Client as NATS
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+DEFAULT_SUBJECT = os.environ.get("NATS_SUBJECT", "telemetry.events")
+
+
+async def _connect(url: str = DEFAULT_NATS_URL) -> NATS:
+    nc = NATS()
+    await nc.connect(servers=[url])
+    return nc
+
+
+async def publish_event(
+    name: str,
+    payload: dict[str, Any],
+    *,
+    subject: str = DEFAULT_SUBJECT,
+    url: str = DEFAULT_NATS_URL,
+    nc: NATS | None = None,
+) -> bool:
+    """Publish ``payload`` to NATS and return ``True`` when successful."""
+    data = json.dumps({"name": name, **payload}).encode("utf-8")
+    close = False
+    if nc is None:
+        close = True
+        nc = await _connect(url)
+    try:
+        await nc.publish(subject, data)
+        await nc.flush()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to publish telemetry event: %s", exc)
+        return False
+    finally:
+        if close:
+            await nc.drain()
+    return True
+
+
+async def iter_events(
+    *,
+    subject: str = DEFAULT_SUBJECT,
+    url: str = DEFAULT_NATS_URL,
+    nc: NATS | None = None,
+) -> AsyncIterator[dict[str, Any]]:
+    """Yield events from ``subject`` as dictionaries."""
+    close = False
+    if nc is None:
+        close = True
+        nc = await _connect(url)
+    sub = await nc.subscribe(subject)
+    try:
+        while True:
+            msg = await sub.next_msg()
+            yield json.loads(msg.data.decode("utf-8"))
+    finally:
+        await sub.unsubscribe()
+        if close:
+            await nc.drain()
+
+
+def publish_event_sync(name: str, payload: dict[str, Any], *, enabled: bool = False) -> bool:
+    """Synchronous helper used by CLI tools."""
+    if not enabled:
+        return False
+    return asyncio.run(publish_event(name, payload))
+
+
+__all__ = [
+    "publish_event",
+    "publish_event_sync",
+    "iter_events",
+    "DEFAULT_NATS_URL",
+    "DEFAULT_SUBJECT",
+]


### PR DESCRIPTION
## Summary
- add `ume.events` for publishing and consuming events with nats-py
- publish events from CLI helpers
- verify publishing with unit tests and mock NATS server
- update dependencies for `nats-py`

## Testing
- `ruff check ume/events.py scripts/cli_actions.py tests/test_ume_events.py tests/test_ai_cli_nats.py`
- `mypy --install-types --non-interactive ume/events.py scripts/cli_actions.py tests/test_ume_events.py tests/test_ai_cli_nats.py`
- `pytest tests/test_ume_events.py tests/test_ai_cli_nats.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c9cfd3fc8326a9e709f6176bc363