### PR TITLE
feat: add release automation

### DIFF
--- a/scoop/tino.json
+++ b/scoop/tino.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.1.0",
+    "version": "{{VERSION}}",
     "description": "Bootstrap scripts and configuration for d0tTino",
     "homepage": "https://github.com/d0tTino/d0tTino",
     "license": "MIT",
-    "url": "https://github.com/d0tTino/d0tTino/archive/refs/tags/v0.1.0.zip",
-    "hash": "b3527c54a0bb40be55939dd0416943dfa04139472cb8d800106ffa290b4ae3e6",
+    "url": "https://github.com/d0tTino/d0tTino/archive/refs/tags/v{{VERSION}}.zip",
+    "hash": "{{SHA256}}",
     "autoupdate": {
         "url": "https://github.com/d0tTino/d0tTino/archive/refs/tags/v$version.zip"
     }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Release helper to update manifests and publish.
+
+This script derives the latest version from git tags, regenerates the
+Winget and Scoop manifests with the correct download URLs and hashes and
+optionally publishes them to upstream repositories.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.request import urlopen
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def run(cmd: list[str]) -> None:
+    """Run a command and raise if it fails."""
+    subprocess.run(cmd, check=True)
+
+
+def latest_tag() -> str:
+    """Return the most recent git tag."""
+    return (
+        subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"], text=True)
+        .strip()
+    )
+
+
+def tag_version(tag: str) -> str:
+    """Strip a leading 'v' from the tag for the version field."""
+    return tag[1:] if tag.startswith("v") else tag
+
+
+def download_sha256(url: str) -> str:
+    """Download *url* and return its sha256 hex digest."""
+    with urlopen(url) as resp:  # nosec - url comes from our own repository
+        data = resp.read()
+    return hashlib.sha256(data).hexdigest()
+
+
+def update_winget(tag: str, version: str, sha: str) -> Path:
+    """Update the Winget manifest with the provided values."""
+    path = REPO / "winget" / "tino.yaml"
+    with path.open() as fh:
+        manifest = yaml.safe_load(fh)
+    manifest["PackageVersion"] = version
+    manifest["Installers"][0]["InstallerUrl"] = (
+        f"https://github.com/d0tTino/d0tTino/archive/refs/tags/{tag}.zip"
+    )
+    manifest["Installers"][0]["Sha256"] = sha
+    with path.open("w") as fh:
+        yaml.safe_dump(manifest, fh, sort_keys=False)
+    return path
+
+
+def update_scoop(tag: str, version: str, sha: str) -> Path:
+    """Update the Scoop manifest with the provided values."""
+    path = REPO / "scoop" / "tino.json"
+    with path.open() as fh:
+        manifest = json.load(fh)
+    manifest["version"] = version
+    manifest["url"] = (
+        f"https://github.com/d0tTino/d0tTino/archive/refs/tags/{tag}.zip"
+    )
+    manifest["hash"] = sha
+    with path.open("w") as fh:
+        json.dump(manifest, fh, indent=4)
+        fh.write("\n")
+    return path
+
+
+def publish_winget(manifest: Path, token: str) -> None:
+    """Submit the manifest to the Winget upstream repository.
+
+    Requires the `wingetcreate` tool and a GitHub PAT passed in *token*.
+    """
+    run(["wingetcreate", "submit", str(manifest), "-t", token])
+
+
+def publish_scoop(manifest: Path, repo_url: str) -> None:
+    """Commit the manifest to a Scoop bucket repository specified by *repo_url*."""
+    with tempfile.TemporaryDirectory() as tmp:
+        run(["git", "clone", repo_url, tmp])
+        dest = Path(tmp) / "bucket" / manifest.name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(manifest, dest)
+        run(["git", "-C", tmp, "add", str(dest.relative_to(tmp))])
+        run(["git", "-C", tmp, "commit", "-m", f"Update {manifest.name}"])
+        run(["git", "-C", tmp, "push"])
+
+
+def main() -> None:
+    tag = latest_tag()
+    version = tag_version(tag)
+    url = f"https://github.com/d0tTino/d0tTino/archive/refs/tags/{tag}.zip"
+    sha = download_sha256(url)
+
+    winget_path = update_winget(tag, version, sha)
+    scoop_path = update_scoop(tag, version, sha)
+
+    token = os.environ.get("WINGET_TOKEN")
+    if token:
+        publish_winget(winget_path, token)
+    else:
+        print("WINGET_TOKEN not set; skipping Winget publish")
+
+    repo_url = os.environ.get("SCOOP_BUCKET")
+    if repo_url:
+        publish_scoop(scoop_path, repo_url)
+    else:
+        print("SCOOP_BUCKET not set; skipping Scoop publish")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -1,4 +1,6 @@
 import importlib
+import sys
+
 import pytest
 
 
@@ -6,16 +8,15 @@ import pytest
 def reset_router(monkeypatch):
     yield
     monkeypatch.delenv("LLM_ROUTER_BUDGET", raising=False)
-    import llm.router as router
-    importlib.reload(router)
+    sys.modules.pop("llm.router", None)
+    importlib.import_module("llm.router")
 
 
 def _reload_router(monkeypatch, budget: str = "1"):
     monkeypatch.setenv("LLM_ROUTER_BUDGET", budget)
     monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
-    import llm.router as router
-    importlib.reload(router)
-    return router
+    sys.modules.pop("llm.router", None)
+    return importlib.import_module("llm.router")
 
 
 def test_budget_decrements_and_exhausts(monkeypatch):

--- a/winget/tino.yaml
+++ b/winget/tino.yaml
@@ -1,5 +1,6 @@
 PackageIdentifier: Tino.d0tTino
-PackageVersion: 1.0.0
+# The release script fills in version and installer metadata from the latest git tag
+PackageVersion: "{{VERSION}}"
 PackageLocale: en-US
 Publisher: d0tTino
 PackageName: d0tTino
@@ -9,7 +10,7 @@ PackageUrl: https://github.com/d0tTino/d0tTino
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/d0tTino/d0tTino/archive/refs/tags/v1.0.0.zip
-    Sha256: 5fd81a8bbd03bc12bd83f78a67bfcc469fbc969a6bbe3e2f819593170ccbe2d3
+    InstallerUrl: https://github.com/d0tTino/d0tTino/archive/refs/tags/v{{VERSION}}.zip
+    Sha256: "{{SHA256}}"
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- derive Winget and Scoop manifest values from git tags
- add release script to regenerate manifests and submit upstream
- reload router module cleanly in tests to ensure reliable budget checks

## Testing
- `ruff check scripts/release.py tests/test_router_budget.py`
- `pytest tests/test_api_routes.py::test_prompt_event_loop_not_blocked tests/test_api_routes.py::test_plan_event_loop_not_blocked tests/test_router_budget.py::test_budget_decrements_and_exhausts tests/test_router_budget.py::test_local_does_not_use_budget -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd81e3c20832697ef76e627eb4b0b