### PR TITLE
Document backend override env vars

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -74,6 +74,11 @@ When the mode is `auto` the router now sorts available backends by the
 estimated cost of running the prompt and ignores models that cannot fit the
 input within their context window.
 
+Set `LLM_PRIMARY_BACKEND` to define which backend the router tries first. Use
+`LLM_FALLBACK_BACKEND` to specify a secondary option. These variables override
+the `DEFAULT_PRIMARY_BACKEND` and `DEFAULT_FALLBACK_BACKEND` constants in
+`llm/router.py`, which default to `gemini` and `ollama` respectively.
+
 ## FastAPI/Next.js Dashboard
 
 The project ships with a small FastAPI backend that exposes routes for sending


### PR DESCRIPTION
## Summary
- explain `LLM_PRIMARY_BACKEND` and `LLM_FALLBACK_BACKEND` in ai-automation docs
- mention how they override `DEFAULT_PRIMARY_BACKEND` and `DEFAULT_FALLBACK_BACKEND`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688919539b3083269515db3fa6298ad7