### PR TITLE
Add registry pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,10 @@ repos:
     hooks:
       - id: mypy
         args: [--install-types, --non-interactive]
+  - repo: local
+    hooks:
+      - id: update-plugin-registry
+        name: Check plugin registry
+        entry: python -m scripts.update_registry --check
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -237,12 +237,14 @@ pytest -n auto || pytest
 
 ## Contributing
 
-Run `ruff` and `mypy` before committing to ensure the code is lint and type
-error free. You can run them directly or via `pre-commit`:
+Run `ruff`, `mypy`, and the plugin registry check before committing to ensure
+the code is lint and type error free and that `plugin-registry.json` is up to
+date. You can run them directly or via `pre-commit`:
 
 ```bash
 ruff check .
 mypy --install-types --non-interactive
+python scripts/update_registry.py --check
 pre-commit run --files <changed files>
 ```
 


### PR DESCRIPTION
## Summary
- ensure plugin registry is validated on commit
- document the registry check in the contributing guide

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`

------
https://chatgpt.com/codex/tasks/task_e_688b8b7832cc832684c705cf781de5f7