### PR TITLE
feat: enumerate plan steps

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -122,8 +122,8 @@ def _cmd_plan(args: argparse.Namespace) -> int:
     goal, steps = _clarify_goal(
         args.goal, config=args.config, analytics=args.analytics
     )
-    for step in steps:
-        print(step)
+    for i, step in enumerate(steps, start=1):
+        print(f"{i}. {step}")
     end = time.time()
     _publish_event(
         args,

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -36,7 +36,7 @@ def test_plan_subcommand(monkeypatch):
     with contextlib.redirect_stdout(out):
         rc = ai_cli.main(["plan", "goal", "--config", "cfg.json"])
     assert rc == 0
-    assert out.getvalue().splitlines() == ["one", "two"]
+    assert out.getvalue().splitlines() == ["1. one", "2. two"]
 
 
 def test_do_subcommand(monkeypatch, tmp_path):
@@ -94,7 +94,7 @@ def test_plan_requests_clarification(monkeypatch):
         rc = ai_cli.main(["plan", "goal"])
     assert rc == 0
     assert calls == ["goal", "goal. more info"]
-    assert out.getvalue().splitlines() == ["echo goal. more info"]
+    assert out.getvalue().splitlines() == ["1. echo goal. more info"]
 
 
 def test_do_requests_clarification(monkeypatch):


### PR DESCRIPTION
## Summary
- number each step in ai_cli plan output
- update tests for numbered plan lines

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli.py`
- `pytest tests/test_ai_cli.py::test_plan_subcommand tests/test_ai_cli.py::test_plan_requests_clarification tests/test_ai_cli_nats_events.py::test_ai_cli_plan_nats_events -q`


------
https://chatgpt.com/codex/tasks/task_e_689b561fe2d08326a9ebc1eb54f9f243