### PR TITLE
Annotate exec_stream return type

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -129,7 +129,15 @@ async def plan(req: ExecRequest) -> dict[str, list[str]]:
     return {"steps": steps}
 
 @app.get("/api/exec")
-async def exec_stream(goal: str):
+async def exec_stream(goal: str) -> StreamingResponse:
+    """Return an SSE stream of shell command execution.
+
+    The response yields lines prefixed with ``data:`` and terminated by a
+    blank line as required by the Server-Sent Events specification. Commands
+    are emitted as ``data: $ <command>`` followed by their output and a final
+    ``data: (exit <code>)`` line.
+    """
+
     steps = ai_exec.plan(goal)
 
     async def streamer():

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -3,6 +3,7 @@ import pytest
 pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
+from fastapi.responses import StreamingResponse
 import httpx
 import asyncio
 import importlib
@@ -242,3 +243,12 @@ async def test_prompt_concurrent(tmp_path):
     with TestClient(app) as sync_client:
         stats_resp = sync_client.get('/api/stats')
         assert stats_resp.json() == {'queries': 2, 'memory': 2}
+
+
+@pytest.mark.asyncio
+async def test_exec_stream_return_type(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_exec, 'plan', lambda goal: [])
+    load_app(state_path=tmp_path / 'state.json')
+    api = importlib.import_module('api')
+    response = await api.exec_stream('x')
+    assert isinstance(response, StreamingResponse)


### PR DESCRIPTION
## Summary
- annotate `exec_stream` as returning `StreamingResponse`
- document server‑sent event output format in `exec_stream`
- test that `exec_stream` returns `StreamingResponse`

## Testing
- `pytest -q`
- `ruff check api/__init__.py tests/test_api_routes.py`
- `mypy --install-types --non-interactive api/__init__.py tests/test_api_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_688962ff8c188326a03a6b23a7481827