### PR TITLE
Handle calendar agent import errors

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -26,6 +26,7 @@ from telemetry import analytics_default
 from ume import events as ume_events
 import logging
 import time
+import importlib
 
 SESSION_FILE = Path.home() / ".config" / "d0tTino" / "cli_session.json"
 _session: dict[str, Any] = {}
@@ -325,14 +326,31 @@ def _cmd_metrics(args: argparse.Namespace) -> int:
     return 0
 
 
+def _load_calendar_agent() -> type[Any] | None:
+    """Load and return the calendar NLP agent class if available."""
+    try:
+        module = importlib.import_module("calendar_nlp")
+        return getattr(module, "CalendarNLP_Agent")
+    except (ImportError, AttributeError):
+        return None
+
+
 def _cmd_calendar_add(args: argparse.Namespace) -> int:
     start = time.time()
-    agent_cls = globals().get("CalendarNLP_Agent")
+    agent_cls = _load_calendar_agent()
     if agent_cls is None:
-        print("CalendarNLP_Agent is not available", file=sys.stderr)
+        msg = "CalendarNLP_Agent is not available"
+        print(msg, file=sys.stderr)
+        end = time.time()
         cli_actions.record_event_logged(
             "ai-cli-calendar-add",
-            {"exit_code": 1, "start_ts": start, "end_ts": start, "latency_ms": 0},
+            {
+                "exit_code": 1,
+                "start_ts": start,
+                "end_ts": end,
+                "latency_ms": int((end - start) * 1000),
+                "error": msg,
+            },
             enabled=args.analytics,
         )
         return 1

--- a/tests/test_ai_cli_calendar.py
+++ b/tests/test_ai_cli_calendar.py
@@ -16,7 +16,7 @@ def test_calendar_add(monkeypatch):
         def add_event(self, text):
             captured["text"] = text
 
-    monkeypatch.setattr(ai_cli, "CalendarNLP_Agent", FakeAgent, raising=False)
+    monkeypatch.setattr(ai_cli, "_load_calendar_agent", lambda: FakeAgent)
 
     rc = ai_cli.main(["calendar", "add", "Lunch tomorrow", "--analytics"])
     assert rc == 0
@@ -24,6 +24,26 @@ def test_calendar_add(monkeypatch):
     name, payload, enabled = recorded[0]
     assert name == "ai-cli-calendar-add"
     assert payload["exit_code"] == 0
+    assert enabled is True
+
+
+def test_calendar_add_missing_agent(monkeypatch, capsys):
+    recorded = []
+
+    def fake_record(name, payload, *, enabled=False):
+        recorded.append((name, payload, enabled))
+        return True
+
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
+    monkeypatch.setattr(ai_cli, "_load_calendar_agent", lambda: None)
+
+    rc = ai_cli.main(["calendar", "add", "Lunch", "--analytics"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "CalendarNLP_Agent is not available" in err
+    name, payload, enabled = recorded[0]
+    assert name == "ai-cli-calendar-add"
+    assert payload["exit_code"] == 1
     assert enabled is True
 
 


### PR DESCRIPTION
## Summary
- load CalendarNLP agent via importlib instead of globals
- log analytics and clear error if agent import fails
- test calendar add behavior when agent missing

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli_calendar.py`
- `pytest tests/test_ai_cli_calendar.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd6eefcb483269982e74228ba2e7e