### PR TITLE
feat: tag risky commands with risk labels

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -123,12 +123,7 @@ def _cmd_plan(args: argparse.Namespace) -> int:
         args.goal, config=args.config, analytics=args.analytics
     )
     for i, step in enumerate(steps, 1):
-        if step.endswith("]") and " [" in step:
-            before, tag = step.rsplit(" [", 1)
-            tag = "[" + tag
-            print(f"{i}. {tag} {before}")
-        else:
-            print(f"{i}. {step}")
+        print(f"{i}. {step}")
 
     end = time.time()
     _publish_event(

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import argparse
-import re
+import shlex
 import subprocess
 import time
 from pathlib import Path
@@ -26,14 +26,27 @@ from telemetry import analytics_default
 _LAST_MODEL_REMOTE = True
 _LAST_MODEL_LOCK = Lock()
 
-RISKY_COMMANDS = {"rm", "sudo", "reboot", "shutdown", "poweroff", "mkfs", "dd"}
+RISKY_COMMANDS = {"rm", "reboot", "shutdown", "poweroff", "mkfs", "dd"}
 
 
 def _tag_risky(step: str) -> str:
-    """Append a risk tag to ``step`` when it matches dangerous commands."""
-    pattern = re.compile(r"\b(" + "|".join(re.escape(cmd) for cmd in RISKY_COMMANDS) + r")\b")
-    if pattern.search(step):
-        return f"{step} [danger]"
+    """Append a risk tag with the command type when ``step`` is dangerous."""
+    try:
+        tokens = shlex.split(step)
+    except ValueError:
+        return step
+    if not tokens:
+        return step
+    cmd = tokens[0]
+    risk: Optional[str] = None
+    if cmd == "sudo":
+        risk = "sudo"
+        if len(tokens) > 1 and tokens[1] in RISKY_COMMANDS:
+            risk = tokens[1]
+    elif cmd in RISKY_COMMANDS:
+        risk = cmd
+    if risk:
+        return f"{step} [risk:{risk}]"
     return step
 
 def last_model_remote() -> bool:

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -111,7 +111,17 @@ def test_plan_tags_risky_commands(monkeypatch):
     monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
     steps = ai_exec.plan("goal")
-    assert steps == ["rm -rf / [danger]", "ls"]
+    assert steps == ["rm -rf / [risk:rm]", "ls"]
+
+
+def test_plan_tags_sudo_commands(monkeypatch):
+    monkeypatch.setattr(
+        ai_exec.router, "run_gemini", lambda *a, **k: "sudo reboot now\nls"
+    )
+    monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
+    monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
+    steps = ai_exec.plan("goal")
+    assert steps == ["sudo reboot now [risk:reboot]", "ls"]
 
 
 def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:


### PR DESCRIPTION
## Summary
- detect dangerous commands in `ai_exec.plan` and append `[risk:<cmd>]` tags
- show step tags inline with numbered output in `ai_cli`
- test risky tagging including sudo handling

## Testing
- `python -m pre_commit run --files scripts/ai_exec.py scripts/ai_cli.py tests/test_ai_exec.py`
- `pytest tests/test_ai_exec.py`

------
https://chatgpt.com/codex/tasks/task_e_689baadf0ccc8326abe08f11b4f397a8