### PR TITLE
Add unit tests for ume events JetStream helpers

### DIFF
--- a/tests/test_ume_events.py
+++ b/tests/test_ume_events.py
@@ -142,3 +142,64 @@ async def test_iter_events_js(monkeypatch):
     event = await gen.__anext__()
     assert event == {"b": 2}
     await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_publish_event_js_existing_nc(monkeypatch):
+    fake = FakeNATS()
+
+    async def should_not_call(url=events.DEFAULT_NATS_URL):
+        raise AssertionError("should not connect")
+
+    monkeypatch.setattr(events, "_connect", should_not_call)
+    success = await events.publish_event_js("name", {"z": 9}, nc=fake)
+    assert success is True
+    assert fake.js.published == [
+        (events.DEFAULT_SUBJECT, b'{"name": "name", "z": 9}')
+    ]
+    assert fake.drained is False
+
+
+class FakePullSubBatch(FakePullSub):
+    def __init__(self):
+        self.msg1 = FakeMsg(b"{\"b\": 2}")
+        self.msg2 = FakeMsg(b"{\"c\": 3}")
+        self.fetch_batches = []
+        self.messages = [self.msg1, self.msg2]
+
+    async def fetch(self, batch):
+        self.fetch_batches.append(batch)
+        msgs = self.messages[:batch]
+        self.messages = self.messages[batch:]
+        return msgs
+
+class FakeJSTrack(FakeJS):
+    async def pull_subscribe(self, subject, durable="ume_iter"):
+        self.pull_subject = subject
+        self.durable = durable
+        self.sub = FakePullSubBatch()
+        return self.sub
+
+
+@pytest.mark.asyncio
+async def test_iter_events_js_ack(monkeypatch):
+    fake = FakeNATS()
+    fake.js = FakeJSTrack(fake)
+
+    async def fake_connect(url=events.DEFAULT_NATS_URL):
+        return fake
+
+    monkeypatch.setattr(events, "_connect", fake_connect)
+    gen = events.iter_events_js(durable="dur", batch=2)
+    event1 = await gen.__anext__()
+    event2 = await gen.__anext__()
+    assert event1 == {"b": 2}
+    assert event2 == {"c": 3}
+    await gen.asend(None)
+    await gen.aclose()
+    assert fake.js.sub.msg1.acked is True
+    assert fake.js.sub.msg2.acked is True
+    assert fake.js.sub.unsub is True
+    assert fake.drained is True
+    assert fake.js.durable == "dur"
+    assert fake.js.sub.fetch_batches == [2]


### PR DESCRIPTION
## Summary
- add new tests for `publish_event_js` and `iter_events_js` using mocked NATS JetStream

## Testing
- `ruff check .`
- `pytest tests/test_ume_events.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688c066c954c8326be1b54e6e57a3ccd