### PR TITLE
Restrict context switch options

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -472,7 +472,11 @@ def build_parser() -> argparse.ArgumentParser:
     switch_context = sub.add_parser(
         "switch-context", help="Switch active context", parents=[analytics]
     )
-    switch_context.add_argument("context", help="Context identifier")
+    switch_context.add_argument(
+        "context",
+        choices=("personal", "group"),
+        help="Context identifier (personal or group)",
+    )
     switch_context.set_defaults(func=_cmd_switch_context)
     send = sub.add_parser("send", help="Send a prompt to the LLM backend", parents=[analytics])
     send.add_argument("prompt", help="Prompt or '-' to read from STDIN")

--- a/tests/test_ai_cli_context.py
+++ b/tests/test_ai_cli_context.py
@@ -39,3 +39,9 @@ def test_context_switch_affects_send(monkeypatch, tmp_path):
         assert data["context"] == "group"
     finally:
         ai_cli._session.clear()
+
+
+def test_switch_context_invalid_value():
+    with pytest.raises(SystemExit) as excinfo:
+        ai_cli.main(["switch-context", "invalid"])
+    assert excinfo.value.code == 2


### PR DESCRIPTION
## Summary
- limit `switch-context` to `personal` or `group`
- add test ensuring invalid context value exits with error

## Testing
- `pre-commit run --files scripts/ai_cli.py tests/test_ai_cli_context.py`
- `pytest tests/test_ai_cli_context.py`


------
https://chatgpt.com/codex/tasks/task_e_689202e268e88326827a5efba066b2e0