### PR TITLE
Handle invalid API state JSON

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -30,7 +31,11 @@ async def _load_state() -> dict[str, Any]:
     async with STATE_LOCK:
         if STATE_PATH.exists():
             with STATE_PATH.open("r", encoding="utf-8") as f:
-                return json.load(f)
+                try:
+                    return json.load(f)
+                except json.JSONDecodeError:
+                    logging.exception("Failed to decode state JSON")
+                    return {"queries": 0, "nodes": [], "edges": []}
         return {"queries": 0, "nodes": [], "edges": []}
 
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -39,6 +39,16 @@ def test_health(tmp_path):
         assert resp.json() == {'status': 'ok'}
 
 
+def test_health_bad_state(tmp_path):
+    state_path = tmp_path / 'state.json'
+    app = load_app(state_path=state_path)
+    # load_app removes the file; write invalid JSON afterward
+    state_path.write_text('{')
+    with TestClient(app) as client:
+        resp = client.get('/api/health')
+        assert resp.status_code == 200
+
+
 def test_stats_local(tmp_path):
     app = load_app(state_path=tmp_path / 'state.json')
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary
- make `_load_state` resilient to malformed JSON
- test that `/api/health` works when state file is corrupted

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest tests/test_api_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc2ff6a788326b9b3a227d803acfe