### PR TITLE
feat: add dry run and confirmation flags

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -144,15 +144,18 @@ def _cmd_do(args: argparse.Namespace) -> int:
     goal, steps = _clarify_goal(
         args.goal, config=args.config, analytics=args.analytics
     )
-    return cli_actions.run_steps(
-        "ai-cli-do",
-        steps,
-        log_path=args.log,
-        analytics=args.analytics,
-        payload={"goal": goal, "step_count": len(steps)},
-        nats_url=args.nats_url,
-        jetstream=getattr(args, "jetstream", False),
-    )
+    kwargs: dict[str, Any] = {
+        "log_path": args.log,
+        "analytics": args.analytics,
+        "payload": {"goal": goal, "step_count": len(steps)},
+        "nats_url": args.nats_url,
+        "jetstream": getattr(args, "jetstream", False),
+    }
+    if getattr(args, "dry_run", False):
+        kwargs["dry_run"] = True
+    if getattr(args, "yes", False):
+        kwargs["assume_yes"] = True
+    return cli_actions.run_steps("ai-cli-do", steps, **kwargs)
 
 
 def _cmd_recipe(args: argparse.Namespace) -> int:
@@ -163,15 +166,17 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
         return 1
     recipe_func = mapping[args.name]
     steps = recipe_func(args.goal)
-    exit_code = cli_actions.run_recipe(
-        args.name,
-        args.goal,
-        steps,
-        log_path=args.log,
-        analytics=args.analytics,
-        nats_url=args.nats_url,
-        jetstream=getattr(args, "jetstream", False),
-    )
+    kwargs: dict[str, Any] = {
+        "log_path": args.log,
+        "analytics": args.analytics,
+        "nats_url": args.nats_url,
+        "jetstream": getattr(args, "jetstream", False),
+    }
+    if getattr(args, "dry_run", False):
+        kwargs["dry_run"] = True
+    if getattr(args, "yes", False):
+        kwargs["assume_yes"] = True
+    exit_code = cli_actions.run_recipe(args.name, args.goal, steps, **kwargs)
     end = time.time()
     if exit_code == 0:
         _publish_event(
@@ -506,6 +511,18 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Publish events via JetStream",
     )
+    do.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing",
+    )
+    do.add_argument(
+        "--yes",
+        "--confirm",
+        dest="yes",
+        action="store_true",
+        help="Run without interactive prompts",
+    )
     do.set_defaults(func=_cmd_do)
 
     recipe = sub.add_parser("recipe", help="Execute a named recipe", parents=[analytics])
@@ -521,6 +538,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--jetstream",
         action="store_true",
         help="Publish events via JetStream",
+    )
+    recipe.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing",
+    )
+    recipe.add_argument(
+        "--yes",
+        "--confirm",
+        dest="yes",
+        action="store_true",
+        help="Run without interactive prompts",
     )
     recipe.set_defaults(func=_cmd_recipe)
 

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -54,6 +54,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         default=REPO_ROOT / "ai_do.log",
         help="Log file path (default: %(default)s)",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing",
+    )
+    parser.add_argument(
+        "--yes",
+        "--confirm",
+        dest="yes",
+        action="store_true",
+        help="Run without interactive prompts",
+    )
     args = parser.parse_args(argv)
 
     analytics = getattr(args, "analytics", analytics_default())
@@ -70,6 +82,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         },
         duration_key="duration_ms",
         nats_url=args.nats_url if hasattr(args, "nats_url") else None,
