### PR TITLE
Add JetStream flag to ai-cli do/recipe

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -87,6 +87,7 @@ def _cmd_do(args: argparse.Namespace) -> int:
         analytics=args.analytics,
         payload={"goal": args.goal, "step_count": len(steps)},
         nats_url=args.nats_url,
+        jetstream=getattr(args, "jetstream", False),
     )
 
 
@@ -105,6 +106,7 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
         log_path=args.log,
         analytics=args.analytics,
         nats_url=args.nats_url,
+        jetstream=getattr(args, "jetstream", False),
     )
     end = time.time()
     if exit_code == 0:
@@ -226,6 +228,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=REPO_ROOT / "ai_do.log",
         help="Log file path (default: %(default)s)",
     )
+    do.add_argument(
+        "--jetstream",
+        action="store_true",
+        help="Publish events via JetStream",
+    )
     do.set_defaults(func=_cmd_do)
 
     recipe = sub.add_parser("recipe", help="Execute a named recipe", parents=[analytics])
@@ -236,6 +243,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=REPO_ROOT / "ai_do.log",
         help="Log file path (default: %(default)s)",
+    )
+    recipe.add_argument(
+        "--jetstream",
+        action="store_true",
+        help="Publish events via JetStream",
     )
     recipe.set_defaults(func=_cmd_recipe)
 

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -31,6 +31,7 @@ def run_steps(
     payload: dict[str, Any] | None = None,
     duration_key: str = "latency_ms",
     nats_url: str | None = None,
+    jetstream: bool = False,
 ) -> int:
     """Execute ``steps`` and record an analytics event."""
     start = time.time()
@@ -47,7 +48,10 @@ def run_steps(
     record_event_logged(event_name, data, enabled=analytics)
     if analytics and nats_url:
         try:
-            asyncio.run(ume_events.publish_event(nats_url, event_name, data))  # type: ignore[misc,arg-type]
+            if jetstream:
+                asyncio.run(ume_events.publish_event_js(nats_url, event_name, data))  # type: ignore[misc,arg-type]
+            else:
+                asyncio.run(ume_events.publish_event(nats_url, event_name, data))  # type: ignore[misc,arg-type]
 
         except Exception as exc:  # noqa: BLE001
             logging.debug("Failed to publish NATS event: %s", exc)
@@ -62,6 +66,7 @@ def run_recipe(
     log_path: Path,
     analytics: bool = False,
     nats_url: str | None = None,
+    jetstream: bool = False,
 ) -> int:
     """Execute a recipe and record an analytics event."""
     if callable(steps_or_callable):
@@ -75,6 +80,7 @@ def run_recipe(
         analytics=analytics,
         payload={"recipe": name, "goal": goal, "step_count": len(steps)},
         nats_url=nats_url,
+        jetstream=jetstream,
     )
 
 __all__ = ["record_event_logged", "run_steps", "run_recipe"]

--- a/tests/test_ai_cli_nats_events.py
+++ b/tests/test_ai_cli_nats_events.py
@@ -3,6 +3,7 @@ import subprocess
 import time
 
 from scripts import ai_cli
+from scripts import cli_actions
 import shutil
 import pytest
 
@@ -60,3 +61,42 @@ def test_ai_cli_plan_nats_events(monkeypatch):
     assert name_arg == "ai-cli-plan"
     assert payload_arg["goal"] == "echo"
     assert payload_arg["step_count"] == 1
+
+
+def test_ai_cli_do_jetstream_events(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr(cli_actions, "execute_steps", lambda *a, **k: 0)
+
+    captured = []
+
+    async def fake_publish_event_js(url_arg, name_arg, payload_arg):
+        captured.append((url_arg, name_arg, payload_arg))
+        return True
+
+    class FakeNATS:
+        async def connect(self, servers=None):
+            pass
+
+    async def fake_connect(url=events.DEFAULT_NATS_URL):
+        return FakeNATS()
+
+    monkeypatch.setattr(events, "publish_event_js", fake_publish_event_js)
+    monkeypatch.setattr(events, "_connect", fake_connect)
+
+    log = tmp_path / "log.txt"
+    rc = ai_cli.main([
+        "do",
+        "goal",
+        "--analytics",
+        "--nats-url",
+        "nats://example.com:4222",
+        "--jetstream",
+        "--log",
+        str(log),
+    ])
+
+    assert rc == 0
+    url_arg, name_arg, payload_arg = captured[0]
+    assert url_arg == "nats://example.com:4222"
+    assert name_arg == "ai-cli-do"
+    assert payload_arg["goal"] == "goal"


### PR DESCRIPTION
## Summary
- support publishing JetStream events in `run_steps` and `run_recipe`
- expose `--jetstream` for `do` and `recipe` subcommands
- test JetStream publishing from the `do` command

## Testing
- `ruff check scripts/cli_actions.py scripts/ai_cli.py tests/test_ai_cli_nats_events.py`
- `mypy --config-file mypy.ini scripts/cli_actions.py scripts/ai_cli.py tests/test_ai_cli_nats_events.py`
- `pytest tests/test_ai_cli_nats_events.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688c066b845883269d25ed5ca9820e0b