### PR TITLE
Add publish URL missing test

### DIFF
--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -331,3 +331,22 @@ def test_recipe_publish(monkeypatch):
     assert "https://example.com/simple" in called["cmd"]
     assert "package.whl" in called["cmd"]
 
+
+def test_recipe_publish_without_url(monkeypatch, capsys):
+    called = {}
+
+    def fake_run(cmd, *a, **k):
+        called["cmd"] = cmd
+        class Res:
+            returncode = 0
+        return Res()
+
+    monkeypatch.setattr(plugins.subprocess, "run", fake_run)
+    monkeypatch.delenv("PLUGIN_REGISTRY_UPLOAD_URL", raising=False)
+
+    rc = plugins.main(["recipes", "publish", "package.whl"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "Upload URL required" in captured.err
+    assert "cmd" not in called
+


### PR DESCRIPTION
## Summary
- test recipe publishing without --url fails

## Testing
- `ruff check tests/test_plugins_script.py`
- `mypy --install-types --non-interactive`
- `pytest tests/test_plugins_script.py::test_recipe_publish_without_url -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac98d30a483268d158ee41ecdfe73