### PR TITLE
ci: automate winget manifest submission

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -14,9 +14,10 @@ jobs:
           dotnet tool install --global wingetcreate
       - name: Update manifest
         env:
-          VERSION: ${{ github.ref_name }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          wingetcreate update winget/tino.yaml https://github.com/d0tTino/d0tTino/releases/download/$env:VERSION/d0tTino.zip $env:VERSION
+          $version = $env:TAG_NAME.TrimStart('v')
+          wingetcreate update winget/tino.yaml https://github.com/d0tTino/d0tTino/releases/download/$env:TAG_NAME/d0tTino.zip $version
       - name: Submit to winget-pkgs
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Hi, I’m Tino
+[![winget](https://github.com/d0tTino/d0tTino/actions/workflows/winget.yml/badge.svg)](https://github.com/d0tTino/d0tTino/actions/workflows/winget.yml)
 
 I build local‑first automation, agentic systems and tooling that’s easy to run on your own hardware. My work spans persistent memory engines, emergent AI sandboxes and practical task orchestration.
 

--- a/llm/backends/loader.py
+++ b/llm/backends/loader.py
@@ -45,3 +45,9 @@ def discover_plugins() -> None:
 def load_backends() -> None:
     """Convenience wrapper to import all available backends."""
     discover_plugins()
+    # Ensure the built-in SuperClaude backend is always available even if the
+    # registry has been cleared during tests or reinitialization.
+    if "superclaude" not in backends.available_backends():
+        from llm import router
+
+        backends.register_backend("superclaude", router.run_superclaude)

--- a/winget/tino.yaml
+++ b/winget/tino.yaml
@@ -10,7 +10,7 @@ PackageUrl: https://github.com/d0tTino/d0tTino
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/d0tTino/d0tTino/archive/refs/tags/v{{VERSION}}.zip
+    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v{{VERSION}}/d0tTino.zip
     Sha256: "{{SHA256}}"
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- wire winget/tino.yaml into wingetcreate submission workflow
- point winget manifest at release asset
- show winget packaging status in README
- ensure SuperClaude backend is restored when plugin registry resets

## Testing
- `pre-commit run --files llm/backends/loader.py`
- `pytest tests/test_ai_router.py::test_superclaude_backend_registered -q`
- `python - <<'PY'\nfrom llm import backends, router\nbackends.clear_registry()\nbackends.load_backends()\nassert backends.get_backend('superclaude') is router.run_superclaude\nprint('superclaude registered after load_backends')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_689dfb640a748326aca743e3ea2cc789