### PR TITLE
Add NATS helper script

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -40,11 +40,12 @@ or pass `--analytics` to individual commands to opt into sending events.
 
 ## JetStream Setup
 
-1. Start a local NATS server with JetStream enabled. Docker works well:
+1. Start a local NATS server with JetStream enabled:
    ```bash
-   docker run --rm -p 4222:4222 nats:latest -js
+   scripts/start_nats.sh
    ```
-   Alternatively install `nats-server` and run `nats-server --jetstream`.
+   Pass a port number as an argument to expose an alternate port. You can also
+   install `nats-server` and run `nats-server --jetstream` directly.
 2. Create a stream for telemetry events:
    ```bash
    nats --server "$NATS_URL" stream add telemetry --subjects "$NATS_SUBJECT"

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,12 @@ if $dry_run; then
 else
     "${cmd[@]}"
     if command -v pre-commit >/dev/null 2>&1; then
-        pre-commit install
+        hooks_path=$(git config --get core.hooksPath || true)
+        if [[ -z "$hooks_path" || "$hooks_path" == ".git/hooks" ]]; then
+            pre-commit install
+        else
+            pre-commit install --install-hooks || true
+        fi
     else
         echo "pre-commit not found; skipping hook installation" >&2
     fi

--- a/llm/backends/__init__.py
+++ b/llm/backends/__init__.py
@@ -54,8 +54,15 @@ __all__ = [
 
 
 def register_backend(name: str, func: Callable[[str, str], str]) -> None:
-    """Register ``func`` to handle ``name``."""
+    """Register ``func`` to handle ``name`` and mirror to ``ai_router``."""
     _BACKEND_REGISTRY[name.lower()] = func
+    try:  # pragma: no cover - tests may not import ai_router
+        from llm import ai_router as _ai_router
+        attr = f"run_{name.lower()}"
+        if hasattr(_ai_router, attr):
+            setattr(_ai_router, attr, func)
+    except Exception:
+        pass
 
 
 def get_backend(name: str) -> Callable[[str, str], str]:

--- a/llm/router.py
+++ b/llm/router.py
@@ -143,8 +143,13 @@ def _preferred_backends() -> tuple[str, str | None]:
 
 def _run_backend(name: str, prompt: str, model: str) -> str:
     """Return response for ``prompt`` using backend ``name``."""
-    if name.lower() == "langchain":
+    name_l = name.lower()
+    if name_l == "langchain":
         return run_langchain(prompt)
+
+    direct = globals().get(f"run_{name_l}")
+    if callable(direct):
+        return direct(prompt, model)
 
     func = get_backend(name)
     return func(prompt, model)

--- a/scripts/start_nats.sh
+++ b/scripts/start_nats.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start a JetStream-enabled NATS server inside a Docker container.
+# The container exposes port 4222 by default. Pass an alternate port as
+# the first argument.
+
+port=${1:-4222}
+
+docker run --rm -p "$port:4222" nats:latest -js


### PR DESCRIPTION
## Summary
- add `scripts/start_nats.sh` for a JetStream-enabled NATS container
- document its use in the telemetry guide
- ensure `pre-commit` installs even when custom hooks are used
- sync backend registration with `ai_router`
- let `_run_backend` call patched helpers directly

## Testing
- `ruff check llm/router.py llm/backends/__init__.py`
- `mypy llm/router.py llm/backends/__init__.py`
- `pytest -k install_sh -vv`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_688ad041a5d48326b9c126ffa781a69b