### PR TITLE
Fix log dir creation and add test

### DIFF
--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -35,6 +35,7 @@ def run_steps(
 ) -> int:
     """Execute ``steps`` and record an analytics event."""
     start = time.time()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
     exit_code = execute_steps(steps, log_path=log_path)
     end = time.time()
     data = {

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -62,6 +62,24 @@ def test_do_subcommand(monkeypatch, tmp_path):
     assert log.exists()
 
 
+def test_do_creates_log_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    class Result:
+        def __init__(self):
+            self.stdout = ""
+            self.stderr = ""
+            self.returncode = 0
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: Result())
+
+    log = tmp_path / "logs" / "log.txt"
+    rc = ai_cli.main(["do", "goal", "--log", str(log)])
+    assert rc == 0
+    assert log.exists()
+
+
 def test_send_records_event(monkeypatch):
     monkeypatch.setattr(ai_cli.router, "send_prompt", lambda *a, **k: "ok")
     recorded = []


### PR DESCRIPTION
## Summary
- ensure parent directories exist before executing CLI steps
- test that ai-do makes new log subdirectories

## Testing
- `ruff check scripts/cli_actions.py tests/test_ai_cli.py`
- `mypy scripts/cli_actions.py tests/test_ai_cli.py --install-types --non-interactive`
- `pytest tests/test_ai_cli.py::test_do_creates_log_dir -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc2ff425c8326acd1820de0bc3518