### PR TITLE
Document cli_rlhf prototype

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -333,3 +333,20 @@ ai-cli do "Refactor the codebase" --analytics --nats-url "$NATS_URL"
 
 
 
+
+## CLI RLHF Prototype
+
+The repository includes `cli_rlhf.py`, an experimental script for training a language model to produce shell commands. It relies on optional packages that are not installed with the default requirements:
+
+```bash
+pip install torch transformers datasets trl
+```
+
+Run the script directly to launch a short PPO training session:
+
+```bash
+python cli_rlhf.py
+```
+
+Training logs are written to `cli_rlhf_rewards.csv` and the final model weights are saved under the `cli_rlhf_model/` directory.
+Refer to [tests/test_cli_rlhf.py](../tests/test_cli_rlhf.py) for a minimal test exercising the training loop with stubs.

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -22,7 +22,6 @@ import requests
 from scripts import cli_actions
 from telemetry import analytics_default
 from ume import events as ume_events
-import asyncio
 import logging
 import time
 

--- a/tests/test_cli_rlhf.py
+++ b/tests/test_cli_rlhf.py
@@ -1,0 +1,72 @@
+import types
+import contextlib
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("trl")
+
+import cli_rlhf  # noqa: E402 - imported after importorskip
+
+
+def test_cli_rlhf_train_creates_log(monkeypatch, tmp_path):
+    """Training should create a rewards CSV."""
+
+    class DummyHFModel:
+        def __init__(self, model=None, tokenizer=None):
+            self.model = model
+            self.tokenizer = tokenizer
+
+    @contextlib.contextmanager
+    def dummy_context(**_):
+        yield
+
+    class DummySettings:
+        def configure(self, *, lm=None):
+            self.lm = lm
+
+        context = staticmethod(dummy_context)
+
+    class DummyPolicy:
+        def __call__(self, instruction):
+            return types.SimpleNamespace(command="echo SUCCESS")
+
+    dummy_tokenizer = types.SimpleNamespace(
+        pad_token="</s>",
+        eos_token="</s>",
+        encode=lambda text, return_tensors=None: torch.tensor([0]),
+        save_pretrained=lambda path: Path(path).mkdir(exist_ok=True),
+    )
+
+    class DummyTrainer:
+        def __init__(self, *a, **k):
+            self.model = "model"
+            self.tokenizer = dummy_tokenizer
+
+        def step(self, *a, **k):
+            pass
+
+        def save_model(self, directory):
+            Path(directory).mkdir(exist_ok=True)
+
+    monkeypatch.setattr(cli_rlhf, "PPOTrainer", DummyTrainer)
+    monkeypatch.setattr(
+        cli_rlhf, "AutoModelForCausalLMWithValueHead", types.SimpleNamespace(from_pretrained=lambda *a, **k: "model")
+    )
+    monkeypatch.setattr(cli_rlhf, "AutoTokenizer", types.SimpleNamespace(from_pretrained=lambda *a, **k: dummy_tokenizer))
+    monkeypatch.setattr(cli_rlhf, "Dataset", types.SimpleNamespace(from_dict=lambda d: d))
+
+    monkeypatch.setattr(cli_rlhf, "ShellEnvironment", lambda *a, **k: types.SimpleNamespace(execute_command=lambda c: "SUCCESS", get_reward=lambda s: torch.tensor(1.0)))
+
+    monkeypatch.setattr(cli_rlhf.dspy, "HFModel", DummyHFModel)
+    monkeypatch.setattr(cli_rlhf.dspy, "Predict", lambda *a, **k: DummyPolicy())
+    monkeypatch.setattr(cli_rlhf.dspy, "settings", DummySettings())
+
+    monkeypatch.setattr(cli_rlhf, "TRAINING_STEPS", 1)
+    log_path = tmp_path / "rewards.csv"
+    monkeypatch.setattr(cli_rlhf, "LOG_FILE_PATH", log_path)
+
+    cli_rlhf.train_cli_agent()
+
+    assert log_path.exists()


### PR DESCRIPTION
## Summary
- document RLHF command training prototype
- fix duplicate import causing ruff failure
- add minimal test for cli_rlhf training

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889240ef32c8326b4455967921788e3