### PR TITLE
Add tests for install_dotfiles.sh

### DIFF
--- a/tests/test_install_dotfiles.py
+++ b/tests/test_install_dotfiles.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+@pytest.mark.skipif(shutil.which("bash") is None or shutil.which("stow") is None, reason="requires bash and stow")
+def test_install_dotfiles(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    result = subprocess.run([
+        "/bin/bash",
+        str(REPO_ROOT / "scripts" / "install_dotfiles.sh"),
+        "--target",
+        str(tmp_path),
+    ], capture_output=True, text=True, env=env, cwd=REPO_ROOT, check=True)
+    assert "LINK: config.toml" in result.stderr
+
+    link = tmp_path / "config.toml"
+    assert link.is_symlink()
+    assert link.resolve().samefile(REPO_ROOT / "dotfiles" / "btm" / "config.toml")
+
+    mtime = link.lstat().st_mtime
+    dry = subprocess.run([
+        "/bin/bash",
+        str(REPO_ROOT / "scripts" / "install_dotfiles.sh"),
+        "--dry-run",
+        "--target",
+        str(tmp_path),
+    ], capture_output=True, text=True, env=env, cwd=REPO_ROOT, check=True)
+
+    assert "simulation mode" in dry.stderr
+    assert link.lstat().st_mtime == mtime


### PR DESCRIPTION
## Summary
- add test covering `install_dotfiles.sh`

## Testing
- `ruff check tests/test_install_dotfiles.py`
- `mypy tests/test_install_dotfiles.py`
- `pytest tests/test_install_dotfiles.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888bfffb4888326a9f49c7c9a50c016