### PR TITLE
Require calendar view timeframe

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -622,7 +622,7 @@ def build_parser() -> argparse.ArgumentParser:
     cal_add.set_defaults(func=_cmd_calendar_add)
 
     cal_view = cal_sub.add_parser("view", help="View calendar events", parents=[analytics])
-    group = cal_view.add_mutually_exclusive_group()
+    group = cal_view.add_mutually_exclusive_group(required=True)
     group.add_argument("--day", dest="day")
     group.add_argument("--week", dest="week")
     cal_view.add_argument(

--- a/tests/test_ai_cli_calendar.py
+++ b/tests/test_ai_cli_calendar.py
@@ -1,3 +1,5 @@
+import pytest
+
 from scripts import ai_cli, cli_actions
 
 
@@ -119,3 +121,9 @@ def test_calendar_view_timeline(monkeypatch, capsys):
     out = capsys.readouterr().out.strip()
     assert "Meeting" in out
     assert "2024-07-12T10:00:00" in out
+
+
+def test_calendar_view_requires_timeframe():
+    with pytest.raises(SystemExit) as excinfo:
+        ai_cli.main(["calendar", "view"])
+    assert excinfo.value.code == 2


### PR DESCRIPTION
## Summary
- ensure calendar CLI view subcommand requires either `--day` or `--week`
- test that calendar view without timeframe exits with an error

## Testing
- `pre-commit run --files scripts/ai_cli.py tests/test_ai_cli_calendar.py`
- `pytest tests/test_ai_cli_calendar.py`


------
https://chatgpt.com/codex/tasks/task_e_6894a7b93c888326a6ef986cfb5b1e87