### PR TITLE
Add Supabase troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ following fields:
 - `start_ts` and `end_ts` – Unix timestamps capturing the plan duration
 - `latency_ms` – computed from the timestamps
 
+- See [docs/telemetry.md#troubleshooting](docs/telemetry.md#troubleshooting) for help resolving common Supabase connection issues.
+
 See [docs/telemetry.md](docs/telemetry.md) for a quick Supabase setup and
 configuration of `EVENTS_URL` and `EVENTS_TOKEN`.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -128,3 +128,11 @@ NSM_URL=https://example.com/nsm ai-cli metrics --aggregates-url https://example.
 ```
 
 The output mirrors `nsm_stats.py` and prints `developer,week,count` CSV rows.
+
+## Troubleshooting
+
+Connection problems with Supabase usually fall into a few common categories:
+
+- **401 Unauthorized** – verify that `EVENTS_TOKEN` contains a valid anon or service key with permission to insert rows.
+- **Connection refused** – ensure your Supabase instance is running and that `EVENTS_URL` points to the correct host and port.
+- **SSL certificate errors** – when using a self-hosted instance with a self-signed certificate, use `http://` during local testing or configure your certificate authority.


### PR DESCRIPTION
## Summary
- document common Supabase connection failures in `docs/telemetry.md`
- reference the troubleshooting section from the Telemetry notes in `README.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688cd3a1f4008326949acd0445d68c94