### PR TITLE
Fix Windows case handling in data path helper

### DIFF
--- a/llm/universal_dspy_wrapper_v2.py
+++ b/llm/universal_dspy_wrapper_v2.py
@@ -27,8 +27,12 @@ except ImportError as exc:  # pragma: no cover - import guard
 
 _REPO_ROOT = get_repo_root()
 
+_ROOT_POSIX = _REPO_ROOT.as_posix()
+if os.name == "nt":
+    _ROOT_POSIX = _ROOT_POSIX.casefold()
+
 _PATH_REGEX = re.compile(
-    rf"^(?P<root>{re.escape(_REPO_ROOT.as_posix())})/.+(?P<data>[^/]+\.(?:ya?ml|json))$",
+    rf"^(?P<root>{re.escape(_ROOT_POSIX)})/.+(?P<data>[^/]+\.(?:ya?ml|json))$",
     re.IGNORECASE if os.name == "nt" else 0,
 )
 
@@ -36,6 +40,8 @@ _PATH_REGEX = re.compile(
 def is_repo_data_path(path: str | Path) -> bool:
     """Return True if ``path`` is within the repo and ends with an allowed extension."""
     normalised = Path(path).as_posix().replace("\\", "/")
+    if os.name == "nt":
+        normalised = normalised.casefold()
     return bool(_PATH_REGEX.match(normalised))
 
 

--- a/tests/test_universal_dspy_wrapper_v2.py
+++ b/tests/test_universal_dspy_wrapper_v2.py
@@ -49,7 +49,7 @@ def test_is_repo_data_path_windows_and_posix():
 
 def test_is_repo_data_path_mixed_case(monkeypatch):
     """Paths should be case-insensitive on Windows."""
-    mixed = Path(f"{_REPO_ROOT.as_posix().upper()}/FiLe.JsOn")
+    mixed = Path(f"{_REPO_ROOT.as_posix().swapcase()}/FiLe.JsOn")
 
     if os.name == "nt":
         assert is_repo_data_path(mixed)


### PR DESCRIPTION
## Summary
- normalize repo root and target paths using `casefold` on Windows
- compile regex with normalized repo root
- tweak mixed-case path test to use swapcase

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive`
- `pytest tests/test_universal_dspy_wrapper_v2.py::test_is_repo_data_path_mixed_case -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0c511614832684e7a04ffebcb5da