### PR TITLE
Fix metrics env default

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -22,7 +22,6 @@ import requests
 from scripts import cli_actions
 from telemetry import analytics_default
 from ume import events as ume_events
-import asyncio
 import logging
 import time
 
@@ -167,11 +166,8 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 def _cmd_metrics(args: argparse.Namespace) -> int:
     """Show weekly totals of successful ai-do runs."""
-    if args.aggregates_url:
-        url = args.aggregates_url or os.environ.get("NSM_URL")
-        if not url:
-            print("NSM_URL or --aggregates-url required", file=sys.stderr)
-            return 1
+    url = args.aggregates_url or os.environ.get("NSM_URL")
+    if url:
         try:
             resp = requests.get(url, timeout=10)
             resp.raise_for_status()
@@ -182,7 +178,10 @@ def _cmd_metrics(args: argparse.Namespace) -> int:
     else:
         source = args.source or os.environ.get("EVENTS_URL")
         if not source:
-            print("EVENTS_URL or source required", file=sys.stderr)
+            print(
+                "NSM_URL or --aggregates-url or EVENTS_URL or source required",
+                file=sys.stderr,
+            )
             return 1
         try:
             events = list(nsm_stats.iter_events(source))

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -474,6 +474,31 @@ def test_metrics_aggregates_url(monkeypatch):
     assert out.getvalue().splitlines() == ["alice,2023-W01,2"]
 
 
+def test_metrics_env_aggregates_url(monkeypatch):
+    monkeypatch.setenv("NSM_URL", "https://example.com/nsm")
+    called = {}
+
+    def fake_get(url, timeout=None):
+        called["url"] = url
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"alice": {"2023-W01": 2}}
+
+        return Resp()
+
+    monkeypatch.setattr(ai_cli.requests, "get", fake_get)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["metrics"])
+    assert rc == 0
+    assert called["url"] == "https://example.com/nsm"
+    assert out.getvalue().splitlines() == ["alice,2023-W01,2"]
+
+
 def test_metrics_requires_url(monkeypatch):
     monkeypatch.delenv("EVENTS_URL", raising=False)
     monkeypatch.setattr(ai_cli.nsm_stats, "iter_events", lambda src: iter(()))


### PR DESCRIPTION
## Summary
- use `NSM_URL` when `--aggregates-url` isn't provided
- update error message for missing URLs
- test reading `NSM_URL` env var

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest --maxfail=1 -q` *(passes: 16 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6888bffeaa608326b44335aac48bb10c