### PR TITLE
Add context switching to AI CLI

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -164,8 +164,19 @@ def _model_info(model: str) -> dict[str, Any]:
     return cast(dict[str, Any], cfg.get("models", {}).get(model, {}))
 
 
-def send_prompt(prompt: str, *, local: bool = False, model: str = DEFAULT_MODEL) -> str:
-    """Send ``prompt`` using the configured backends."""
+def send_prompt(
+    prompt: str,
+    *,
+    local: bool = False,
+    model: str = DEFAULT_MODEL,
+    context: str | None = None,
+) -> str:
+    """Send ``prompt`` using the configured backends.
+
+    The optional ``context`` parameter can be used by higher level callers to
+    route requests differently. It is currently unused by the router itself but
+    accepted for compatibility with CLI features.
+    """
     primary, fallback = _preferred_backends()
     order: List[str] = []
 

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -54,10 +54,21 @@ def _cmd_login(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_switch_context(args: argparse.Namespace) -> int:
+    data = {**_session, "context": args.context}
+    SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SESSION_FILE.write_text(json.dumps(data))
+    _session.update(data)
+    _publish_event(args, "ai-cli-switch-context", {"context": args.context, "exit_code": 0})
+    return 0
+
+
 def _publish_event(args: argparse.Namespace, name: str, payload: dict[str, Any]) -> None:
     """Record analytics and publish to NATS when configured."""
     if "user_id" not in payload and _session.get("user_id"):
         payload = {"user_id": _session["user_id"], **payload}
+    if "context" not in payload and _session.get("context"):
+        payload = {"context": _session["context"], **payload}
     cli_actions.record_event_logged(name, payload, enabled=args.analytics)
     if args.analytics and getattr(args, "nats_url", None):
         try:
@@ -70,7 +81,10 @@ def _publish_event(args: argparse.Namespace, name: str, payload: dict[str, Any])
 def _cmd_send(args: argparse.Namespace) -> int:
     prompt = read_prompt(args.prompt)
     try:
-        output = router.send_prompt(prompt, local=args.local, model=args.model)
+        kwargs = {"local": args.local, "model": args.model}
+        if _session.get("context"):
+            kwargs["context"] = _session["context"]
+        output = router.send_prompt(prompt, **kwargs)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)
         _publish_event(args, "ai-cli-send", {"exit_code": 1})
@@ -237,6 +251,11 @@ def build_parser() -> argparse.ArgumentParser:
     login = sub.add_parser("login", help="Authenticate user", parents=[analytics])
     login.add_argument("user_id", help="Identifier to persist for the session")
     login.set_defaults(func=_cmd_login)
+    switch_context = sub.add_parser(
+        "switch-context", help="Switch active context", parents=[analytics]
+    )
+    switch_context.add_argument("context", help="Context identifier")
+    switch_context.set_defaults(func=_cmd_switch_context)
     send = sub.add_parser("send", help="Send a prompt to the LLM backend", parents=[analytics])
     send.add_argument("prompt", help="Prompt or '-' to read from STDIN")
     send.add_argument("--local", action="store_true", help="Force use of fallback backend")
@@ -335,6 +354,11 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 def login_main(argv: Optional[List[str]] = None) -> int:
     argv = ["login", *(argv or [])]
+    return main(argv)
+
+
+def switch_context_main(argv: Optional[List[str]] = None) -> int:
+    argv = ["switch-context", *(argv or [])]
     return main(argv)
 
 

--- a/tests/test_ai_cli_context.py
+++ b/tests/test_ai_cli_context.py
@@ -1,0 +1,41 @@
+import json
+import io
+import contextlib
+import pytest
+
+pytest.importorskip("requests")
+
+from scripts import ai_cli
+
+
+def test_context_switch_affects_send(monkeypatch, tmp_path):
+    session_file = tmp_path / ".config" / "d0tTino" / "cli_session.json"
+    monkeypatch.setattr(ai_cli, "SESSION_FILE", session_file)
+    ai_cli._session.clear()
+
+    sent_contexts = []
+
+    def fake_send(prompt, *, local=False, model=ai_cli.router.DEFAULT_MODEL, context=None):
+        sent_contexts.append(context)
+        return "ok"
+
+    monkeypatch.setattr(ai_cli.router, "send_prompt", fake_send)
+
+    try:
+        assert ai_cli.main(["switch-context", "personal"]) == 0
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            assert ai_cli.main(["send", "msg1"]) == 0
+        assert out.getvalue().strip() == "ok"
+
+        assert ai_cli.main(["switch-context", "group"]) == 0
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            assert ai_cli.main(["send", "msg2"]) == 0
+        assert out.getvalue().strip() == "ok"
+
+        assert sent_contexts == ["personal", "group"]
+        data = json.loads(session_file.read_text())
+        assert data["context"] == "group"
+    finally:
+        ai_cli._session.clear()


### PR DESCRIPTION
## Summary
- support active context in the AI CLI with `switch-context` command
- pass session context to routing and telemetry
- cover context switching behaviour with tests

## Testing
- `ruff check scripts/ai_cli.py llm/router.py tests/test_ai_cli_context.py`
- `pytest tests/test_ai_cli_context.py tests/test_ai_cli.py tests/test_ai_cli_login.py tests/test_ai_router.py tests/test_langchain_backend.py tests/test_n8n_flow.py tests/test_ai_cli_nats.py tests/test_ai_cli_nats_events.py tests/test_ai_cli_plugins.py tests/test_analytics_default.py tests/test_textual_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_688e94a84d6c832680ab4dabf54bc586