### PR TITLE
feat: tag risky plan steps

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -122,8 +122,13 @@ def _cmd_plan(args: argparse.Namespace) -> int:
     goal, steps = _clarify_goal(
         args.goal, config=args.config, analytics=args.analytics
     )
-    for step in steps:
-        print(step)
+    for i, step in enumerate(steps, 1):
+        if step.endswith("]") and " [" in step:
+            before, tag = step.rsplit(" [", 1)
+            tag = "[" + tag
+            print(f"{i}. {tag} {before}")
+        else:
+            print(f"{i}. {step}")
     end = time.time()
     _publish_event(
         args,

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -5,10 +5,12 @@
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
+import time
 from pathlib import Path
-from typing import List, Optional
 from threading import Lock
+from typing import List, Optional
 
 from llm import router
 from llm.ai_router import get_preferred_models
@@ -20,10 +22,19 @@ from scripts.cli_common import (
 )
 from scripts import cli_actions
 from telemetry import analytics_default
-import time
 
 _LAST_MODEL_REMOTE = True
 _LAST_MODEL_LOCK = Lock()
+
+RISKY_COMMANDS = {"rm", "sudo", "reboot", "shutdown", "poweroff", "mkfs", "dd"}
+
+
+def _tag_risky(step: str) -> str:
+    """Append a risk tag to ``step`` when it matches dangerous commands."""
+    pattern = re.compile(r"\b(" + "|".join(re.escape(cmd) for cmd in RISKY_COMMANDS) + r")\b")
+    if pattern.search(step):
+        return f"{step} [danger]"
+    return step
 
 def last_model_remote() -> bool:
     """Return ``True`` if the last plan used a remote model."""
@@ -52,7 +63,7 @@ def plan(
             used_remote = False
             text = router.run_ollama(goal, model=fallback or router.DEFAULT_MODEL)
 
-        steps = [line.strip() for line in text.splitlines() if line.strip()]
+        steps = [_tag_risky(line.strip()) for line in text.splitlines() if line.strip()]
         return steps
     except Exception:
         exit_code = 1

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -36,7 +36,7 @@ def test_plan_subcommand(monkeypatch):
     with contextlib.redirect_stdout(out):
         rc = ai_cli.main(["plan", "goal", "--config", "cfg.json"])
     assert rc == 0
-    assert out.getvalue().splitlines() == ["one", "two"]
+    assert out.getvalue().splitlines() == ["1. one", "2. two"]
 
 
 def test_do_subcommand(monkeypatch, tmp_path):
@@ -94,7 +94,7 @@ def test_plan_requests_clarification(monkeypatch):
         rc = ai_cli.main(["plan", "goal"])
     assert rc == 0
     assert calls == ["goal", "goal. more info"]
-    assert out.getvalue().splitlines() == ["echo goal. more info"]
+    assert out.getvalue().splitlines() == ["1. echo goal. more info"]
 
 
 def test_do_requests_clarification(monkeypatch):

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -106,6 +106,14 @@ def test_plan_records_event(monkeypatch):
     assert payload["model_source"] == "remote"
 
 
+def test_plan_tags_risky_commands(monkeypatch):
+    monkeypatch.setattr(ai_exec.router, "run_gemini", lambda *a, **k: "rm -rf /\nls")
+    monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
+    monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
+    steps = ai_exec.plan("goal")
+    assert steps == ["rm -rf / [danger]", "ls"]
+
+
 def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
     path.write_text(contents, encoding="utf-8")
     path.chmod(0o755)


### PR DESCRIPTION
## Summary
- tag dangerous shell commands during planning
- show plan step tags next to numbers in CLI
- test command risk tagging

## Testing
- `ruff check scripts/ai_exec.py scripts/ai_cli.py tests/test_ai_exec.py tests/test_ai_cli.py`
- `pytest tests/test_ai_exec.py tests/test_ai_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689b5621d7708326a7f4cdcca1b1c7f5