### PR TITLE
Add JetStream helpers for ume events

### DIFF
--- a/tests/test_ume_events.py
+++ b/tests/test_ume_events.py
@@ -15,6 +15,7 @@ class FakeNATS:
         self.published = []
         self.connected = []
         self.drained = False
+        self.js = FakeJS(self)
 
     async def connect(self, servers=None):
         self.connected.append(servers)
@@ -31,6 +32,9 @@ class FakeNATS:
     async def subscribe(self, subject):
         self.subscribed = subject
         return FakeSub()
+
+    def jetstream(self):
+        return self.js
 
 
 class FakeSub:
@@ -49,6 +53,36 @@ class FakeSub:
 class FakeMsg:
     def __init__(self, data):
         self.data = data
+
+    async def ack(self):
+        self.acked = True
+
+
+class FakePullSub:
+    def __init__(self):
+        self.messages = [FakeMsg(b"{\"b\": 2}")]
+
+    async def fetch(self, batch):
+        msgs = self.messages[:batch]
+        self.messages = self.messages[batch:]
+        return msgs
+
+    async def unsubscribe(self):
+        self.unsub = True
+
+
+class FakeJS:
+    def __init__(self, nc):
+        self.nc = nc
+        self.published = []
+
+    async def publish(self, subject, data):
+        self.published.append((subject, data))
+
+    async def pull_subscribe(self, subject, durable="ume_iter"):
+        self.pull_subject = subject
+        self.durable = durable
+        return FakePullSub()
 
 
 def test_publish_event_sync(monkeypatch):
@@ -78,4 +112,33 @@ async def test_iter_events(monkeypatch):
     gen = events.iter_events()
     event = await gen.__anext__()
     assert event == {"a": 1}
+    await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_publish_event_js(monkeypatch):
+    fake = FakeNATS()
+
+    async def fake_connect(url=events.DEFAULT_NATS_URL):
+        return fake
+
+    monkeypatch.setattr(events, "_connect", fake_connect)
+    success = await events.publish_event_js("js", {"y": 3})
+    assert success is True
+    assert fake.js.published == [
+        (events.DEFAULT_SUBJECT, b'{"name": "js", "y": 3}')
+    ]
+
+
+@pytest.mark.asyncio
+async def test_iter_events_js(monkeypatch):
+    fake = FakeNATS()
+
+    async def fake_connect(url=events.DEFAULT_NATS_URL):
+        return fake
+
+    monkeypatch.setattr(events, "_connect", fake_connect)
+    gen = events.iter_events_js()
+    event = await gen.__anext__()
+    assert event == {"b": 2}
     await gen.aclose()

--- a/ume/events.py
+++ b/ume/events.py
@@ -8,6 +8,7 @@ from typing import Any, AsyncIterator
 
 
 from nats.aio.client import Client as NATS
+from nats.js import JetStreamContext
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,59 @@ async def iter_events(
             await nc.drain()
 
 
+async def publish_event_js(
+    name: str,
+    payload: dict[str, Any],
+    *,
+    subject: str = DEFAULT_SUBJECT,
+    url: str = DEFAULT_NATS_URL,
+    nc: NATS | None = None,
+) -> bool:
+    """Publish ``payload`` to JetStream and return ``True`` when successful."""
+    data = json.dumps({"name": name, **payload}).encode("utf-8")
+    close = False
+    if nc is None:
+        close = True
+        nc = await _connect(url)
+    js: JetStreamContext = nc.jetstream()
+    try:
+        await js.publish(subject, data)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to publish telemetry event to JetStream: %s", exc)
+        return False
+    finally:
+        if close:
+            await nc.drain()
+    return True
+
+
+async def iter_events_js(
+    *,
+    subject: str = DEFAULT_SUBJECT,
+    url: str = DEFAULT_NATS_URL,
+    nc: NATS | None = None,
+    durable: str = "ume_iter",
+    batch: int = 1,
+) -> AsyncIterator[dict[str, Any]]:
+    """Yield events from JetStream ``subject`` as dictionaries."""
+    close = False
+    if nc is None:
+        close = True
+        nc = await _connect(url)
+    js: JetStreamContext = nc.jetstream()
+    sub = await js.pull_subscribe(subject, durable=durable)
+    try:
+        while True:
+            msgs = await sub.fetch(batch)
+            for msg in msgs:
+                yield json.loads(msg.data.decode("utf-8"))
+                await msg.ack()
+    finally:
+        await sub.unsubscribe()
+        if close:
+            await nc.drain()
+
+
 def publish_event_sync(name: str, payload: dict[str, Any], *, enabled: bool = False) -> bool:
     """Synchronous helper used by CLI tools."""
     if not enabled:
@@ -83,7 +137,9 @@ def publish_event_sync(name: str, payload: dict[str, Any], *, enabled: bool = Fa
 __all__ = [
     "publish_event",
     "publish_event_sync",
+    "publish_event_js",
     "iter_events",
+    "iter_events_js",
     "DEFAULT_NATS_URL",
     "DEFAULT_SUBJECT",
 ]


### PR DESCRIPTION
## Summary
- support JetStream in ume.events with `publish_event_js` and `iter_events_js`
- test the new helpers with a fake JetStream implementation

## Testing
- `ruff check ume/events.py tests/test_ume_events.py`
- `pytest -q tests/test_ume_events.py`

------
https://chatgpt.com/codex/tasks/task_e_688ac5b43bc88326825c72c3f6a397da