### PR TITLE
feat: add ai suggestion command

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -15,7 +15,7 @@ import threading
 from llm import router
 from llm.backends import initialize
 import asyncio
-from scripts import ai_exec, recipes, plugins, query_sources, nsm_stats
+from scripts import ai_exec, recipes, plugins, query_sources, nsm_stats, ai_suggest
 from scripts.cli_common import (
     PlanStep,
     read_prompt,
@@ -75,7 +75,7 @@ def _publish_event(args: argparse.Namespace, name: str, payload: dict[str, Any])
     cli_actions.record_event_logged(name, payload, enabled=args.analytics)
     if args.analytics and getattr(args, "nats_url", None):
         try:
-            asyncio.run(ume_events.publish_event(args.nats_url, name, payload))  # type: ignore[misc,arg-type]
+            asyncio.run(ume_events.publish_event(args.nats_url, name, payload))
 
         except Exception as exc:  # noqa: BLE001
             logging.debug("Failed to publish NATS event: %s", exc)
@@ -104,7 +104,7 @@ def _cmd_suggest(args: argparse.Namespace) -> int:
         kwargs = {"local": args.local, "model": args.model}
         if _session.get("context"):
             kwargs["context"] = _session["context"]
-        suggestions = router.shell_suggest(args.goal, **kwargs)
+        suggestions = ai_suggest.suggest(args.goal, **kwargs)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         print(exc, file=sys.stderr)
         _publish_event(args, "ai-cli-suggest", {"exit_code": 1})
@@ -535,6 +535,11 @@ def build_parser() -> argparse.ArgumentParser:
     send.add_argument("--model", default=router.DEFAULT_MODEL, help="Model name for Ollama (default: %(default)s)")
     send.set_defaults(func=_cmd_send)
 
+    plan = sub.add_parser("plan", help="Generate a shell plan for a goal", parents=[analytics])
+    plan.add_argument("goal")
+    plan.add_argument("--config")
+    plan.set_defaults(func=_cmd_plan)
+
     suggest = sub.add_parser(
         "suggest", help="Suggest shell commands for a goal", parents=[analytics]
     )
@@ -548,11 +553,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Model name for Ollama (default: %(default)s)",
     )
     suggest.set_defaults(func=_cmd_suggest)
-
-    plan = sub.add_parser("plan", help="Generate a shell plan for a goal", parents=[analytics])
-    plan.add_argument("goal")
-    plan.add_argument("--config")
-    plan.set_defaults(func=_cmd_plan)
 
     do = sub.add_parser("do", help="Interactively execute a goal", parents=[analytics])
     do.add_argument("goal")

--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Suggest up to three shell commands for a goal with risk labels."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from typing import List, Optional
+
+from llm import router
+from llm.backends import initialize
+from scripts.cli_common import build_analytics_parser
+from scripts import cli_actions
+from telemetry import analytics_default
+
+initialize()
+
+RISKY_COMMANDS = {"rm", "reboot", "shutdown", "poweroff", "mkfs", "dd"}
+
+
+def _label_risk(step: str) -> str:
+    """Append a risk tag to ``step`` describing potential danger."""
+    try:
+        tokens = shlex.split(step)
+    except ValueError:
+        return f"{step} [risk:info]"
+    if not tokens:
+        return f"{step} [risk:info]"
+    cmd = tokens[0]
+    risk = "info"
+    if cmd == "sudo":
+        risk = "sudo"
+        if len(tokens) > 1 and tokens[1] in RISKY_COMMANDS:
+            risk = tokens[1]
+    elif cmd in RISKY_COMMANDS:
+        risk = cmd
+    return f"{step} [risk:{risk}]"
+
+
+def suggest(
+    goal: str,
+    *,
+    local: bool = False,
+    model: str = router.DEFAULT_MODEL,
+    context: str | None = None,
+) -> List[str]:
+    """Return up to three risk-tagged shell command suggestions for ``goal``."""
+    text = router.shell_suggest(goal, local=local, model=model, context=context)
+    return [_label_risk(line) for line in text[:3]]
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    analytics = build_analytics_parser()
+    parser = argparse.ArgumentParser(description=__doc__, parents=[analytics])
+    parser.add_argument("goal", help="High level description of the task")
+    parser.add_argument("--local", action="store_true", help="Force use of fallback backend")
+    parser.add_argument(
+        "--model",
+        default=router.DEFAULT_MODEL,
+        help="Model name for Ollama (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+    args.analytics = getattr(args, "analytics", analytics_default())
+    try:
+        suggestions = suggest(args.goal, local=args.local, model=args.model)
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        print(exc, file=sys.stderr)
+        cli_actions.record_event_logged(
+            "ai-suggest", {"exit_code": 1}, enabled=args.analytics
+        )
+        return 1
+    for line in suggestions:
+        print(line)
+    cli_actions.record_event_logged(
+        "ai-suggest",
+        {"exit_code": 0, "suggestion_count": len(suggestions)},
+        enabled=args.analytics,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ai_cli_suggest.py
+++ b/tests/test_ai_cli_suggest.py
@@ -4,7 +4,7 @@ import pytest
 
 pytest.importorskip("requests")
 
-from scripts import ai_cli
+from scripts import ai_cli, ai_suggest
 
 
 def test_suggest_subcommand(monkeypatch):
@@ -20,7 +20,7 @@ def test_suggest_subcommand(monkeypatch):
         assert model == "m"
         return suggestions
 
-    monkeypatch.setattr(ai_cli.router, "shell_suggest", fake_suggest)
+    monkeypatch.setattr(ai_suggest, "suggest", fake_suggest)
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
         rc = ai_cli.main(["suggest", "goal", "--local", "--model", "m"])

--- a/tests/test_ai_suggest.py
+++ b/tests/test_ai_suggest.py
@@ -1,0 +1,34 @@
+import contextlib
+import io
+
+import pytest
+
+pytest.importorskip("requests")
+
+from scripts import ai_suggest
+
+
+def test_ai_suggest_risk_tagging(monkeypatch):
+    lines = [
+        "rm -rf /",
+        "sudo reboot now",
+        "ls -la",
+        "echo hi",
+    ]
+
+    def fake(goal, *, local=False, model=ai_suggest.router.DEFAULT_MODEL, context=None):
+        assert goal == "goal"
+        return lines
+
+    monkeypatch.setattr(ai_suggest.router, "shell_suggest", fake)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_suggest.main(["goal", "--local", "--model", "m"])
+    assert rc == 0
+    suggestions = out.getvalue().splitlines()
+    assert len(suggestions) == 3
+    assert suggestions[0].endswith("[risk:rm]")
+    assert suggestions[1].endswith("[risk:reboot]")
+    assert suggestions[2].endswith("[risk:info]")
+    for line in suggestions:
+        assert "[risk:" in line


### PR DESCRIPTION
## Summary
- add standalone `ai_suggest` script for risk-tagged shell command suggestions
- expose new `suggest` subcommand in unified CLI
- test CLI and script suggestion behavior

## Testing
- `ruff check scripts/ai_suggest.py scripts/ai_cli.py tests/test_ai_suggest.py tests/test_ai_cli_suggest.py`
- `mypy --follow-imports=skip scripts/ai_suggest.py scripts/ai_cli.py tests/test_ai_suggest.py tests/test_ai_cli_suggest.py`
- `pytest tests/test_ai_suggest.py tests/test_ai_cli_suggest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e05b4dfc48326ae369cc1feac2990