### PR TITLE
feat: add windows dev recipes

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,37 @@
+# Windows Development Recipes
+
+The recipe plug-ins under `scripts/recipes/plugins/` provide reusable command
+sequences for setting up a Windows development environment. Each recipe returns
+a list of shell commands that can be executed on a Windows host.
+
+## wsl
+- **Usage:** Enables and installs the Windows Subsystem for Linux.
+- **Prerequisites:** Requires Windows 10 or later with virtualization enabled.
+
+## docker_desktop
+- **Usage:** Installs Docker Desktop via `winget`.
+- **Prerequisites:** Requires WSL 2 and a 64‑bit system.
+
+## vscode
+- **Usage:** Installs Visual Studio Code using `winget`.
+- **Prerequisites:** None.
+
+## gpu_drivers
+- **Usage:** Installs NVIDIA GPU drivers through `winget`.
+- **Prerequisites:** NVIDIA GPU hardware.
+
+## windows_terminal
+- **Usage:** Installs Windows Terminal from the Microsoft Store using `winget`.
+- **Prerequisites:** None.
+
+## powershell
+- **Usage:** Installs the latest PowerShell.
+- **Prerequisites:** None.
+
+## nodejs
+- **Usage:** Installs the LTS version of Node.js.
+- **Prerequisites:** None.
+
+## git
+- **Usage:** Installs Git for Windows.
+- **Prerequisites:** None.

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -9,6 +9,14 @@
     "lmql": "d0ttino-lmql-plugin"
   },
   "recipes": {
-    "echo": "d0ttino-echo-recipe"
+    "echo": "d0ttino-echo-recipe",
+    "wsl": "d0ttino-wsl-recipe",
+    "docker_desktop": "d0ttino-docker-desktop-recipe",
+    "vscode": "d0ttino-vscode-recipe",
+    "gpu_drivers": "d0ttino-gpu-drivers-recipe",
+    "windows_terminal": "d0ttino-windows-terminal-recipe",
+    "powershell": "d0ttino-powershell-recipe",
+    "nodejs": "d0ttino-nodejs-recipe",
+    "git": "d0ttino-git-recipe"
   }
 }

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -62,6 +62,14 @@ PLUGIN_REGISTRY: Dict[str, str] = {
 # cannot be loaded from the network or cache.
 RECIPE_REGISTRY: Dict[str, str] = {
     "echo": "d0ttino-echo-recipe",
+    "wsl": "d0ttino-wsl-recipe",
+    "docker_desktop": "d0ttino-docker-desktop-recipe",
+    "vscode": "d0ttino-vscode-recipe",
+    "gpu_drivers": "d0ttino-gpu-drivers-recipe",
+    "windows_terminal": "d0ttino-windows-terminal-recipe",
+    "powershell": "d0ttino-powershell-recipe",
+    "nodejs": "d0ttino-nodejs-recipe",
+    "git": "d0ttino-git-recipe",
 }
 
 # Default directory for recipe packages downloaded via ``recipes sync``

--- a/scripts/recipes/plugins/docker_desktop.py
+++ b/scripts/recipes/plugins/docker_desktop.py
@@ -1,0 +1,16 @@
+"""Docker Desktop recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(_: str) -> List[str]:
+    """Install Docker Desktop using winget."""
+    return ["winget install -e --id Docker.DockerDesktop"]
+
+
+register_recipe("docker_desktop", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/git.py
+++ b/scripts/recipes/plugins/git.py
@@ -1,0 +1,16 @@
+"""Git recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(_: str) -> List[str]:
+    """Install Git via winget."""
+    return ["winget install -e --id Git.Git"]
+
+
+register_recipe("git", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/gpu_drivers.py
+++ b/scripts/recipes/plugins/gpu_drivers.py
@@ -1,0 +1,16 @@
+"""GPU drivers recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(_: str) -> List[str]:
+    """Install NVIDIA GPU drivers via winget."""
+    return ["winget install -e --id Nvidia.DisplayDriver"]
+
+
+register_recipe("gpu_drivers", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/nodejs.py
+++ b/scripts/recipes/plugins/nodejs.py
@@ -1,0 +1,16 @@
+"""Node.js recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(_: str) -> List[str]:
+    """Install Node.js via winget."""
+    return ["winget install -e --id OpenJS.NodeJS.LTS"]
+
+
+register_recipe("nodejs", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/powershell.py
+++ b/scripts/recipes/plugins/powershell.py
@@ -1,0 +1,16 @@
+"""PowerShell recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(_: str) -> List[str]:
+    """Install PowerShell via winget."""
+    return ["winget install -e --id Microsoft.PowerShell"]
+
+
+register_recipe("powershell", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/vscode.py
+++ b/scripts/recipes/plugins/vscode.py
@@ -1,0 +1,16 @@
+"""VS Code recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(_: str) -> List[str]:
+    """Install Visual Studio Code via winget."""
+    return ["winget install -e --id Microsoft.VisualStudioCode"]
+
+
+register_recipe("vscode", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/windows_terminal.py
+++ b/scripts/recipes/plugins/windows_terminal.py
@@ -1,0 +1,16 @@
+"""Windows Terminal recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(_: str) -> List[str]:
+    """Install Windows Terminal via winget."""
+    return ["winget install -e --id Microsoft.WindowsTerminal"]
+
+
+register_recipe("windows_terminal", run)
+
+__all__ = ["run"]

--- a/scripts/recipes/plugins/wsl.py
+++ b/scripts/recipes/plugins/wsl.py
@@ -1,0 +1,16 @@
+"""WSL recipe plug-in."""
+from __future__ import annotations
+
+from typing import List
+
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(_: str) -> List[str]:
+    """Install the Windows Subsystem for Linux."""
+    return ["wsl --install"]
+
+
+register_recipe("wsl", run)
+
+__all__ = ["run"]


### PR DESCRIPTION
## Summary
- add Windows recipe plug-ins for WSL, Docker Desktop, VS Code, GPU drivers, Windows Terminal, PowerShell, Node.js, and Git
- document available recipes and prerequisites
- register new recipe packages in plugin registry

## Testing
- `pre-commit run --files scripts/recipes/plugins/wsl.py scripts/recipes/plugins/docker_desktop.py scripts/recipes/plugins/vscode.py scripts/recipes/plugins/gpu_drivers.py scripts/recipes/plugins/windows_terminal.py scripts/recipes/plugins/powershell.py scripts/recipes/plugins/nodejs.py scripts/recipes/plugins/git.py plugin-registry.json scripts/plugins.py docs/recipes.md`
- `npm test`
- `pytest tests/test_recipe_plugins.py tests/test_plugin_registry.py::test_load_registry_recipes_section -q`

------
https://chatgpt.com/codex/tasks/task_e_689e05be84dc8326832621f8f2e2828d