### PR TITLE
Clarify calendar plugin guidance

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -369,7 +369,9 @@ def _cmd_calendar_add(args: argparse.Namespace) -> int:
     start = time.time()
     agent_cls = _load_calendar_agent()
     if agent_cls is None:
-        msg = "CalendarNLP_Agent is not available"
+        msg = (
+            "CalendarNLP_Agent is not available. Install or enable the calendar plugin."
+        )
         print(msg, file=sys.stderr)
         end = time.time()
         cli_actions.record_event_logged(

--- a/tests/test_ai_cli_calendar.py
+++ b/tests/test_ai_cli_calendar.py
@@ -29,7 +29,7 @@ def test_calendar_add(monkeypatch):
     assert enabled is True
 
 
-def test_calendar_add_missing_agent(monkeypatch):
+def test_calendar_add_missing_agent(monkeypatch, capsys):
 
     recorded = []
 
@@ -43,6 +43,8 @@ def test_calendar_add_missing_agent(monkeypatch):
     rc = ai_cli.main(["calendar", "add", "Lunch tomorrow", "--analytics"])
 
     assert rc != 0
+    err = capsys.readouterr().err.strip()
+    assert "Install or enable the calendar plugin" in err
 
     name, payload, enabled = recorded[0]
     assert name == "ai-cli-calendar-add"


### PR DESCRIPTION
## Summary
- Clarify calendar CLI error to direct users to install or enable the calendar plugin
- Verify missing agent guidance through updated calendar tests

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli_calendar.py`
- `pytest tests/test_ai_cli_calendar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894af4390b883268b7916447c00b8b1