### PR TITLE
Add test for clarify_goal user prompt

### DIFF
--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -120,6 +120,21 @@ def test_do_requests_clarification(monkeypatch):
     assert captured["steps"] == ["echo goal. extra detail"]
 
 
+def test_clarify_goal_prompts_user(monkeypatch):
+    calls = []
+
+    def fake_plan(goal: str, *, config_path=None, analytics=False):
+        calls.append(goal)
+        return [] if len(calls) == 1 else [f"echo {goal}"]
+
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", fake_plan)
+    monkeypatch.setattr("builtins.input", lambda _: "details")
+    goal, steps = ai_cli._clarify_goal("goal", config=None, analytics=False)
+    assert calls == ["goal", "goal. details"]
+    assert goal == "goal. details"
+    assert steps == ["echo goal. details"]
+
+
 def test_send_records_event(monkeypatch):
     monkeypatch.setattr(ai_cli.router, "send_prompt", lambda *a, **k: "ok")
     recorded = []


### PR DESCRIPTION
## Summary
- add unit test verifying _clarify_goal prompts for user details when initial planning returns no steps

## Testing
- `pre-commit run --files tests/test_ai_cli.py`
- `pytest tests/test_ai_cli.py::test_clarify_goal_prompts_user -q`


------
https://chatgpt.com/codex/tasks/task_e_689202e175cc8326a05f739d0b774200