### PR TITLE
feat: diff-aware planning with risk confirmation

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -17,6 +17,7 @@ from llm.backends import initialize
 import asyncio
 from scripts import ai_exec, recipes, plugins, query_sources, nsm_stats
 from scripts.cli_common import (
+    PlanStep,
     read_prompt,
     build_analytics_parser,
 )
@@ -100,7 +101,7 @@ def _cmd_send(args: argparse.Namespace) -> int:
 
 def _clarify_goal(
     goal: str, *, config, analytics: bool
-) -> tuple[str, List[str]]:
+) -> tuple[str, List[PlanStep]]:
     """Request clarification from the user until planning succeeds.
 
     ``ai_exec.plan`` may return an empty list when the goal is ambiguous or
@@ -122,8 +123,10 @@ def _cmd_plan(args: argparse.Namespace) -> int:
     goal, steps = _clarify_goal(
         args.goal, config=args.config, analytics=args.analytics
     )
-    for i, step in enumerate(steps, 1):
-        print(f"{i}. {step}")
+    for step in steps:
+        print(f"{step.number}. {step.command}")
+        if step.diff:
+            print(step.diff)
 
     end = time.time()
     _publish_event(
@@ -155,6 +158,8 @@ def _cmd_do(args: argparse.Namespace) -> int:
         kwargs["dry_run"] = True
     if getattr(args, "yes", False):
         kwargs["assume_yes"] = True
+    if getattr(args, "confirm", False):
+        kwargs["confirm"] = True
     return cli_actions.run_steps("ai-cli-do", steps, **kwargs)
 
 
@@ -176,6 +181,8 @@ def _cmd_recipe(args: argparse.Namespace) -> int:
         kwargs["dry_run"] = True
     if getattr(args, "yes", False):
         kwargs["assume_yes"] = True
+    if getattr(args, "confirm", False):
+        kwargs["confirm"] = True
     exit_code = cli_actions.run_recipe(args.name, args.goal, steps, **kwargs)
     end = time.time()
     if exit_code == 0:
@@ -518,10 +525,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     do.add_argument(
         "--yes",
-        "--confirm",
-        dest="yes",
         action="store_true",
-        help="Run without interactive prompts",
+        help="Run without interactive prompts for non-risky commands",
+    )
+    do.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Also run commands tagged [risk:*] without prompting",
     )
     do.set_defaults(func=_cmd_do)
 
@@ -546,10 +556,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     recipe.add_argument(
         "--yes",
-        "--confirm",
-        dest="yes",
         action="store_true",
-        help="Run without interactive prompts",
+        help="Run without interactive prompts for non-risky commands",
+    )
+    recipe.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Also run commands tagged [risk:*] without prompting",
     )
     recipe.set_defaults(func=_cmd_recipe)
 

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -61,10 +61,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
     parser.add_argument(
         "--yes",
-        "--confirm",
-        dest="yes",
         action="store_true",
-        help="Run without interactive prompts",
+        help="Run without interactive prompts for non-risky commands",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Also run commands tagged [risk:*] without prompting",
     )
     args = parser.parse_args(argv)
 
@@ -84,6 +87,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         nats_url=args.nats_url if hasattr(args, "nats_url") else None,
         dry_run=args.dry_run,
         assume_yes=args.yes,
+        confirm=args.confirm,
     )
     if args.notify:
         if exit_code == 0:

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -16,6 +16,7 @@ from llm import router
 from llm.ai_router import get_preferred_models
 from llm.backends import initialize
 from scripts.cli_common import (
+    PlanStep,
     read_prompt,
     send_notification,
     build_analytics_parser,
@@ -56,9 +57,34 @@ def last_model_remote() -> bool:
 
 initialize()
 
+def _parse_steps(text: str) -> List[PlanStep]:
+    """Return a list of :class:`PlanStep` objects from ``text``."""
+
+    steps: List[PlanStep] = []
+    current: Optional[str] = None
+    diff_lines: List[str] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith((" ", "+", "-", "@", "diff", "---", "+++")) and current:
+            diff_lines.append(line)
+            continue
+        if current is not None:
+            steps.append(
+                PlanStep(len(steps) + 1, _tag_risky(current), "\n".join(diff_lines) or None)
+            )
+            diff_lines = []
+        current = line.strip()
+    if current is not None:
+        steps.append(
+            PlanStep(len(steps) + 1, _tag_risky(current), "\n".join(diff_lines) or None)
+        )
+    return steps
+
+
 def plan(
     goal: str, *, config_path: Optional[Path] = None, analytics: bool = False
-) -> List[str]:
+) -> List[PlanStep]:
     """Return planning steps for ``goal`` using preferred models."""
     global _LAST_MODEL_REMOTE
     start = time.time()
@@ -68,7 +94,7 @@ def plan(
     )
     used_remote = True
     exit_code = 0
-    steps: List[str] = []
+    steps: List[PlanStep] = []
     try:
         try:
             text = router.run_gemini(goal, model=primary)
@@ -76,7 +102,7 @@ def plan(
             used_remote = False
             text = router.run_ollama(goal, model=fallback or router.DEFAULT_MODEL)
 
-        steps = [_tag_risky(line.strip()) for line in text.splitlines() if line.strip()]
+        steps = _parse_steps(text)
         return steps
     except Exception:
         exit_code = 1
@@ -110,7 +136,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     goal = read_prompt(args.goal)
     steps = plan(goal, config_path=cfg_path, analytics=args.analytics)
     for step in steps:
-        print(step)
+        print(f"{step.number}. {step.command}")
+        if step.diff:
+            print(step.diff)
     if args.notify:
         send_notification("ai-plan completed")
     return 0

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -9,7 +9,7 @@ from typing import Iterable, Callable, Sequence, Any
 
 from ume import events as ume_events
 
-from scripts.cli_common import execute_steps
+from scripts.cli_common import PlanStep, execute_steps
 from telemetry import record_event
 from ume.events import publish_event_sync
 
@@ -24,7 +24,7 @@ def record_event_logged(name: str, payload: dict[str, Any], *, enabled: bool = F
 
 def run_steps(
     event_name: str,
-    steps: Iterable[str],
+    steps: Iterable[PlanStep],
     *,
     log_path: Path,
     analytics: bool = False,
@@ -34,12 +34,13 @@ def run_steps(
     jetstream: bool = False,
     dry_run: bool = False,
     assume_yes: bool = False,
+    confirm: bool = False,
 ) -> int:
     """Execute ``steps`` and record an analytics event."""
     start = time.time()
     log_path.parent.mkdir(parents=True, exist_ok=True)
     exit_code = execute_steps(
-        steps, log_path=log_path, dry_run=dry_run, assume_yes=assume_yes
+        steps, log_path=log_path, dry_run=dry_run, assume_yes=assume_yes, confirm=confirm
     )
     end = time.time()
     data = {
@@ -74,12 +75,14 @@ def run_recipe(
     jetstream: bool = False,
     dry_run: bool = False,
     assume_yes: bool = False,
+    confirm: bool = False,
 ) -> int:
     """Execute a recipe and record an analytics event."""
     if callable(steps_or_callable):
-        steps = list(steps_or_callable(goal))
+        raw_steps = list(steps_or_callable(goal))
     else:
-        steps = list(steps_or_callable)
+        raw_steps = list(steps_or_callable)
+    steps = [PlanStep(i + 1, s) for i, s in enumerate(raw_steps)]
     return run_steps(
         "ai-do-recipe",
         steps,
@@ -90,6 +93,7 @@ def run_recipe(
         jetstream=jetstream,
         dry_run=dry_run,
         assume_yes=assume_yes,
+        confirm=confirm,
     )
 
 __all__ = ["record_event_logged", "run_steps", "run_recipe"]

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -11,8 +11,9 @@ import os
 import shlex
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 import requests  # noqa: F401 -- imported for backward-compatibility
 from telemetry import analytics_default, record_event
@@ -25,45 +26,76 @@ def read_prompt(prompt: str) -> str:
     return prompt
 
 
+@dataclass
+class PlanStep:
+    """Single planned step with an optional diff preview."""
+
+    number: int
+    command: str
+    diff: Optional[str] = None
+
+
+def _strip_risk_tag(command: str) -> str:
+    """Return ``command`` without any ``[risk:*]`` suffix."""
+
+    if " [risk:" in command:
+        return command.rsplit(" [risk:", 1)[0]
+    return command
+
+
 def execute_steps(
-    steps: Iterable[str], *, log_path: Path, dry_run: bool = False, assume_yes: bool = False
+    steps: Iterable[PlanStep],
+    *,
+    log_path: Path,
+    dry_run: bool = False,
+    assume_yes: bool = False,
+    confirm: bool = False,
 ) -> int:
     """Execute ``steps`` and write a log to ``log_path``.
 
     When ``dry_run`` is ``True`` the commands are printed and logged without
     being executed. If ``assume_yes`` is ``True`` all confirmation prompts are
