### PR TITLE
feat: add diff previews and confirm prompt

### DIFF
--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -9,6 +9,7 @@ import shlex
 import subprocess
 import time
 from pathlib import Path
+from typing import Iterable
 from threading import Lock
 from typing import List, Optional
 
@@ -82,6 +83,34 @@ def _parse_steps(text: str) -> List[PlanStep]:
     return steps
 
 
+def _append_file_diffs(steps: Iterable[PlanStep]) -> None:
+    """Populate ``diff`` for steps that reference existing files."""
+
+    for step in steps:
+        if step.diff:
+            continue
+        command = step.command
+        if " [risk:" in command:
+            command = command.rsplit(" [risk:", 1)[0]
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            continue
+        files = [Path(tok) for tok in tokens[1:] if Path(tok).is_file()]
+        diffs: List[str] = []
+        for file in files:
+            result = subprocess.run(
+                ["git", "diff", "--no-index", "--", "/dev/null", str(file)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.stdout:
+                diffs.append(result.stdout.strip())
+        if diffs:
+            step.diff = "\n".join(diffs)
+
+
 def plan(
     goal: str, *, config_path: Optional[Path] = None, analytics: bool = False
 ) -> List[PlanStep]:
@@ -103,6 +132,7 @@ def plan(
             text = router.run_ollama(goal, model=fallback or router.DEFAULT_MODEL)
 
         steps = _parse_steps(text)
+        _append_file_diffs(steps)
         return steps
     except Exception:
         exit_code = 1

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -55,14 +55,35 @@ def execute_steps(
 ) -> int:
     """Execute ``steps`` and write a log to ``log_path``.
 
-    When ``dry_run`` is ``True`` the commands are printed and logged without
-    being executed. If ``assume_yes`` is ``True`` all confirmation prompts are
-    skipped for non-risky commands. Commands tagged with ``[risk:*]`` require the
-    ``confirm`` flag to run without prompting.
+    ``dry_run`` prints the planned commands and their diffs without executing
+    them. When executing, commands tagged with ``[risk:*]`` require the
+    ``confirm`` flag to be set or the function aborts before running anything.
     """
+    step_list = list(steps)
+
+    # Display the plan up-front so users can review the numbered steps.
+    for step in step_list:
+        print(f"{step.number}. {step.command}")
+        if dry_run and step.diff:
+            print(step.diff)
+
+    if dry_run:
+        for step in step_list:
+            with log_path.open("a", encoding="utf-8") as log:
+                log.write(f"$ {step.command}\n")
+                if step.diff:
+                    log.write(f"{step.diff}\n")
+                log.write(f"[capabilities: {', '.join(sorted(step.capabilities))}]\n")
+                log.write("(dry-run)\n\n")
+        return 0
+
+    if any("[risk:" in step.command for step in step_list) and not confirm:
+        print("Risky commands present. Re-run with --confirm to execute.", file=sys.stderr)
+        return 1
+
     exit_code = 0
     allowed = allowed_capabilities or set()
-    for step in steps:
+    for step in step_list:
         missing_caps = step.capabilities - allowed
         if missing_caps:
             msg = f"Missing capabilities: {', '.join(sorted(missing_caps))}"
@@ -76,17 +97,6 @@ def execute_steps(
             continue
         is_risky = "[risk:" in step.command
         step_assume_yes = assume_yes and (confirm or not is_risky)
-        if dry_run:
-            print(f"{step.number}. {step.command}")
-            if step.diff:
-                print(step.diff)
-            with log_path.open("a", encoding="utf-8") as log:
-                log.write(f"$ {step.command}\n")
-                if step.diff:
-                    log.write(f"{step.diff}\n")
-                log.write(f"[capabilities: {', '.join(sorted(step.capabilities))}]\n")
-                log.write("(dry-run)\n\n")
-            continue
 
         if not step_assume_yes:
             answer = input(f"{step.number}. {step.command} [y/N]?").strip().lower()

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -12,6 +12,7 @@ pytest.importorskip("requests")
 
 from scripts import ai_exec, cli_actions
 from scripts.cli_common import PlanStep
+import scripts.cli_common as cli_common
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -233,4 +234,42 @@ def test_main_env_enables_analytics(monkeypatch):
     assert rc == 0
     assert out.getvalue().splitlines() == ["1. step"]
     assert recorded == [True]
+
+
+def test_plan_adds_file_diff(monkeypatch, tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("hello\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        ai_exec.router, "run_gemini", lambda *a, **k: f"cat {target}"
+    )
+    monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
+    monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
+
+    steps = ai_exec.plan("goal")
+    assert steps[0].diff is not None
+    assert "+hello" in steps[0].diff
+
+
+def test_execute_steps_requires_confirm(monkeypatch, tmp_path):
+    step = PlanStep(1, "rm -rf / [risk:rm]")
+    called = []
+
+    def fake_run(cmd, shell=False, capture_output=False, text=False):
+        called.append(cmd)
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    log = tmp_path / "log.txt"
+    rc = cli_common.execute_steps([step], log_path=log, assume_yes=True)
+    assert rc == 1
+    assert called == []
+
+    rc = cli_common.execute_steps([step], log_path=log, assume_yes=True, confirm=True)
+    assert rc == 0
+    assert called != []
 


### PR DESCRIPTION
## Summary
- show git diff previews for file-modifying steps in ai_exec
- display numbered plans and require --confirm for risky steps
- test diff generation and confirmation enforcement

## Testing
- `pre-commit run --files scripts/ai_exec.py scripts/cli_common.py tests/test_ai_exec.py`
- `pytest tests/test_ai_exec.py tests/test_cli_common.py`


------
https://chatgpt.com/codex/tasks/task_e_689e05b40d788326b139dda5eefe21af