### PR TITLE
Add calendar CLI with add/view commands

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -237,6 +237,88 @@ def _cmd_metrics(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_calendar_add(args: argparse.Namespace) -> int:
+    start = time.time()
+    agent_cls = globals().get("CalendarNLP_Agent")
+    if agent_cls is None:
+        print("CalendarNLP_Agent is not available", file=sys.stderr)
+        cli_actions.record_event_logged(
+            "ai-cli-calendar-add",
+            {"exit_code": 1, "start_ts": start, "end_ts": start, "latency_ms": 0},
+            enabled=args.analytics,
+        )
+        return 1
+    try:
+        agent = agent_cls()
+        agent.add_event(args.text)
+    except Exception as exc:  # noqa: BLE001
+        end = time.time()
+        print(exc, file=sys.stderr)
+        cli_actions.record_event_logged(
+            "ai-cli-calendar-add",
+            {
+                "exit_code": 1,
+                "start_ts": start,
+                "end_ts": end,
+                "latency_ms": int((end - start) * 1000),
+            },
+            enabled=args.analytics,
+        )
+        return 1
+    end = time.time()
+    cli_actions.record_event_logged(
+        "ai-cli-calendar-add",
+        {
+            "exit_code": 0,
+            "start_ts": start,
+            "end_ts": end,
+            "latency_ms": int((end - start) * 1000),
+        },
+        enabled=args.analytics,
+    )
+    return 0
+
+
+def _cmd_calendar_view(args: argparse.Namespace) -> int:
+    base = args.url or os.environ.get("CALENDAR_URL")
+    if not base:
+        print("Calendar URL required (--url or CALENDAR_URL)", file=sys.stderr)
+        return 1
+    params: dict[str, Any] = {}
+    if args.day:
+        params["day"] = args.day
+    if args.week:
+        params["week"] = args.week
+    if args.layers:
+        params["layers"] = ",".join(args.layers)
+    try:
+        resp = requests.get(f"{base}/v1/calendar/events", params=params, timeout=10)
+        resp.raise_for_status()
+        events = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        print(f"failed to fetch events: {exc}", file=sys.stderr)
+        return 1
+    if args.timeline:
+        for ev in events:
+            start = ev.get("start", "")
+            end = ev.get("end", "")
+            summary = ev.get("summary", "")
+            if end:
+                print(f"{start} - {end} {summary}".strip())
+            else:
+                print(f"{start} {summary}".strip())
+    else:
+        print(f"{'Start':<20} {'End':<20} {'Summary':<30} {'Layer':<10}")
+        for ev in events:
+            layer = ev.get("layer")
+            if layer is None:
+                layer = ",".join(str(x) for x in ev.get("layers", []))
+            print(
+                f"{ev.get('start',''):<20} {ev.get('end',''):<20} {ev.get('summary',''):<30} {layer}"
+            )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     analytics = build_analytics_parser()
 
@@ -341,6 +423,37 @@ def build_parser() -> argparse.ArgumentParser:
         help="URL for precomputed weekly aggregates (default: NSM_URL)",
     )
     metrics.set_defaults(func=_cmd_metrics)
+
+    calendar = sub.add_parser("calendar", help="Manage calendar events", parents=[analytics])
+    cal_sub = calendar.add_subparsers(dest="calendar_cmd", required=True)
+
+    cal_add = cal_sub.add_parser("add", help="Add calendar event", parents=[analytics])
+    cal_add.add_argument("text", help="Event description")
+    cal_add.set_defaults(func=_cmd_calendar_add)
+
+    cal_view = cal_sub.add_parser("view", help="View calendar events", parents=[analytics])
+    group = cal_view.add_mutually_exclusive_group()
+    group.add_argument("--day", dest="day")
+    group.add_argument("--week", dest="week")
+    cal_view.add_argument(
+        "--layers",
+        nargs="+",
+        dest="layers",
+        default=None,
+        help="Filter by layers",
+    )
+    cal_view.add_argument(
+        "--timeline",
+        action="store_true",
+        help="Display events as timeline",
+    )
+    cal_view.add_argument(
+        "--url",
+        dest="url",
+        default=None,
+        help="Calendar service base URL (default: CALENDAR_URL)",
+    )
+    cal_view.set_defaults(func=_cmd_calendar_view)
 
     return parser
 

--- a/tests/test_ai_cli_calendar.py
+++ b/tests/test_ai_cli_calendar.py
@@ -1,0 +1,100 @@
+from scripts import ai_cli, cli_actions
+
+
+def test_calendar_add(monkeypatch):
+    recorded = []
+
+    def fake_record(name, payload, *, enabled=False):
+        recorded.append((name, payload, enabled))
+        return True
+
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
+
+    captured = {}
+
+    class FakeAgent:
+        def add_event(self, text):
+            captured["text"] = text
+
+    monkeypatch.setattr(ai_cli, "CalendarNLP_Agent", FakeAgent, raising=False)
+
+    rc = ai_cli.main(["calendar", "add", "Lunch tomorrow", "--analytics"])
+    assert rc == 0
+    assert captured["text"] == "Lunch tomorrow"
+    name, payload, enabled = recorded[0]
+    assert name == "ai-cli-calendar-add"
+    assert payload["exit_code"] == 0
+    assert enabled is True
+
+
+def test_calendar_view(monkeypatch, capsys):
+    events = [
+        {
+            "start": "2024-07-12T10:00:00",
+            "end": "2024-07-12T11:00:00",
+            "summary": "Meeting",
+            "layer": "work",
+        }
+    ]
+
+    def fake_get(url, params=None, timeout=10):
+        assert url == "https://cal/v1/calendar/events"
+        assert params["day"] == "2024-07-12"
+        assert params["layers"] == "work"
+
+        class Resp:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return events
+
+        return Resp()
+
+    monkeypatch.setattr(ai_cli.requests, "get", fake_get)
+    rc = ai_cli.main(
+        ["calendar", "view", "--day", "2024-07-12", "--layers", "work", "--url", "https://cal"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out.splitlines()
+    assert "Start" in out[0]
+    assert "Meeting" in out[1]
+
+
+def test_calendar_view_timeline(monkeypatch, capsys):
+    events = [
+        {
+            "start": "2024-07-12T10:00:00",
+            "end": "2024-07-12T11:00:00",
+            "summary": "Meeting",
+        }
+    ]
+
+    def fake_get(url, params=None, timeout=10):
+        assert params["week"] == "2024-W28"
+
+        class Resp:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return events
+
+        return Resp()
+
+    monkeypatch.setattr(ai_cli.requests, "get", fake_get)
+    rc = ai_cli.main(
+        [
+            "calendar",
+            "view",
+            "--week",
+            "2024-W28",
+            "--timeline",
+            "--url",
+            "https://cal",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert "Meeting" in out
+    assert "2024-07-12T10:00:00" in out


### PR DESCRIPTION
## Summary
- add calendar add and view subcommands to CLI
- support viewing day or week events and add events via CalendarNLP_Agent
- test calendar CLI interactions

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli_calendar.py`
- `mypy scripts/ai_cli.py tests/test_ai_cli_calendar.py`
- `pytest tests/test_ai_cli_calendar.py`

------
https://chatgpt.com/codex/tasks/task_e_688ea028834c8326acc38df4467e9159