### PR TITLE
Add MCP plugin adapter and CLI flag

### DIFF
--- a/plugins/mcp.py
+++ b/plugins/mcp.py
@@ -1,0 +1,31 @@
+"""MCP adapter exposing registered tools."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Dict
+
+from .utils import discover_entry_points
+
+__all__ = ["iter_tools", "get_tools"]
+
+
+ENTRY_POINT_GROUP = "d0ttino.tools"
+
+
+def iter_tools() -> Iterator[tuple[str, Any]]:
+    """Yield ``(name, tool)`` for each registered MCP tool.
+
+    Tools are discovered from the :data:`ENTRY_POINT_GROUP` entry point
+    group. Any entry point that fails to load is skipped.
+    """
+    for ep in discover_entry_points(ENTRY_POINT_GROUP):
+        try:
+            yield ep.name, ep.load()
+        except Exception:  # pragma: no cover - best effort loading
+            continue
+
+
+def get_tools() -> Dict[str, Any]:
+    """Return a mapping of MCP tool names to loaded objects."""
+    return {name: tool for name, tool in iter_tools()}

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -474,6 +474,13 @@ def build_parser() -> argparse.ArgumentParser:
     analytics = build_analytics_parser()
 
     analytics.add_argument(
+        "--enable-mcp",
+        action="store_true",
+        dest="enable_mcp",
+        help="Load MCP plug-ins exposing additional tools",
+    )
+
+    analytics.add_argument(
         "--nats-url",
         dest="nats_url",
         default=None,
@@ -697,6 +704,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     args.analytics = getattr(args, "analytics", analytics_default())
+    if getattr(args, "enable_mcp", False):
+        try:
+            mcp = importlib.import_module("plugins.mcp")
+            mcp.get_tools()
+        except Exception as exc:  # noqa: BLE001
+            logging.debug("Failed to load MCP plug-ins: %s", exc)
     return args.func(args)
 
 

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,0 +1,59 @@
+import importlib.metadata
+import sys
+import types
+
+from plugins import mcp
+
+
+def test_mcp_adapter_exposes_registered_tools(monkeypatch):
+    module = types.ModuleType("dummy_tool_mod")
+
+    def tool_func():
+        return "ok"
+
+    module.tool = tool_func
+    monkeypatch.setitem(sys.modules, "dummy_tool_mod", module)
+
+    entry = importlib.metadata.EntryPoint(
+        name="dummy", value="dummy_tool_mod:tool", group="d0ttino.tools"
+    )
+    monkeypatch.setattr(mcp, "discover_entry_points", lambda group: iter([entry]))
+
+    tools = mcp.get_tools()
+    assert tools["dummy"] is tool_func
+
+
+def test_ai_cli_flag_enables_mcp(monkeypatch, tmp_path):
+    from scripts import ai_cli
+
+    monkeypatch.setattr(ai_cli, "SESSION_FILE", tmp_path / "session.json")
+    monkeypatch.setattr(ai_cli.cli_actions, "record_event_logged", lambda *a, **k: None)
+
+    called = {"value": False}
+
+    def fake_get_tools():
+        called["value"] = True
+        return {}
+
+    monkeypatch.setattr(mcp, "get_tools", fake_get_tools)
+
+    ai_cli.main(["login", "user", "--enable-mcp"])
+    assert called["value"]
+
+
+def test_ai_cli_does_not_enable_mcp_without_flag(monkeypatch, tmp_path):
+    from scripts import ai_cli
+
+    monkeypatch.setattr(ai_cli, "SESSION_FILE", tmp_path / "session.json")
+    monkeypatch.setattr(ai_cli.cli_actions, "record_event_logged", lambda *a, **k: None)
+
+    called = {"value": False}
+
+    def fake_get_tools():
+        called["value"] = True
+        return {}
+
+    monkeypatch.setattr(mcp, "get_tools", fake_get_tools)
+
+    ai_cli.main(["login", "user"])
+    assert not called["value"]


### PR DESCRIPTION
## Summary
- expose entry-point based MCP tools via new plugins.mcp module
- add `--enable-mcp` flag to ai_cli to load MCP plugins
- cover MCP tool discovery, CLI integration, and flag default behavior with tests

## Testing
- `python -m ruff check plugins/mcp.py scripts/ai_cli.py tests/test_mcp_adapter.py`
- `pytest tests/test_mcp_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d00d298c88326a8e0d0f1d5d95cad