### PR TITLE
feat(cli): enforce capabilities and audit logging

### DIFF
--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -35,12 +35,18 @@ def run_steps(
     dry_run: bool = False,
     assume_yes: bool = False,
     confirm: bool = False,
+    allowed_capabilities: set[str] | None = None,
 ) -> int:
     """Execute ``steps`` and record an analytics event."""
     start = time.time()
     log_path.parent.mkdir(parents=True, exist_ok=True)
     exit_code = execute_steps(
-        steps, log_path=log_path, dry_run=dry_run, assume_yes=assume_yes, confirm=confirm
+        steps,
+        log_path=log_path,
+        dry_run=dry_run,
+        assume_yes=assume_yes,
+        confirm=confirm,
+        allowed_capabilities=allowed_capabilities,
     )
     end = time.time()
     data = {
@@ -76,6 +82,7 @@ def run_recipe(
     dry_run: bool = False,
     assume_yes: bool = False,
     confirm: bool = False,
+    allowed_capabilities: set[str] | None = None,
 ) -> int:
     """Execute a recipe and record an analytics event."""
     if callable(steps_or_callable):
@@ -94,6 +101,7 @@ def run_recipe(
         dry_run=dry_run,
         assume_yes=assume_yes,
         confirm=confirm,
+        allowed_capabilities=allowed_capabilities,
     )
 
 __all__ = ["record_event_logged", "run_steps", "run_recipe"]

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -11,9 +11,9 @@ import os
 import shlex
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Set
 
 import requests  # noqa: F401 -- imported for backward-compatibility
 from telemetry import analytics_default, record_event
@@ -33,6 +33,7 @@ class PlanStep:
     number: int
     command: str
     diff: Optional[str] = None
+    capabilities: Set[str] = field(default_factory=set)
 
 
 def _strip_risk_tag(command: str) -> str:
@@ -50,6 +51,7 @@ def execute_steps(
     dry_run: bool = False,
     assume_yes: bool = False,
     confirm: bool = False,
+    allowed_capabilities: Set[str] | None = None,
 ) -> int:
     """Execute ``steps`` and write a log to ``log_path``.
 
@@ -59,7 +61,19 @@ def execute_steps(
     ``confirm`` flag to run without prompting.
     """
     exit_code = 0
+    allowed = allowed_capabilities or set()
     for step in steps:
+        missing_caps = step.capabilities - allowed
+        if missing_caps:
+            msg = f"Missing capabilities: {', '.join(sorted(missing_caps))}"
+            print(msg, file=sys.stderr)
+            with log_path.open("a", encoding="utf-8") as log:
+                log.write(f"$ {step.command}\n")
+                log.write(f"[missing capabilities: {', '.join(sorted(missing_caps))}]\n")
+                log.write("(skipped)\n\n")
+            if not exit_code:
+                exit_code = 1
+            continue
         is_risky = "[risk:" in step.command
         step_assume_yes = assume_yes and (confirm or not is_risky)
         if dry_run:
@@ -70,6 +84,7 @@ def execute_steps(
                 log.write(f"$ {step.command}\n")
                 if step.diff:
                     log.write(f"{step.diff}\n")
+                log.write(f"[capabilities: {', '.join(sorted(step.capabilities))}]\n")
                 log.write("(dry-run)\n\n")
             continue
 
@@ -104,6 +119,7 @@ def execute_steps(
         result = subprocess.run(cmd, shell=needs_shell, capture_output=True, text=True)
         with log_path.open("a", encoding="utf-8") as log:
             log.write(f"$ {step.command}\n")
+            log.write(f"[capabilities: {', '.join(sorted(step.capabilities))}]\n")
             if result.stdout:
                 log.write(result.stdout)
             if result.stderr:

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -258,6 +258,7 @@ def test_recipe_subcommand(monkeypatch, tmp_path):
         analytics=False,
         nats_url=None,
         jetstream=False,
+        **kwargs,
     ):
         captured["name"] = name
         captured["goal"] = goal

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -185,3 +185,59 @@ def test_execute_steps_windows_path(monkeypatch, tmp_path):
 
     assert captured["cmd"] == ["C:\\Program Files\\Foo Bar\\tool.exe", "arg"]
     assert captured["shell"] is False
+
+
+def test_execute_steps_enforces_capabilities(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        captured["called"] = True
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
+
+    step = PlanStep(1, "echo hi", capabilities={"process.exec"})
+    rc = cli_common.execute_steps(
+        [step],
+        log_path=tmp_path / "log.txt",
+        allowed_capabilities={"filesystem.read"},
+        assume_yes=True,
+    )
+
+    assert rc == 1
+    assert "called" not in captured
+    content = (tmp_path / "log.txt").read_text()
+    assert "missing capabilities: process.exec" in content
+
+
+def test_execute_steps_logs_capabilities(monkeypatch, tmp_path):
+    inputs = iter(["y", "y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
+
+    step = PlanStep(1, "echo hi", capabilities={"process.exec"})
+    cli_common.execute_steps(
+        [step],
+        log_path=tmp_path / "log.txt",
+        allowed_capabilities={"process.exec"},
+    )
+
+    content = (tmp_path / "log.txt").read_text()
+    assert "[capabilities: process.exec]" in content


### PR DESCRIPTION
## Summary
- allow steps to declare capabilities and enforce allowed set
- log each step's capabilities to `ai_do.log`
- propagate capability limits through `run_steps` and `run_recipe`

## Testing
- `python -m ruff check scripts/cli_common.py scripts/cli_actions.py tests/test_cli_common.py tests/test_ai_cli.py`
- `pytest tests/test_cli_common.py tests/test_ai_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d38c761b48326a8478c1e4af93182