### PR TITLE
feat: add finance analyze workflow

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -206,6 +206,39 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_finance_analyze(args: argparse.Namespace) -> int:
+    payload: dict[str, Any] = {
+        "workflow": "FinancialDecisionSupport",
+        "parameters": {"max_options": args.max_options},
+    }
+    params = payload["parameters"]
+    if args.min_budget is not None:
+        params["min_budget"] = args.min_budget
+    if args.max_budget is not None:
+        params["max_budget"] = args.max_budget
+    try:
+        text = router.send_prompt(json.dumps(payload))
+        data = json.loads(text)
+        options = data.get("options", [])
+    except Exception as exc:  # noqa: BLE001
+        print(exc, file=sys.stderr)
+        _publish_event(args, "finance-analyze", {"exit_code": 1})
+        return 1
+    for idx, opt in enumerate(options, start=1):
+        print(opt)
+        _publish_event(
+            args,
+            "finance-analyze-progress",
+            {"options_generated": idx},
+        )
+    _publish_event(
+        args,
+        "finance-analyze",
+        {"exit_code": 0, "option_count": len(options)},
+    )
+    return 0
+
+
 def _cmd_metrics(args: argparse.Namespace) -> int:
     """Show weekly totals of successful ai-do runs."""
     if args.aggregates_url:
@@ -302,6 +335,28 @@ def build_parser() -> argparse.ArgumentParser:
     plugin = sub.add_parser("plugin", help="Manage plug-ins")
     plugin.add_argument("plugin_args", nargs=argparse.REMAINDER)
     plugin.set_defaults(func=_cmd_plugin)
+
+    finance = sub.add_parser(
+        "finance", help="Financial decision support", parents=[analytics]
+    )
+    finance_sub = finance.add_subparsers(dest="finance_command", required=True)
+    analyze = finance_sub.add_parser(
+        "analyze", help="Analyze financial options", parents=[analytics]
+    )
+    analyze.add_argument(
+        "--max-options",
+        type=int,
+        default=3,
+        dest="max_options",
+        help="Maximum number of options to generate (default: %(default)s)",
+    )
+    analyze.add_argument(
+        "--min-budget", type=float, dest="min_budget", default=None
+    )
+    analyze.add_argument(
+        "--max-budget", type=float, dest="max_budget", default=None
+    )
+    analyze.set_defaults(func=_cmd_finance_analyze)
 
     sources = sub.add_parser(
         "sources",

--- a/tests/test_ai_cli_finance.py
+++ b/tests/test_ai_cli_finance.py
@@ -1,0 +1,64 @@
+import contextlib
+import io
+import json
+
+from scripts import ai_cli
+
+
+def test_finance_analyze(monkeypatch):
+    captured = {}
+
+    def fake_send(prompt, *, local=False, model=ai_cli.router.DEFAULT_MODEL):
+        data = json.loads(prompt)
+        captured["payload"] = data
+        return json.dumps({"options": ["opt1", "opt2"]})
+
+    monkeypatch.setattr(ai_cli.router, "send_prompt", fake_send)
+
+    events = []
+    monkeypatch.setattr(ai_cli, "_publish_event", lambda a, n, p: events.append((n, p)))
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(
+            [
+                "finance",
+                "analyze",
+                "--max-options",
+                "2",
+                "--min-budget",
+                "10",
+                "--max-budget",
+                "20",
+            ]
+        )
+    assert rc == 0
+    assert captured["payload"] == {
+        "workflow": "FinancialDecisionSupport",
+        "parameters": {"max_options": 2, "min_budget": 10.0, "max_budget": 20.0},
+    }
+    assert out.getvalue().splitlines() == ["opt1", "opt2"]
+    assert events == [
+        ("finance-analyze-progress", {"options_generated": 1}),
+        ("finance-analyze-progress", {"options_generated": 2}),
+        ("finance-analyze", {"exit_code": 0, "option_count": 2}),
+    ]
+
+
+def test_finance_analyze_no_budget(monkeypatch):
+    captured = {}
+
+    def fake_send(prompt, *, local=False, model=ai_cli.router.DEFAULT_MODEL):
+        data = json.loads(prompt)
+        captured["payload"] = data
+        return json.dumps({"options": []})
+
+    monkeypatch.setattr(ai_cli.router, "send_prompt", fake_send)
+    monkeypatch.setattr(ai_cli, "_publish_event", lambda *a, **k: None)
+
+    rc = ai_cli.main(["finance", "analyze", "--max-options", "5"])
+    assert rc == 0
+    assert captured["payload"] == {
+        "workflow": "FinancialDecisionSupport",
+        "parameters": {"max_options": 5},
+    }


### PR DESCRIPTION
## Summary
- add finance analyze command invoking FinancialDecisionSupport workflow
- support optional budget constraints and analytics progress events
- cover finance analyze CLI parameters and telemetry with tests

## Testing
- `pre-commit run ruff --files scripts/ai_cli.py tests/test_ai_cli_finance.py` (fails: check:1:1: E902 No such file or directory)
- `ruff check scripts/ai_cli.py tests/test_ai_cli_finance.py`
- `pytest tests/test_ai_cli_finance.py`

------
https://chatgpt.com/codex/tasks/task_e_688ea02adc84832681eae25c47241d43