### PR TITLE
docs: add CalendarNLP troubleshooting note

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,15 +4,17 @@ These examples demonstrate common workflows using the `ai` command line helpers.
 
 ## Multi-user session
 
+Valid contexts for `ai switch-context` are `personal` and `group`.
+
 1. Alice signs in and sets her working context:
    ```bash
    ai login alice
-   ai switch-context work
+   ai switch-context group
    ```
 2. She schedules a team meeting and verifies it:
    ```bash
    ai calendar add "Team sync tomorrow at 10am"
-   ai calendar view --day 2024-07-12 --layers work
+   ai calendar view --day 2024-07-12 --layers group
    ```
 3. Bob uses the same machine later:
    ```bash
@@ -32,3 +34,7 @@ These examples demonstrate common workflows using the `ai` command line helpers.
    ai finance view
    ```
 3. Repeat the cycle with updated goals as your plan evolves.
+
+## Troubleshooting
+
+- **CalendarNLP_Agent is not available** – install the `calendar_nlp` package or ensure it is on your `PYTHONPATH` so `ai calendar` commands can function.


### PR DESCRIPTION
## Summary
- document valid contexts for `ai switch-context`
- add troubleshooting note for missing CalendarNLP agent

## Testing
- no tests run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_6894af445bb483268d01b9f78356cb1a