### PR TITLE
Add status subcommand to AI CLI

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -262,6 +262,15 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_status(args: argparse.Namespace) -> int:
+    """Show remaining budget and routing mode."""
+    budget = router.get_budget()
+    mode = os.environ.get("LLM_ROUTING_MODE", "auto")
+    print(f"Budget remaining: {budget}")
+    print(f"Routing mode: {mode}")
+    return 0
+
+
 def _cmd_finance_analyze(args: argparse.Namespace) -> int:
     payload: dict[str, Any] = {
         "workflow": "FinancialDecisionSupport",
@@ -675,6 +684,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Filter by tag (repeatable)",
     )
     sources.set_defaults(func=_cmd_sources)
+
+    status = sub.add_parser(
+        "status",
+        help="Show remaining budget and routing mode",
+        parents=[analytics],
+    )
+    status.set_defaults(func=_cmd_status)
 
     stats = sub.add_parser(
         "stats",

--- a/tests/test_ai_cli_status.py
+++ b/tests/test_ai_cli_status.py
@@ -1,0 +1,25 @@
+import contextlib
+import importlib
+import io
+import sys
+
+from scripts import ai_cli
+
+
+def test_status_reports_budget_depletion(monkeypatch):
+    monkeypatch.setenv("LLM_ROUTER_BUDGET", "1")
+    monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
+    sys.modules.pop("llm.router", None)
+    router = importlib.import_module("llm.router")
+    importlib.reload(router)
+    monkeypatch.setattr(ai_cli, "router", router)
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+
+    ai_cli.main(["send", "hi"])
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["status"])
+    assert rc == 0
+    assert out.getvalue().splitlines() == ["Budget remaining: 0", "Routing mode: remote"]


### PR DESCRIPTION
## Summary
- add `status` subcommand to display remaining LLM budget and routing mode
- test that `status` reflects depleted budget after prompt consumption

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli_status.py`
- `pytest tests/test_ai_cli_status.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d38c6e3fc8326bc759bc8fe40d2e0