### PR TITLE
docs: expand CLI usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,22 @@ ai-cli send "Hello"
 ai-cli plan "Refactor the codebase"
 ai-cli do "Refactor the codebase"
 
+# Authenticate and manage session context
+ai login alice
+ai switch-context personal
+
+# Schedule events
+ai calendar add "Lunch tomorrow at noon"
+ai calendar view --day 2024-07-12
+
+# Analyze budgets and review options
+ai finance analyze --goal "Reduce monthly expenses"
+ai finance view
+
+```
 Legacy commands `ai`, `ai-plan`, and `ai-do` now invoke these subcommands
 behind the scenes.
 
-```
 Set `LLM_ROUTING_MODE` to `remote` or `local` to override the automatic
 selection logic, or adjust `LLM_COMPLEXITY_THRESHOLD` to change when the prompt
 is considered complex.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,34 @@
+# CLI Scenarios
+
+These examples demonstrate common workflows using the `ai` command line helpers.
+
+## Multi-user session
+
+1. Alice signs in and sets her working context:
+   ```bash
+   ai login alice
+   ai switch-context work
+   ```
+2. She schedules a team meeting and verifies it:
+   ```bash
+   ai calendar add "Team sync tomorrow at 10am"
+   ai calendar view --day 2024-07-12 --layers work
+   ```
+3. Bob uses the same machine later:
+   ```bash
+   ai login bob
+   ai switch-context personal
+   ai calendar view --day 2024-07-12 --layers personal
+   ```
+
+## Budget analysis
+
+1. Generate cost-cutting ideas:
+   ```bash
+   ai finance analyze --goal "Lower cloud spending"
+   ```
+2. Review the options produced by the previous step:
+   ```bash
+   ai finance view
+   ```
+3. Repeat the cycle with updated goals as your plan evolves.


### PR DESCRIPTION
## Summary
- expand `README.md` with login, context switching, calendar, and finance usage examples
- add `docs/cli.md` outlining multi-user session and budget analysis scenarios

## Testing
- No tests were run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_6891394f4f148326aad4b08148fadba4