### PR TITLE
Add remote call budget tracking to LLM router

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -33,6 +33,46 @@ DEFAULT_FALLBACK_BACKEND = "ollama"
 DEFAULT_COMPLEXITY_THRESHOLD = 50
 
 
+_REMOTE_BACKENDS = {
+    "gemini",
+    "openrouter",
+    "anthropic",
+    "mistral",
+    "superclaude",
+    "langchain",
+}
+
+
+def _load_budget() -> int | None:
+    env_val = os.environ.get("LLM_ROUTER_BUDGET")
+    if env_val:
+        try:
+            return int(env_val)
+        except ValueError:  # pragma: no cover - invalid env value
+            return None
+    path = os.environ.get("LLM_CONFIG_PATH")
+    cfg_path = Path(path) if path else _DEFAULT_CONFIG
+    cfg = _load_config(cfg_path)
+    budget_val = cfg.get("budget")
+    return int(budget_val) if isinstance(budget_val, int) else None
+
+
+_BUDGET = _load_budget()
+
+
+def get_budget() -> int | None:
+    return _BUDGET
+
+
+def _decrement_budget() -> None:
+    global _BUDGET
+    if _BUDGET is None:
+        return
+    if _BUDGET <= 0:
+        raise RuntimeError("LLM budget exhausted")
+    _BUDGET -= 1
+
+
 def estimate_prompt_complexity(prompt: str) -> int:
     """Return a basic complexity score for ``prompt``."""
     return len(prompt.split())
@@ -224,6 +264,8 @@ def send_prompt(
                     order.append(primary)
     for backend_name in order:
         try:
+            if backend_name in _REMOTE_BACKENDS:
+                _decrement_budget()
             return _run_backend(backend_name, prompt, model)
         except (FileNotFoundError, subprocess.CalledProcessError):
             continue
@@ -245,4 +287,5 @@ __all__ = [
     "create_default_chain",
     "run_langchain",
     "send_prompt",
+    "get_budget",
 ]

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -1,0 +1,39 @@
+import importlib
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_router(monkeypatch):
+    yield
+    monkeypatch.delenv("LLM_ROUTER_BUDGET", raising=False)
+    import llm.router as router
+    importlib.reload(router)
+
+
+def _reload_router(monkeypatch, budget: str = "1"):
+    monkeypatch.setenv("LLM_ROUTER_BUDGET", budget)
+    monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
+    import llm.router as router
+    importlib.reload(router)
+    return router
+
+
+def test_budget_decrements_and_exhausts(monkeypatch):
+    router = _reload_router(monkeypatch, "1")
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+
+    assert router.get_budget() == 1
+    router.send_prompt("hello", model="g1")
+    assert router.get_budget() == 0
+    with pytest.raises(RuntimeError):
+        router.send_prompt("again", model="g1")
+
+
+def test_local_does_not_use_budget(monkeypatch):
+    router = _reload_router(monkeypatch, "1")
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", "ollama"))
+    monkeypatch.setattr(router, "run_ollama", lambda prompt, model: "local")
+
+    router.send_prompt("hi", local=True, model="o1")
+    assert router.get_budget() == 1


### PR DESCRIPTION
## Summary
- add remote call budget tracking with environment/config support
- expose `get_budget` helper and decrement per remote call
- add tests for budget exhaustion and local routing

## Testing
- `pre-commit run --files llm/router.py tests/test_router_budget.py`
- `pytest tests/test_router_budget.py tests/test_ai_router.py`


------
https://chatgpt.com/codex/tasks/task_e_689bd30e08d0832691fe595c7d10e9ae