### PR TITLE
Add Scoop manifest and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,8 @@ For private and ongoing work (such as **Aiga** and other closed repos), I focus 
 
 ---
 
+# d0tTino Configuration
+
+Refer to the docs for environment variables and other options.
+
 I prefer local‑first defaults with optional cloud. You’ll find me under **Tino** or **T** across platforms.

--- a/docs/install-scoop.md
+++ b/docs/install-scoop.md
@@ -1,0 +1,18 @@
+# Install via Scoop
+
+Use [Scoop](https://scoop.sh) to install the tools from this repository on Windows.
+
+1. Add this repository as a custom bucket, pointing at the `scoop` subdirectory:
+   ```powershell
+   scoop bucket add tino https://github.com/d0tTino/d0tTino main scoop
+   ```
+2. Install the manifest:
+   ```powershell
+   scoop install tino
+   ```
+3. Update when needed:
+   ```powershell
+   scoop update tino
+   ```
+
+The manifest downloads the current `main` branch archive and verifies it using the SHA256 hash stored in `scoop/tino.json`.

--- a/scoop/tino.json
+++ b/scoop/tino.json
@@ -1,0 +1,8 @@
+{
+    "version": "0.1.0",
+    "description": "Bootstrap scripts and configuration for d0tTino",
+    "homepage": "https://github.com/d0tTino/d0tTino",
+    "license": "MIT",
+    "url": "https://github.com/d0tTino/d0tTino/archive/refs/heads/main.zip",
+    "hash": "57bdea58dd433f12a39c0cdcfe25182cf8fced8c0481cfe4ff935b7f15cbe7a1"
+}

--- a/ume/events.py
+++ b/ume/events.py
@@ -18,7 +18,12 @@ DEFAULT_SUBJECT = os.environ.get("NATS_SUBJECT", "telemetry.events")
 
 async def _connect(url: str = DEFAULT_NATS_URL) -> NATS:
     nc = NATS()
-    await nc.connect(servers=[url])
+    await nc.connect(
+        servers=[url],
+        connect_timeout=1,
+        max_reconnect_attempts=1,
+        reconnect_time_wait=0.1,
+    )
     return nc
 
 


### PR DESCRIPTION
## Summary
- add Scoop manifest for d0tTino with download URL and checksum
- document Scoop installation steps
- avoid hanging NATS connections during analytics
- mention configuration header in README

## Testing
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689801ae58cc8326bea2e09aa18a60da