### PR TITLE
scoop: pin release archive and autoupdate

### DIFF
--- a/scoop/tino.json
+++ b/scoop/tino.json
@@ -3,6 +3,9 @@
     "description": "Bootstrap scripts and configuration for d0tTino",
     "homepage": "https://github.com/d0tTino/d0tTino",
     "license": "MIT",
-    "url": "https://github.com/d0tTino/d0tTino/archive/refs/heads/main.zip",
-    "hash": "57bdea58dd433f12a39c0cdcfe25182cf8fced8c0481cfe4ff935b7f15cbe7a1"
+    "url": "https://github.com/d0tTino/d0tTino/archive/refs/tags/v0.1.0.zip",
+    "hash": "b3527c54a0bb40be55939dd0416943dfa04139472cb8d800106ffa290b4ae3e6",
+    "autoupdate": {
+        "url": "https://github.com/d0tTino/d0tTino/archive/refs/tags/v$version.zip"
+    }
 }


### PR DESCRIPTION
## Summary
- point Scoop manifest to v0.1.0 release archive with matching SHA256
- keep autoupdate rule for future tags

## Testing
- `pre-commit run --files scoop/tino.json`
- `pytest tests/test_router_budget.py::test_budget_decrements_and_exhausts tests/test_router_budget.py::test_local_does_not_use_budget`
- `scoop install tino` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c943b60c483268c4b1d050aa85fd0