### PR TITLE
Handle missing plugin registry file

### DIFF
--- a/scripts/update_registry.py
+++ b/scripts/update_registry.py
@@ -19,9 +19,15 @@ SCHEMA_PATH = REPO_ROOT / "plugin-registry.schema.json"
 
 
 def load_registry(path: Path = REGISTRY_PATH) -> dict[str, object]:
-    """Return registry data from ``path``."""
-    with path.open(encoding="utf-8") as fh:
-        return json.load(fh)
+    """Return registry data from ``path``.
+
+    When ``path`` does not exist, return an empty registry dictionary.
+    """
+    try:
+        with path.open(encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {"plugins": {}, "recipes": {}}
 
 
 def load_schema(path: Path = SCHEMA_PATH) -> dict[str, object]:
@@ -64,7 +70,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         data = load_registry()
     except json.JSONDecodeError as exc:
-        print(f"Failed to parse {REGISTRY_PATH}: {exc}", file=sys.stderr)
+        print(
+            f"Failed to parse JSON from {REGISTRY_PATH}: {exc}",
+            file=sys.stderr,
+        )
         return 1
 
     schema = load_schema()

--- a/tests/test_update_registry.py
+++ b/tests/test_update_registry.py
@@ -25,3 +25,27 @@ def test_update_registry_rewrites_outdated_file(tmp_path, monkeypatch):
     assert rc == 0
     expected = {"plugins": plugins.PLUGIN_REGISTRY, "recipes": plugins.RECIPE_REGISTRY}
     assert json.loads(reg.read_text(encoding="utf-8")) == expected
+
+
+def test_update_registry_creates_missing_file(tmp_path, monkeypatch):
+    reg = tmp_path / "plugin-registry.json"
+    monkeypatch.setattr(update_registry, "REGISTRY_PATH", reg)
+    orig_load = update_registry.load_registry
+    monkeypatch.setattr(update_registry, "load_registry", lambda path=reg: orig_load(path))
+    rc = update_registry.main([])
+    assert rc == 0
+    expected = {"plugins": plugins.PLUGIN_REGISTRY, "recipes": plugins.RECIPE_REGISTRY}
+    assert json.loads(reg.read_text(encoding="utf-8")) == expected
+
+
+def test_update_registry_malformed_json(tmp_path, monkeypatch, capsys):
+    reg = tmp_path / "plugin-registry.json"
+    reg.write_text("{ bad json }", encoding="utf-8")
+    monkeypatch.setattr(update_registry, "REGISTRY_PATH", reg)
+    orig_load = update_registry.load_registry
+    monkeypatch.setattr(update_registry, "load_registry", lambda path=reg: orig_load(path))
+    rc = update_registry.main([])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "Failed to parse JSON" in captured.err
+    assert reg.read_text(encoding="utf-8") == "{ bad json }"


### PR DESCRIPTION
## Summary
- tolerate missing plugin-registry.json
- improve JSON parse error message
- test plugin registry creation and malformed file cases

## Testing
- `ruff check .`
- `pytest tests/test_update_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2b3fbb188326aa6632e0bdc2be0f