### PR TITLE
feat: expose router budget and model source

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -58,19 +58,20 @@ def _load_budget() -> int | None:
 
 
 _BUDGET = _load_budget()
+_LAST_MODEL_SOURCE: str | None = None
 
 
-def get_budget() -> int | None:
-    return _BUDGET
+def get_budget() -> tuple[int | None, str | None]:
+    return _BUDGET, _LAST_MODEL_SOURCE
 
 
-def _decrement_budget() -> None:
+def _decrement_budget(tokens: int) -> None:
     global _BUDGET
     if _BUDGET is None:
         return
-    if _BUDGET <= 0:
+    if _BUDGET < tokens:
         raise RuntimeError("LLM budget exhausted")
-    _BUDGET -= 1
+    _BUDGET -= tokens
 
 
 def estimate_prompt_complexity(prompt: str) -> int:
@@ -217,6 +218,7 @@ def send_prompt(
     route requests differently. It is currently unused by the router itself but
     accepted for compatibility with CLI features.
     """
+    global _LAST_MODEL_SOURCE
     primary, fallback = _preferred_backends()
     order: List[str] = []
 
@@ -262,11 +264,15 @@ def send_prompt(
                     if fallback:
                         order.append(fallback)
                     order.append(primary)
+
+    tokens = estimate_prompt_complexity(prompt)
     for backend_name in order:
         try:
             if backend_name in _REMOTE_BACKENDS:
-                _decrement_budget()
-            return _run_backend(backend_name, prompt, model)
+                _decrement_budget(tokens)
+            text = _run_backend(backend_name, prompt, model)
+            _LAST_MODEL_SOURCE = backend_name
+            return text
         except (FileNotFoundError, subprocess.CalledProcessError):
             continue
     raise RuntimeError("Unable to process prompt")

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -263,11 +263,10 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_status(args: argparse.Namespace) -> int:
-    """Show remaining budget and routing mode."""
-    budget = router.get_budget()
-    mode = os.environ.get("LLM_ROUTING_MODE", "auto")
+    """Show remaining budget and last model source."""
+    budget, source = router.get_budget()
     print(f"Budget remaining: {budget}")
-    print(f"Routing mode: {mode}")
+    print(f"Last model source: {source or 'unknown'}")
     return 0
 
 
@@ -687,7 +686,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     status = sub.add_parser(
         "status",
-        help="Show remaining budget and routing mode",
+        help="Show remaining budget and last model source",
         parents=[analytics],
     )
     status.set_defaults(func=_cmd_status)

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -1,6 +1,11 @@
+import contextlib
 import importlib
+import io
 import sys
+
 import pytest
+
+from scripts import ai_cli
 
 
 @pytest.fixture(autouse=True)
@@ -10,7 +15,7 @@ def reset_router(monkeypatch):
     sys.modules.pop("llm.router", None)
     router = importlib.import_module("llm.router")
     importlib.reload(router)
-
+    monkeypatch.setattr(ai_cli, "router", router, raising=False)
 
 
 def _reload_router(monkeypatch, budget: str = "1"):
@@ -22,23 +27,41 @@ def _reload_router(monkeypatch, budget: str = "1"):
     return router
 
 
-
 def test_budget_decrements_and_exhausts(monkeypatch):
-    router = _reload_router(monkeypatch, "1")
+    router = _reload_router(monkeypatch, "2")
     monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
     monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
 
-    assert router.get_budget() == 1
-    router.send_prompt("hello", model="g1")
-    assert router.get_budget() == 0
+    assert router.get_budget() == (2, None)
+    router.send_prompt("hello world", model="g1")
+    assert router.get_budget() == (0, "gemini")
     with pytest.raises(RuntimeError):
         router.send_prompt("again", model="g1")
 
 
 def test_local_does_not_use_budget(monkeypatch):
-    router = _reload_router(monkeypatch, "1")
+    router = _reload_router(monkeypatch, "2")
     monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", "ollama"))
     monkeypatch.setattr(router, "run_ollama", lambda prompt, model: "local")
 
-    router.send_prompt("hi", local=True, model="o1")
-    assert router.get_budget() == 1
+    router.send_prompt("hi there", local=True, model="o1")
+    assert router.get_budget() == (2, "ollama")
+
+
+def test_status_reports_budget_and_source(monkeypatch):
+    router = _reload_router(monkeypatch, "5")
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+    monkeypatch.setattr(ai_cli, "router", router)
+
+    router.send_prompt("hello world", model="g1")
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["status"])
+    assert rc == 0
+    assert out.getvalue().splitlines() == [
+        "Budget remaining: 3",
+        "Last model source: gemini",
+    ]
+


### PR DESCRIPTION
## Summary
- report token budget and last model source via `ai status`
- decrement router budget by estimated token usage per request
- add tests ensuring router budgeting and `ai status` work

## Testing
- `ruff check llm/router.py scripts/ai_cli.py tests/test_router_budget.py`
- `pytest tests/test_router_budget.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3baf7f748326874b9a4eafcd1252