### PR TITLE
Add monthly budget option to finance CLI and tests

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -238,6 +238,8 @@ def _cmd_finance_analyze(args: argparse.Namespace) -> int:
         params["min_budget"] = args.min_budget
     if args.max_budget is not None:
         params["max_budget"] = args.max_budget
+    if getattr(args, "monthly_budget", None) is not None:
+        params["monthly_budget"] = args.monthly_budget
     stop = threading.Event()
     listener: threading.Thread | None = None
 
@@ -490,6 +492,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     analyze.add_argument(
         "--max-budget", type=float, dest="max_budget", default=None
+    )
+    analyze.add_argument(
+        "--monthly-budget", type=float, dest="monthly_budget", default=None
     )
     analyze.add_argument(
         "--no-progress",

--- a/tests/test_ai_cli_finance.py
+++ b/tests/test_ai_cli_finance.py
@@ -38,12 +38,19 @@ def test_finance_analyze(monkeypatch):
                 "10",
                 "--max-budget",
                 "20",
+                "--monthly-budget",
+                "300",
             ]
         )
     assert rc == 0
     assert captured["payload"] == {
         "workflow": "FinancialDecisionSupport",
-        "parameters": {"max_options": 2, "min_budget": 10.0, "max_budget": 20.0},
+        "parameters": {
+            "max_options": 2,
+            "min_budget": 10.0,
+            "max_budget": 20.0,
+            "monthly_budget": 300.0,
+        },
     }
     assert out.getvalue().splitlines() == [
         "1 options generated. Use `ai finance view` to see results.",


### PR DESCRIPTION
## Summary
- support `--monthly-budget` in finance analyze CLI and forward it in payload
- cover monthly budget in finance tests while preserving progress output assertions

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli_finance.py`
- `pytest tests/test_ai_cli_finance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd374a81c832686022b4e9d0ef723