### PR TITLE
Update telemetry docs with NATS info

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -326,5 +326,8 @@ Pass `--nats-url` to `ai-cli` to override the server per command:
 ai-cli do "Refactor the codebase" --analytics --nats-url "$NATS_URL"
 ```
 
+See [Streaming Events with NATS](telemetry.md#streaming-events-with-nats) in the
+telemetry guide for more details on these variables.
+
 
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -107,3 +107,15 @@ NSM_URL=https://example.com/nsm ai-cli metrics --aggregates-url https://example.
 ```
 
 The output mirrors `nsm_stats.py` and prints `developer,week,count` CSV rows.
+
+## Streaming Events with NATS
+
+Set `NATS_URL` to the address of your NATS server and choose a subject with `NATS_SUBJECT`. Export `EVENTS_ENABLED=true` or pass `--analytics` to send events.
+
+```bash
+export NATS_URL=nats://127.0.0.1:4222
+export NATS_SUBJECT=telemetry.events
+export EVENTS_ENABLED=true
+ai-cli do "task" --analytics --nats-url "$NATS_URL"
+```
+


### PR DESCRIPTION
## Summary
- document how to stream events to NATS
- show `ai-cli do` example for NATS
- refer readers to the telemetry guide from the automation docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888d4bb62a48326919ebc40e457cb34