### PR TITLE
Remove self-modifying code in cli_rlhf

### DIFF
--- a/cli_rlhf.py
+++ b/cli_rlhf.py
@@ -176,12 +176,4 @@ def train_cli_agent() -> None:
 
 
 if __name__ == "__main__":
-    with open("cli_rlhf.py", "a", encoding="utf-8") as f:
-        f.write("\n# SUCCESS\n")
-
     train_cli_agent()
-
-    with open("cli_rlhf.py", "r", encoding="utf-8") as f:
-        lines = f.readlines()
-    with open("cli_rlhf.py", "w", encoding="utf-8") as f:
-        f.writelines(lines[:-2])


### PR DESCRIPTION
## Summary
- clean up `cli_rlhf.py` by removing the section that appends to and truncates itself

## Testing
- `ruff check .`
- `mypy cli_rlhf.py tests/test_cli_rlhf.py`
- `pytest tests/test_cli_rlhf.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8465caa483269708744190354e43