### PR TITLE
Add check for GNU Stow

### DIFF
--- a/scripts/install_dotfiles.sh
+++ b/scripts/install_dotfiles.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure GNU Stow is available before proceeding
+if ! command -v stow >/dev/null 2>&1; then
+    echo "Error: GNU Stow is required but not installed." >&2
+    exit 1
+fi
+
 usage() {
     cat <<'USAGE'
 Usage: $(basename "$0") [--dry-run] [--target DIR]


### PR DESCRIPTION
## Summary
- ensure `scripts/install_dotfiles.sh` fails early when GNU Stow is unavailable

## Testing
- `pytest -q`
- `ruff check .`
- `mypy`
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889757d6ee883268dbb31d7a246c461