### PR TITLE
Add smoke tests to Tauri build

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Build application
         working-directory: src-tauri
         run: cargo tauri build
+      - name: Run smoke tests
+        working-directory: src-tauri
+        run: cargo test --release | tee tauri-test.log
+      - name: Upload test log
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-test-log
+          path: src-tauri/tauri-test.log
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ test = [
     "uvicorn",
     "httpx",
     "jsonschema>=4",
+    "trio",
 ]
 cli = ["tomli_w", "jsonschema>=4"]
 lmql = ["lmql"]

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -173,7 +173,16 @@ def test_recipe_subcommand(monkeypatch, tmp_path):
     )
     captured = {}
 
-    def fake_run_recipe(name, goal, steps, *, log_path, analytics=False, nats_url=None):
+    def fake_run_recipe(
+        name,
+        goal,
+        steps,
+        *,
+        log_path,
+        analytics=False,
+        nats_url=None,
+        jetstream=False,
+    ):
         captured["name"] = name
         captured["goal"] = goal
         captured["steps"] = steps


### PR DESCRIPTION
## Summary
- extend `tauri.yml` to execute smoke tests after building
- fix `test_recipe_subcommand` argument signature
- include `trio` in test dependencies

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `PYTHONPATH=. python scripts/update_registry.py --check`
- `pytest tests/test_ai_cli.py::test_recipe_subcommand -q`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_688c10edd34c832698db2d6b68273481