-    skipped and commands run automatically.
+    skipped for non-risky commands. Commands tagged with ``[risk:*]`` require the
+    ``confirm`` flag to run without prompting.
     """
     exit_code = 0
-    for i, step in enumerate(steps, 1):
+    for step in steps:
+        is_risky = "[risk:" in step.command
+        step_assume_yes = assume_yes and (confirm or not is_risky)
         if dry_run:
-            print(f"{i}. {step}")
+            print(f"{step.number}. {step.command}")
+            if step.diff:
+                print(step.diff)
             with log_path.open("a", encoding="utf-8") as log:
-                log.write(f"$ {step}\n(dry-run)\n\n")
+                log.write(f"$ {step.command}\n")
+                if step.diff:
+                    log.write(f"{step.diff}\n")
+                log.write("(dry-run)\n\n")
             continue
 
-        if not assume_yes:
-            answer = input(f"{i}. {step} [y/N]?").strip().lower()
+        if not step_assume_yes:
+            answer = input(f"{step.number}. {step.command} [y/N]?").strip().lower()
             if answer != "y":
                 continue
         else:
-            print(f"{i}. {step}")
+            print(f"{step.number}. {step.command}")
 
+        cmd_text = _strip_risk_tag(step.command)
         try:
-            tokens = shlex.split(step)
+            tokens = shlex.split(cmd_text)
         except ValueError:
             tokens = []
             needs_shell = True
         else:
-            special_chars = any(ch in step for ch in "|&;><$`")
+            special_chars = any(ch in cmd_text for ch in "|&;><$`")
             if os.name == "nt":
                 # ``shlex.join`` uses POSIX quoting which breaks on Windows.
                 needs_shell = special_chars
             else:
-                needs_shell = special_chars or shlex.join(tokens) != step
-        cmd = step if needs_shell else tokens
-        cmd_str = step if needs_shell else " ".join(tokens)
-        if not assume_yes:
+                needs_shell = special_chars or shlex.join(tokens) != cmd_text
+        cmd = cmd_text if needs_shell else tokens
+        cmd_str = cmd_text if needs_shell else " ".join(tokens)
+        if not step_assume_yes:
             answer = input(f"Run command: {cmd_str} [y/N]?").strip().lower()
             if answer != "y":
                 continue
@@ -71,7 +103,7 @@ def execute_steps(
             print(f"$ {cmd_str}")
         result = subprocess.run(cmd, shell=needs_shell, capture_output=True, text=True)
         with log_path.open("a", encoding="utf-8") as log:
-            log.write(f"$ {step}\n")
+            log.write(f"$ {step.command}\n")
             if result.stdout:
                 log.write(result.stdout)
             if result.stderr:
@@ -111,4 +143,5 @@ __all__ = [
     "build_analytics_parser",
     "analytics_default",
     "record_event",
+    "PlanStep",
 ]

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -7,6 +7,7 @@ pytest.importorskip("requests")
 
 from scripts import ai_cli
 from scripts import cli_actions
+from scripts.cli_common import PlanStep
 import telemetry
 
 
@@ -29,7 +30,7 @@ def test_plan_subcommand(monkeypatch):
     def fake_plan(goal: str, *, config_path=None, analytics=False):
         assert goal == "goal"
         assert config_path == "cfg.json"
-        return ["one", "two"]
+        return [PlanStep(1, "one"), PlanStep(2, "two")]
 
     monkeypatch.setattr(ai_cli.ai_exec, "plan", fake_plan)
     out = io.StringIO()
@@ -41,7 +42,7 @@ def test_plan_subcommand(monkeypatch):
 
 
 def test_do_subcommand(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi")])
 
     inputs = iter(["y", "y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
@@ -64,7 +65,7 @@ def test_do_subcommand(monkeypatch, tmp_path):
 
 
 def test_do_creates_log_dir(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi")])
     monkeypatch.setattr("builtins.input", lambda _: "y")
 
     class Result:
@@ -86,7 +87,7 @@ def test_plan_requests_clarification(monkeypatch):
 
     def fake_plan(goal: str, *, config_path=None, analytics=False):
         calls.append(goal)
-        return [] if len(calls) == 1 else [f"echo {goal}"]
+        return [] if len(calls) == 1 else [PlanStep(1, f"echo {goal}")]
 
     monkeypatch.setattr(ai_cli.ai_exec, "plan", fake_plan)
     monkeypatch.setattr("builtins.input", lambda _: "more info")
@@ -104,7 +105,7 @@ def test_do_requests_clarification(monkeypatch):
 
     def fake_plan(goal: str, *, config_path=None, analytics=False):
         calls.append(goal)
-        return [] if len(calls) == 1 else [f"echo {goal}"]
+        return [] if len(calls) == 1 else [PlanStep(1, f"echo {goal}")]
 
     monkeypatch.setattr(ai_cli.ai_exec, "plan", fake_plan)
     captured = {}
@@ -119,7 +120,7 @@ def test_do_requests_clarification(monkeypatch):
     rc = ai_cli.main(["do", "goal"])
     assert rc == 0
     assert calls == ["goal", "goal. extra detail"]
-    assert captured["steps"] == ["echo goal. extra detail"]
+    assert captured["steps"] == [PlanStep(1, "echo goal. extra detail")]
 
 
 def test_clarify_goal_prompts_user(monkeypatch):
@@ -127,14 +128,14 @@ def test_clarify_goal_prompts_user(monkeypatch):
 
     def fake_plan(goal: str, *, config_path=None, analytics=False):
         calls.append(goal)
-        return [] if len(calls) == 1 else [f"echo {goal}"]
+        return [] if len(calls) == 1 else [PlanStep(1, f"echo {goal}")]
 
     monkeypatch.setattr(ai_cli.ai_exec, "plan", fake_plan)
     monkeypatch.setattr("builtins.input", lambda _: "details")
     goal, steps = ai_cli._clarify_goal("goal", config=None, analytics=False)
     assert calls == ["goal", "goal. details"]
     assert goal == "goal. details"
-    assert steps == ["echo goal. details"]
+    assert steps == [PlanStep(1, "echo goal. details")]
 
 
 def test_send_records_event(monkeypatch):
@@ -155,7 +156,7 @@ def test_send_records_event(monkeypatch):
 
 
 def test_plan_records_event(monkeypatch):
-    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["one"])
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "one")])
     recorded = []
 
     def fake_record(name, payload, *, enabled=False):
@@ -177,7 +178,7 @@ def test_plan_records_event(monkeypatch):
 
 
 def test_do_records_event(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi")])
     inputs = iter(["y", "y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
@@ -209,7 +210,7 @@ def test_do_records_event(monkeypatch, tmp_path):
 
 
 def test_do_records_failure(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["bad"])
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "bad")])
     inputs = iter(["y", "y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
@@ -401,7 +402,7 @@ def test_plan_posts_event(monkeypatch):
     monkeypatch.setenv("EVENTS_URL", "https://example.com")
     monkeypatch.setenv("EVENTS_TOKEN", "tok")
     monkeypatch.setenv("USER", "alice")
-    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["one"])
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "one")])
     sent = {}
 
     def fake_post(url, headers=None, json=None, timeout=None):
@@ -430,7 +431,7 @@ def test_do_posts_event(monkeypatch, tmp_path):
     monkeypatch.setenv("EVENTS_URL", "https://example.com")
     monkeypatch.setenv("EVENTS_TOKEN", "tok")
     monkeypatch.setenv("USER", "alice")
-    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi")])
     monkeypatch.setattr("builtins.input", lambda _: "y")
 
     class Result:
@@ -465,7 +466,7 @@ def test_do_posts_event(monkeypatch, tmp_path):
 
 
 def test_plan_nats_publish(monkeypatch):
-    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: ["one"])
+    monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "one")])
     published = []
 
     def fake_publish(url, name, payload):

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -7,13 +7,14 @@ import pytest
 pytest.importorskip("requests")
 
 from scripts import ai_do, ai_exec, cli_actions
+from scripts.cli_common import PlanStep
 
 
 def test_main_runs_and_logs(monkeypatch, tmp_path):
     def fake_plan(goal: str, *, config_path=None, analytics=False):
         assert goal == "goal"
         assert config_path is None
-        return ["cmd1", "cmd2"]
+        return [PlanStep(1, "cmd1"), PlanStep(2, "cmd2")]
 
     monkeypatch.setattr(ai_exec, "plan", fake_plan)
 
@@ -47,7 +48,7 @@ def test_main_runs_and_logs(monkeypatch, tmp_path):
 
 
 def test_main_skips_when_declined(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["cmd"])
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [PlanStep(1, "cmd")])
     monkeypatch.setattr("builtins.input", lambda _: "n")
     run_called = False
 
@@ -66,7 +67,11 @@ def test_main_skips_when_declined(monkeypatch, tmp_path):
 
 
 def test_main_dry_run(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr(
+        ai_exec,
+        "plan",
+        lambda *a, **k: [PlanStep(1, "echo hi", diff="--- a\n+++ b\n+hi")],
+    )
     def fail_run(*a, **k):
         raise AssertionError("run called")
 
@@ -76,12 +81,13 @@ def test_main_dry_run(monkeypatch, tmp_path):
     with contextlib.redirect_stdout(out):
         rc = ai_do.main(["goal", "--log", str(log), "--dry-run"])
     assert rc == 0
-    assert "echo hi" in out.getvalue()
+    assert "1. echo hi" in out.getvalue()
+    assert "--- a" in out.getvalue()
     assert "dry-run" in log.read_text()
 
 
 def test_main_yes_runs_without_prompts(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi")])
 
     called = []
 
@@ -107,8 +113,57 @@ def test_main_yes_runs_without_prompts(monkeypatch, tmp_path):
     assert called == [["echo", "hi"]]
 
 
+def test_risky_requires_confirm(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        ai_exec, "plan", lambda *a, **k: [PlanStep(1, "rm -rf / [risk:rm]")]
+    )
+    prompts = []
+
+    def fake_input(prompt):
+        prompts.append(prompt)
+        return "n"
+
+    def fail_run(*a, **k):
+        raise AssertionError("should not run")
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr(subprocess, "run", fail_run)
+    log = tmp_path / "log.txt"
+    rc = ai_do.main(["goal", "--log", str(log), "--yes"])
+    assert rc == 0
+    assert prompts  # prompted despite --yes
+
+
+def test_confirm_allows_risky(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi [risk:rm]")]
+    )
+    called = []
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        called.append(cmd)
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    def fail_input(_):  # pragma: no cover - should not be called
+        raise AssertionError("input called")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", fail_input)
+    log = tmp_path / "log.txt"
+    rc = ai_do.main(["goal", "--log", str(log), "--yes", "--confirm"])
+    assert rc == 0
+    assert called == [["echo", "hi"]]
+
+
 def test_main_returns_failure(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["fail"])
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [PlanStep(1, "fail")])
 
     class Result:
         def __init__(self):
@@ -132,7 +187,7 @@ def test_main_returns_failure(monkeypatch, tmp_path):
 
 
 def test_main_confirms_and_sanitizes(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["echo hi"])
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi")])
 
     prompts = []
     inputs = iter(["y", "y"])
@@ -203,7 +258,7 @@ def test_main_records_event(monkeypatch, tmp_path):
 
 
 def test_main_records_failure(monkeypatch, tmp_path):
-    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: ["bad"])
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [PlanStep(1, "bad")])
     inputs = iter(["y", "y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -11,6 +11,7 @@ from pathlib import Path
 pytest.importorskip("requests")
 
 from scripts import ai_exec, cli_actions
+from scripts.cli_common import PlanStep
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -30,7 +31,7 @@ def test_plan_uses_primary(monkeypatch):
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
 
     steps = ai_exec.plan("goal")
-    assert steps == ["step1", "step2"]
+    assert [s.command for s in steps] == ["step1", "step2"]
     assert calls == [("gemini", "goal", "g")]
 
 
@@ -50,7 +51,7 @@ def test_plan_falls_back(monkeypatch):
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
 
     steps = ai_exec.plan("goal")
-    assert steps == ["fallback"]
+    assert [s.command for s in steps] == ["fallback"]
     assert calls == [
         ("gemini", "goal", "g"),
         ("ollama", "goal", "o"),
@@ -61,14 +62,14 @@ def test_main_invokes_plan(monkeypatch):
     def mock_plan(goal: str, *, config_path=None, analytics=False):
         assert goal == "goal"
         assert str(config_path) == "cfg.json"
-        return ["one", "two"]
+        return [PlanStep(1, "one"), PlanStep(2, "two")]
 
     monkeypatch.setattr(ai_exec, "plan", mock_plan)
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
         rc = ai_exec.main(["goal", "--config", "cfg.json"])
     assert rc == 0
-    assert out.getvalue().splitlines() == ["one", "two"]
+    assert out.getvalue().splitlines() == ["1. one", "2. two"]
 
 
 def test_main_notifies(monkeypatch):
@@ -96,7 +97,7 @@ def test_plan_records_event(monkeypatch):
 
     monkeypatch.setattr(cli_actions, "record_event_logged", fake_record)
     steps = ai_exec.plan("goal", analytics=True)
-    assert steps == ["step"]
+    assert [s.command for s in steps] == ["step"]
     name, payload, enabled = recorded[0]
     assert name == "ai-exec-plan"
     assert enabled is True
@@ -111,7 +112,7 @@ def test_plan_tags_risky_commands(monkeypatch):
     monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
     steps = ai_exec.plan("goal")
-    assert steps == ["rm -rf / [risk:rm]", "ls"]
+    assert [s.command for s in steps] == ["rm -rf / [risk:rm]", "ls"]
 
 
 def test_plan_tags_sudo_commands(monkeypatch):
@@ -121,7 +122,19 @@ def test_plan_tags_sudo_commands(monkeypatch):
     monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
     steps = ai_exec.plan("goal")
-    assert steps == ["sudo reboot now [risk:reboot]", "ls"]
+    assert [s.command for s in steps] == ["sudo reboot now [risk:reboot]", "ls"]
+
+
+def test_plan_parses_diffs(monkeypatch):
+    monkeypatch.setattr(
+        ai_exec.router,
+        "run_gemini",
+        lambda *a, **k: "echo hi\n--- a.txt\n+++ b.txt\n+hi",
+    )
+    monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
+    monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
+    steps = ai_exec.plan("goal")
+    assert steps[0].diff == "--- a.txt\n+++ b.txt\n+hi"
 
 
 def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
@@ -163,7 +176,7 @@ def test_script_runs(monkeypatch, tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0
-    assert result.stdout.splitlines() == ["step1", "step2"]
+    assert result.stdout.splitlines() == ["1. step1", "2. step2"]
 
 
 def test_last_model_remote_thread_safety(monkeypatch):
@@ -187,7 +200,7 @@ def test_last_model_remote_thread_safety(monkeypatch):
 
     def run(goal):
         steps = ai_exec.plan(goal)
-        results[goal] = (steps, ai_exec.last_model_remote())
+        results[goal] = ([s.command for s in steps], ai_exec.last_model_remote())
 
     t_remote = threading.Thread(target=run, args=("remote",))
     t_local = threading.Thread(target=run, args=("local",))
@@ -218,6 +231,6 @@ def test_main_env_enables_analytics(monkeypatch):
     with contextlib.redirect_stdout(out):
         rc = ai_exec.main(["goal"])
     assert rc == 0
-    assert out.getvalue().splitlines() == ["step"]
+    assert out.getvalue().splitlines() == ["1. step"]
     assert recorded == [True]
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -266,9 +266,8 @@ async def test_exec_stream_return_type(monkeypatch, tmp_path):
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_prompt_event_loop_not_blocked(monkeypatch, tmp_path, anyio_backend):
-    if anyio_backend != "asyncio":
-        pytest.skip("asyncio backend only")
     app = load_app(state_path=tmp_path / 'state.json')
     api = importlib.import_module('api')
 
@@ -294,9 +293,8 @@ async def test_prompt_event_loop_not_blocked(monkeypatch, tmp_path, anyio_backen
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_plan_event_loop_not_blocked(monkeypatch, tmp_path, anyio_backend):
-    if anyio_backend != "asyncio":
-        pytest.skip("asyncio backend only")
     monkeypatch.setattr(ai_exec, 'plan', lambda goal: ['step'])
     app = load_app(state_path=tmp_path / 'state.json')
 

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -3,6 +3,7 @@ import uuid
 
 pytest.importorskip("requests")
 from scripts import cli_common
+from scripts.cli_common import PlanStep
 
 
 def test_record_event_skips_when_disabled(monkeypatch):
@@ -120,7 +121,9 @@ def test_execute_steps_parses_quoted_args(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
 
-    cli_common.execute_steps(["echo 'foo bar'"], log_path=tmp_path / "log.txt")
+    cli_common.execute_steps(
+        [PlanStep(1, "echo 'foo bar'")], log_path=tmp_path / "log.txt"
+    )
 
     assert captured["cmd"] == ["echo", "foo bar"]
     assert captured["shell"] is False
@@ -146,7 +149,9 @@ def test_execute_steps_fallbacks_to_shell(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
 
-    cli_common.execute_steps(["python -c \"print('hi')\""], log_path=tmp_path / "log.txt")
+    cli_common.execute_steps(
+        [PlanStep(1, "python -c \"print('hi')\"")], log_path=tmp_path / "log.txt"
+    )
 
     assert captured["cmd"] == "python -c \"print('hi')\""
     assert captured["shell"] is True
@@ -173,9 +178,10 @@ def test_execute_steps_windows_path(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
     monkeypatch.setattr(cli_common.os, "name", "nt")
 
-    cli_common.execute_steps([
-        '"C:\\Program Files\\Foo Bar\\tool.exe" arg'
-    ], log_path=tmp_path / "log.txt")
+    cli_common.execute_steps(
+        [PlanStep(1, '"C:\\Program Files\\Foo Bar\\tool.exe" arg')],
+        log_path=tmp_path / "log.txt",
+    )
 
     assert captured["cmd"] == ["C:\\Program Files\\Foo Bar\\tool.exe", "arg"]
     assert captured["shell"] is False

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -1,4 +1,5 @@
 import importlib
+import sys
 import pytest
 
 
@@ -6,14 +7,16 @@ import pytest
 def reset_router(monkeypatch):
     yield
     monkeypatch.delenv("LLM_ROUTER_BUDGET", raising=False)
-    import llm.router as router
+    sys.modules.pop("llm.router", None)
+    router = importlib.import_module("llm.router")
     importlib.reload(router)
 
 
 def _reload_router(monkeypatch, budget: str = "1"):
     monkeypatch.setenv("LLM_ROUTER_BUDGET", budget)
     monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
-    import llm.router as router
+    sys.modules.pop("llm.router", None)
+    router = importlib.import_module("llm.router")
     importlib.reload(router)
     return router
 


### PR DESCRIPTION
## Summary
- support numbered plan steps with optional diff previews
- display step diffs during dry runs and strip risk tags before execution
- require explicit `--confirm` before automatically running risky commands
- stabilize tests by limiting API route tests to the asyncio backend and resetting router state cleanly

## Testing
- `ruff check tests/test_api_routes.py tests/test_router_budget.py`
- `pytest tests/test_api_routes.py::test_prompt_event_loop_not_blocked tests/test_api_routes.py::test_plan_event_loop_not_blocked tests/test_router_budget.py -q`
- `pytest -q` (341 passed, 28 skipped)


------
https://chatgpt.com/codex/tasks/task_e_689cd81f231c8326b4a06ab1cb55472e