### PR TITLE
Extend update_registry test

### DIFF
--- a/tests/test_update_registry.py
+++ b/tests/test_update_registry.py
@@ -13,3 +13,15 @@ def test_update_registry_check_recipes(tmp_path, monkeypatch):
     rc = update_registry.main(["--check"])
     assert rc == 1
     assert json.loads(reg.read_text(encoding="utf-8")) == data
+
+
+def test_update_registry_rewrites_outdated_file(tmp_path, monkeypatch):
+    reg = tmp_path / "plugin-registry.json"
+    reg.write_text(json.dumps({"plugins": {}, "recipes": {}}), encoding="utf-8")
+    monkeypatch.setattr(update_registry, "REGISTRY_PATH", reg)
+    orig_load = update_registry.load_registry
+    monkeypatch.setattr(update_registry, "load_registry", lambda path=reg: orig_load(path))
+    rc = update_registry.main([])
+    assert rc == 0
+    expected = {"plugins": plugins.PLUGIN_REGISTRY, "recipes": plugins.RECIPE_REGISTRY}
+    assert json.loads(reg.read_text(encoding="utf-8")) == expected


### PR DESCRIPTION
## Summary
- extend test suite to verify update_registry rewrites outdated files

## Testing
- `ruff check tests/test_update_registry.py`
- `mypy --install-types --non-interactive tests/test_update_registry.py`
- `pytest tests/test_update_registry.py::test_update_registry_rewrites_outdated_file -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac98dd06c8326bfd93339f29c1a9f