### PR TITLE
Ask for clarification on ambiguous goals

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -96,9 +96,30 @@ def _cmd_send(args: argparse.Namespace) -> int:
     return 0
 
 
+def _clarify_goal(
+    goal: str, *, config, analytics: bool
+) -> tuple[str, List[str]]:
+    """Request clarification from the user until planning succeeds.
+
+    ``ai_exec.plan`` may return an empty list when the goal is ambiguous or
+    lacks sufficient detail. In that case ask the user for more context and
+    re-run planning with the expanded goal.
+    """
+    steps = ai_exec.plan(goal, config_path=config, analytics=analytics)
+    while not steps:
+        extra = input("Goal unclear. Please provide more details: ").strip()
+        if not extra:
+            break
+        goal = f"{goal}. {extra}" if goal else extra
+        steps = ai_exec.plan(goal, config_path=config, analytics=analytics)
+    return goal, steps
+
+
 def _cmd_plan(args: argparse.Namespace) -> int:
     start = time.time()
-    steps = ai_exec.plan(args.goal, config_path=args.config, analytics=args.analytics)
+    goal, steps = _clarify_goal(
+        args.goal, config=args.config, analytics=args.analytics
+    )
     for step in steps:
         print(step)
     end = time.time()
@@ -106,7 +127,7 @@ def _cmd_plan(args: argparse.Namespace) -> int:
         args,
         "ai-cli-plan",
         {
-            "goal": args.goal,
+            "goal": goal,
             "step_count": len(steps),
             "start_ts": start,
             "end_ts": end,
@@ -117,15 +138,15 @@ def _cmd_plan(args: argparse.Namespace) -> int:
 
 
 def _cmd_do(args: argparse.Namespace) -> int:
-    steps = ai_exec.plan(
-        args.goal, config_path=args.config, analytics=args.analytics
+    goal, steps = _clarify_goal(
+        args.goal, config=args.config, analytics=args.analytics
     )
     return cli_actions.run_steps(
         "ai-cli-do",
         steps,
         log_path=args.log,
         analytics=args.analytics,
-        payload={"goal": args.goal, "step_count": len(steps)},
+        payload={"goal": goal, "step_count": len(steps)},
         nats_url=args.nats_url,
         jetstream=getattr(args, "jetstream", False),
     )

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -80,6 +80,46 @@ def test_do_creates_log_dir(monkeypatch, tmp_path):
     assert log.exists()
 
 
+def test_plan_requests_clarification(monkeypatch):
+    calls = []
+
+    def fake_plan(goal: str, *, config_path=None, analytics=False):
+        calls.append(goal)
+        return [] if len(calls) == 1 else [f"echo {goal}"]
+
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", fake_plan)
+    monkeypatch.setattr("builtins.input", lambda _: "more info")
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["plan", "goal"])
+    assert rc == 0
+    assert calls == ["goal", "goal. more info"]
+    assert out.getvalue().splitlines() == ["echo goal. more info"]
+
+
+def test_do_requests_clarification(monkeypatch):
+    calls = []
+
+    def fake_plan(goal: str, *, config_path=None, analytics=False):
+        calls.append(goal)
+        return [] if len(calls) == 1 else [f"echo {goal}"]
+
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", fake_plan)
+    captured = {}
+
+    def fake_run_steps(name, steps, **kwargs):
+        captured["name"] = name
+        captured["steps"] = steps
+        return 0
+
+    monkeypatch.setattr(cli_actions, "run_steps", fake_run_steps)
+    monkeypatch.setattr("builtins.input", lambda _: "extra detail")
+    rc = ai_cli.main(["do", "goal"])
+    assert rc == 0
+    assert calls == ["goal", "goal. extra detail"]
+    assert captured["steps"] == ["echo goal. extra detail"]
+
+
 def test_send_records_event(monkeypatch):
     monkeypatch.setattr(ai_cli.router, "send_prompt", lambda *a, **k: "ok")
     recorded = []


### PR DESCRIPTION
## Summary
- prompt users for more details when a plan yields no steps and re-plan with the clarified goal
- record clarified goal in both `ai-plan` and `ai-do` flows
- add regression tests for clarification-driven replanning

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli.py`
- `pytest tests/test_ai_cli.py::test_plan_requests_clarification tests/test_ai_cli.py::test_do_requests_clarification -q`


------
https://chatgpt.com/codex/tasks/task_e_688ea89d532c8326ac896a40e6fc2417