### PR TITLE
Update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Key directories:
 - `scripts/thm.py` – Terminal Harmony Manager for palette and profile sync (installs as `thm` when using `pip install -e .[cli]`)
 - `scripts/query_sources.py` – search `metadata/sources.json` by name or tag (installs as `query-sources` with the `cli` extra)
 - `research-papers/` – space to store research PDFs, links, and notes
-
-Link the dotfiles into place with GNU Stow:
+ 
+After cloning the repository, run the helper script to link the packages using GNU Stow:
 
 ```bash
 scripts/install_dotfiles.sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -408,11 +408,20 @@ Hyper-V is useful for testing scripts in clean environments.
 3. Mount a local directory to `/home/node/.n8n` to persist workflows between runs.
 4. A simple test flow watches a folder and sends new files to Nextcloud using the built-in nodes.
 
+## API Docker image
+
+Build the container image using the new Dockerfile at the repository root and start the service with Docker Compose:
+
+```bash
+docker compose build api
+docker compose up api
+```
+
 ## API service
 
 The compose file includes a FastAPI backend used by the upcoming dashboard.
 
-1. Start the API service:
+1. After building the image, launch the API service:
    ```bash
    docker compose up api
    ```


### PR DESCRIPTION
## Summary
- clarify running `scripts/install_dotfiles.sh` right after cloning
- document building the API container image with docker compose

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887dc1b8f848326bfeb984341b4f55a