### PR TITLE
test: cover calendar add without agent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,8 @@ repos:
     rev: v0.12.5
     hooks:
       - id: ruff
-        args: [check, .]
+        args: ["."]
+        pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.17.0
     hooks:

--- a/tests/test_ai_cli_calendar.py
+++ b/tests/test_ai_cli_calendar.py
@@ -27,6 +27,25 @@ def test_calendar_add(monkeypatch):
     assert enabled is True
 
 
+def test_calendar_add_missing_agent(monkeypatch):
+    recorded = []
+
+    def fake_record(name, payload, *, enabled=False):
+        recorded.append((name, payload, enabled))
+        return True
+
+    monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
+    monkeypatch.delattr(ai_cli, "CalendarNLP_Agent", raising=False)
+
+    rc = ai_cli.main(["calendar", "add", "Lunch tomorrow", "--analytics"])
+
+    assert rc != 0
+    name, payload, enabled = recorded[0]
+    assert name == "ai-cli-calendar-add"
+    assert payload["exit_code"] == 1
+    assert enabled is True
+
+
 def test_calendar_view(monkeypatch, capsys):
     events = [
         {


### PR DESCRIPTION
## Summary
- add regression test ensuring `ai calendar add` fails and records analytics when CalendarNLP_Agent is missing
- fix pre-commit ruff configuration so the lint check runs successfully

## Testing
- `pytest tests/test_ai_cli_calendar.py::test_calendar_add_missing_agent -q`
- `pre-commit run --files tests/test_ai_cli_calendar.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd6efa4e4832681dd2d89510de0f6