### PR TITLE
Add missing stow requirement test

### DIFF
--- a/tests/test_install_dotfiles.py
+++ b/tests/test_install_dotfiles.py
@@ -1,0 +1,26 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+def test_install_dotfiles_requires_stow(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(REPO_ROOT / "scripts" / "install_dotfiles.sh", scripts_dir / "install_dotfiles.sh")
+
+    env = {"PATH": str(tmp_path / "bin")}
+    (tmp_path / "bin").mkdir()
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/install_dotfiles.sh"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "GNU Stow is required" in result.stderr


### PR DESCRIPTION
## Summary
- add regression test for install_dotfiles.sh when `stow` is missing

## Testing
- `ruff check tests/test_install_dotfiles.py`
- `mypy tests/test_install_dotfiles.py`
- `pytest tests/test_install_dotfiles.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688983bde2988326a7272507c9bf4b27