### PR TITLE
Add finance view CLI and tests

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -295,6 +295,34 @@ def _cmd_finance_analyze(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_finance_view(args: argparse.Namespace) -> int:
+    base = args.url or os.environ.get("FINANCE_URL")
+    if not base:
+        print("Finance URL required (--url or FINANCE_URL)", file=sys.stderr)
+        return 1
+    try:
+        resp = requests.get(f"{base}/v1/finance/options", timeout=10)
+        resp.raise_for_status()
+        options = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        print(f"failed to fetch options: {exc}", file=sys.stderr)
+        return 1
+    if args.timeline:
+        for opt in options:
+            name = opt.get("name", "")
+            for ev in opt.get("timeline", []):
+                when = ev.get("time") or ev.get("date") or ""
+                desc = ev.get("detail") or ev.get("description") or ""
+                print(f"{when} {name} {desc}".strip())
+    else:
+        print(f"{'Name':<20} {'Cost':<10} {'Summary'}")
+        for opt in options:
+            print(
+                f"{opt.get('name',''):<20} {str(opt.get('cost','')):<10} {opt.get('summary','')}",
+            )
+    return 0
+
+
 def _cmd_metrics(args: argparse.Namespace) -> int:
     """Show weekly totals of successful ai-do runs."""
     if args.aggregates_url:
@@ -521,6 +549,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Disable live progress updates",
     )
     analyze.set_defaults(func=_cmd_finance_analyze)
+
+    view = finance_sub.add_parser(
+        "view", help="View financial options", parents=[analytics]
+    )
+    view.add_argument(
+        "--url",
+        dest="url",
+        default=None,
+        help="Base URL for finance service",
+    )
+    view.add_argument(
+        "--timeline",
+        action="store_true",
+        dest="timeline",
+        help="Display options as timeline",
+    )
+    view.set_defaults(func=_cmd_finance_view)
 
     sources = sub.add_parser(
         "sources",

--- a/tests/test_ai_cli_finance_view.py
+++ b/tests/test_ai_cli_finance_view.py
@@ -1,0 +1,72 @@
+from scripts import ai_cli
+
+
+def test_finance_view_table(monkeypatch, capsys):
+    options = [{"name": "OptA", "cost": 100, "summary": "Plan A"}]
+
+    def fake_get(url, timeout=10):
+        assert url == "https://fin/v1/finance/options"
+        class Resp:
+            def raise_for_status(self):
+                return None
+            def json(self):
+                return options
+        return Resp()
+
+    monkeypatch.setattr(ai_cli.requests, "get", fake_get)
+    rc = ai_cli.main(["finance", "view", "--url", "https://fin"])
+    assert rc == 0
+    out = capsys.readouterr().out.splitlines()
+    assert "Name" in out[0]
+    assert "Cost" in out[0]
+    assert "OptA" in out[1]
+    assert "100" in out[1]
+    assert "Plan A" in out[1]
+
+
+def test_finance_view_timeline(monkeypatch, capsys):
+    options = [
+        {
+            "name": "OptA",
+            "timeline": [{"time": "2024-07-12", "detail": "start"}],
+        }
+    ]
+
+    def fake_get(url, timeout=10):
+        class Resp:
+            def raise_for_status(self):
+                return None
+            def json(self):
+                return options
+        return Resp()
+
+    monkeypatch.setattr(ai_cli.requests, "get", fake_get)
+    rc = ai_cli.main([
+        "finance",
+        "view",
+        "--timeline",
+        "--url",
+        "https://fin",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert "OptA" in out
+    assert "2024-07-12" in out
+    assert "start" in out
+
+
+def test_finance_view_empty(monkeypatch, capsys):
+    def fake_get(url, timeout=10):
+        class Resp:
+            def raise_for_status(self):
+                return None
+            def json(self):
+                return []
+        return Resp()
+
+    monkeypatch.setattr(ai_cli.requests, "get", fake_get)
+    rc = ai_cli.main(["finance", "view", "--url", "https://fin"])
+    assert rc == 0
+    out = capsys.readouterr().out.splitlines()
+    assert len(out) == 1
+    assert "Name" in out[0]


### PR DESCRIPTION
## Summary
- add finance view command to fetch and display options as table or timeline
- test finance view CLI output with mocked backend

## Testing
- `pre-commit run --files scripts/ai_cli.py tests/test_ai_cli_finance_view.py`
- `pytest tests/test_ai_cli_finance_view.py tests/test_ai_cli_finance.py tests/test_ai_cli_calendar.py`


------
https://chatgpt.com/codex/tasks/task_e_689020833bbc832695f084e3f21a0d8e