+        dry_run=args.dry_run,
+        assume_yes=args.yes,
     )
     if args.notify:
         if exit_code == 0:

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -32,11 +32,15 @@ def run_steps(
     duration_key: str = "latency_ms",
     nats_url: str | None = None,
     jetstream: bool = False,
+    dry_run: bool = False,
+    assume_yes: bool = False,
 ) -> int:
     """Execute ``steps`` and record an analytics event."""
     start = time.time()
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    exit_code = execute_steps(steps, log_path=log_path)
+    exit_code = execute_steps(
+        steps, log_path=log_path, dry_run=dry_run, assume_yes=assume_yes
+    )
     end = time.time()
     data = {
         "exit_code": exit_code,
@@ -68,6 +72,8 @@ def run_recipe(
     analytics: bool = False,
     nats_url: str | None = None,
     jetstream: bool = False,
+    dry_run: bool = False,
+    assume_yes: bool = False,
 ) -> int:
     """Execute a recipe and record an analytics event."""
     if callable(steps_or_callable):
@@ -82,6 +88,8 @@ def run_recipe(
         payload={"recipe": name, "goal": goal, "step_count": len(steps)},
         nats_url=nats_url,
         jetstream=jetstream,
+        dry_run=dry_run,
+        assume_yes=assume_yes,
     )
 
 __all__ = ["record_event_logged", "run_steps", "run_recipe"]

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -25,13 +25,30 @@ def read_prompt(prompt: str) -> str:
     return prompt
 
 
-def execute_steps(steps: Iterable[str], *, log_path: Path) -> int:
-    """Interactively execute ``steps`` and write a log to ``log_path``."""
+def execute_steps(
+    steps: Iterable[str], *, log_path: Path, dry_run: bool = False, assume_yes: bool = False
+) -> int:
+    """Execute ``steps`` and write a log to ``log_path``.
+
+    When ``dry_run`` is ``True`` the commands are printed and logged without
+    being executed. If ``assume_yes`` is ``True`` all confirmation prompts are
+    skipped and commands run automatically.
+    """
     exit_code = 0
     for i, step in enumerate(steps, 1):
-        answer = input(f"{i}. {step} [y/N]?").strip().lower()
-        if answer != "y":
+        if dry_run:
+            print(f"{i}. {step}")
+            with log_path.open("a", encoding="utf-8") as log:
+                log.write(f"$ {step}\n(dry-run)\n\n")
             continue
+
+        if not assume_yes:
+            answer = input(f"{i}. {step} [y/N]?").strip().lower()
+            if answer != "y":
+                continue
+        else:
+            print(f"{i}. {step}")
+
         try:
             tokens = shlex.split(step)
         except ValueError:
@@ -46,9 +63,12 @@ def execute_steps(steps: Iterable[str], *, log_path: Path) -> int:
                 needs_shell = special_chars or shlex.join(tokens) != step
         cmd = step if needs_shell else tokens
         cmd_str = step if needs_shell else " ".join(tokens)
-        answer = input(f"Run command: {cmd_str} [y/N]?").strip().lower()
-        if answer != "y":
-            continue
+        if not assume_yes:
+            answer = input(f"Run command: {cmd_str} [y/N]?").strip().lower()
+            if answer != "y":
+                continue
+        else:
+            print(f"$ {cmd_str}")
         result = subprocess.run(cmd, shell=needs_shell, capture_output=True, text=True)
         with log_path.open("a", encoding="utf-8") as log:
             log.write(f"$ {step}\n")

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -65,6 +65,48 @@ def test_main_skips_when_declined(monkeypatch, tmp_path):
     assert not log.exists()
 
 
+def test_main_dry_run(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    def fail_run(*a, **k):
+        raise AssertionError("run called")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+    log = tmp_path / "log.txt"
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_do.main(["goal", "--log", str(log), "--dry-run"])
+    assert rc == 0
+    assert "echo hi" in out.getvalue()
+    assert "dry-run" in log.read_text()
+
+
+def test_main_yes_runs_without_prompts(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["echo hi"])
+
+    called = []
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        called.append(cmd)
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    def fail_input(_):  # pragma: no cover - should not be called
+        raise AssertionError("input called")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", fail_input)
+    log = tmp_path / "log.txt"
+    rc = ai_do.main(["goal", "--log", str(log), "--yes"])
+    assert rc == 0
+    assert called == [["echo", "hi"]]
+
+
 def test_main_returns_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["fail"])
 


### PR DESCRIPTION
## Summary
- support dry-run and auto-confirm in shared CLI utilities
- add `--dry-run` and `--yes/--confirm` flags to AI tooling
- test dry-run output and confirmation behavior

## Testing
- `ruff check scripts/ai_do.py scripts/cli_actions.py scripts/cli_common.py tests/test_ai_do.py`
- `ruff check scripts/ai_cli.py`
- `pytest tests/test_cli_common.py tests/test_ai_do.py tests/test_ai_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689bd30bfd2883268b874b4e2c1844cf