### PR TITLE
Add async exec stream test

### DIFF
--- a/tests/test_api_exec_stream.py
+++ b/tests/test_api_exec_stream.py
@@ -1,0 +1,22 @@
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+import httpx
+from api import app
+from scripts import ai_exec
+
+
+@pytest.mark.asyncio
+async def test_exec_stream_async_client(monkeypatch):
+    monkeypatch.setattr(ai_exec, "plan", lambda goal: ["echo hi"])
+    async with httpx.AsyncClient(
+        base_url="http://test",
+        transport=httpx.ASGITransport(app=app),
+    ) as client:
+        async with client.stream("GET", "/api/exec", params={"goal": "echo hi"}) as resp:
+            lines = [line async for line in resp.aiter_lines() if line]
+
+    assert "data: $ echo hi" in lines
+    assert "data: (exit 0)" in lines


### PR DESCRIPTION
## Summary
- add new async test for the `/api/exec` endpoint

## Testing
- `ruff check tests/test_api_exec_stream.py`
- `mypy llm scripts`
- `python -m scripts.update_registry --check`
- `pytest tests/test_api_exec_stream.py::test_exec_stream_async_client -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1b11c47483269814f389b61fb924