### PR TITLE
feat: add MCP server wrapper

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -1,12 +1,33 @@
 {
   "plugins": {
-    "sample": "d0ttino-sample-plugin",
-    "openrouter": "d0ttino-openrouter-plugin",
-    "lobechat": "d0ttino-lobechat-plugin",
-    "mindbridge": "d0ttino-mindbridge-plugin",
-    "anthropic": "d0ttino-anthropic-plugin",
-    "mistral": "d0ttino-mistral-plugin",
-    "lmql": "d0ttino-lmql-plugin"
+    "sample": {
+      "package": "d0ttino-sample-plugin",
+      "mcp": {}
+    },
+    "openrouter": {
+      "package": "d0ttino-openrouter-plugin",
+      "mcp": {}
+    },
+    "lobechat": {
+      "package": "d0ttino-lobechat-plugin",
+      "mcp": {}
+    },
+    "mindbridge": {
+      "package": "d0ttino-mindbridge-plugin",
+      "mcp": {}
+    },
+    "anthropic": {
+      "package": "d0ttino-anthropic-plugin",
+      "mcp": {}
+    },
+    "mistral": {
+      "package": "d0ttino-mistral-plugin",
+      "mcp": {}
+    },
+    "lmql": {
+      "package": "d0ttino-lmql-plugin",
+      "mcp": {}
+    }
   },
   "recipes": {
     "echo": "d0ttino-echo-recipe",

--- a/plugin-registry.schema.json
+++ b/plugin-registry.schema.json
@@ -8,8 +8,19 @@
     "plugins": {
       "type": "object",
       "additionalProperties": {
-        "type": "string",
-        "description": "Name of the pip package containing the plug-in"
+        "type": "object",
+        "required": ["package", "mcp"],
+        "properties": {
+          "package": {
+            "type": "string",
+            "description": "Name of the pip package containing the plug-in"
+          },
+          "mcp": {
+            "type": "object",
+            "description": "MCP metadata for the plug-in"
+          }
+        },
+        "additionalProperties": false
       }
     },
     "recipes": {

--- a/plugins/mcp_adapter.py
+++ b/plugins/mcp_adapter.py
@@ -1,0 +1,81 @@
+"""MCP server wrapper exposing registry-defined tools.
+
+This module converts plug-in registry entries that include ``mcp`` metadata
+into callable tools and optionally serves them over a minimal JSON protocol.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from typing import Any, Dict, Iterator
+
+from scripts import plugins as registry
+
+__all__ = ["iter_tools", "get_tools", "serve"]
+
+
+def iter_tools(registry_data: Dict[str, object] | None = None) -> Iterator[tuple[str, Any]]:
+    """Yield ``(name, tool)`` for each plug-in exposing an MCP entry point.
+
+    ``registry_data`` should be a mapping in the format returned by
+    :func:`scripts.plugins.load_registry` when ``raw=True``. When omitted, the
+    registry is loaded on demand.
+    """
+
+    if registry_data is None:
+        registry_data = registry.load_registry(raw=True)
+
+    for name, meta in registry_data.items():
+        if not isinstance(meta, dict):
+            continue
+        mcp_meta = meta.get("mcp")
+        if not isinstance(mcp_meta, dict):
+            continue
+        entry = mcp_meta.get("entry_point")
+        if not isinstance(entry, str):
+            continue
+        try:
+            module_name, obj_name = entry.split(":", 1)
+            module = importlib.import_module(module_name)
+            yield name, getattr(module, obj_name)
+        except Exception:  # pragma: no cover - best effort loading
+            continue
+
+
+def get_tools(registry_data: Dict[str, object] | None = None) -> Dict[str, Any]:
+    """Return a mapping of tool names to loaded callables."""
+
+    return {name: tool for name, tool in iter_tools(registry_data)}
+
+
+def serve(registry_data: Dict[str, object] | None = None) -> None:
+    """Serve tools over a line-oriented JSON protocol on ``stdin``/``stdout``.
+
+    Each request should be a JSON object containing ``tool`` and optional
+    ``args`` keys. Responses are JSON objects with either ``result`` or
+    ``error`` keys.
+    """
+
+    tools = get_tools(registry_data)
+
+    for line in sys.stdin:
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        name = req.get("tool")
+        args = req.get("args") or {}
+        func = tools.get(name)
+        if func is None:
+            resp = {"error": f"unknown tool: {name}"}
+        else:
+            try:
+                result = func(**args)
+                resp = {"result": result}
+            except Exception as exc:  # pragma: no cover - propagate error
+                resp = {"error": str(exc)}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -27,7 +27,7 @@ from pathlib import Path
 import subprocess
 import sys
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any, overload, Literal, cast
 
 import requests
 try:
@@ -99,9 +99,19 @@ def _valid_registry(data: Dict[str, object]) -> bool:
             return False
     plugins = data.get("plugins")
     recipes = data.get("recipes")
+
+    def _valid_plugin(val: object) -> bool:
+        if isinstance(val, str):
+            return True
+        if isinstance(val, dict):
+            pkg = val.get("package")
+            mcp_meta = val.get("mcp")
+            return isinstance(pkg, str) and isinstance(mcp_meta, dict)
+        return False
+
     return (
         isinstance(plugins, dict)
-        and all(isinstance(v, str) for v in plugins.values())
+        and all(_valid_plugin(v) for v in plugins.values())
         and (
             recipes is None
             or (
@@ -136,9 +146,35 @@ def _fetch_registry(url: str) -> Dict[str, object] | None:
     return None
 
 
+@overload
 def load_registry(
-    section: str = "plugins", update: bool = False, ttl: int = DEFAULT_CACHE_TTL
+    section: str = "plugins",
+    update: bool = False,
+    ttl: int = DEFAULT_CACHE_TTL,
+    *,
+    raw: Literal[False] = False,
 ) -> Dict[str, str]:
+    ...
+
+
+@overload
+def load_registry(
+    section: str = "plugins",
+    update: bool = False,
+    ttl: int = DEFAULT_CACHE_TTL,
+    *,
+    raw: Literal[True],
+) -> Dict[str, Any]:
+    ...
+
+
+def load_registry(
+    section: str = "plugins",
+    update: bool = False,
+    ttl: int = DEFAULT_CACHE_TTL,
+    *,
+    raw: bool = False,
+) -> Dict[str, Any]:
     """Return the registry section with network → cache → default fallback.
 
     The registry URL is taken from ``PLUGIN_REGISTRY_URL`` when set and
@@ -191,11 +227,26 @@ def load_registry(
     if isinstance(data, dict):
         mapping = data.get(section) or {}
         if isinstance(mapping, dict):
-            return {str(k): str(v) for k, v in mapping.items()}
+            if raw:
+                return mapping
+            result: Dict[str, str] = {}
+            for k, v in mapping.items():
+                if isinstance(v, str):
+                    result[str(k)] = v
+                elif isinstance(v, dict):
+                    pkg = v.get("package")
+                    if isinstance(pkg, str):
+                        result[str(k)] = pkg
+            return result
 
     if section == "plugins":
-        return PLUGIN_REGISTRY
-    return RECIPE_REGISTRY
+        if not raw:
+            return PLUGIN_REGISTRY
+        return cast(
+            Dict[str, Any],
+            {k: {"package": v, "mcp": {}} for k, v in PLUGIN_REGISTRY.items()},
+        )
+    return RECIPE_REGISTRY  # recipes not used with raw
 
 
 def _is_installed(package: str) -> bool:
@@ -333,7 +384,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Force fresh download of the plug-in registry",
     )
-    sub = parser.add_subparsers(dest="command", required=True)
+    parser.add_argument(
+        "--mcp",
+        action="store_true",
+        help="Serve MCP endpoints for registered plug-ins",
+    )
+    sub = parser.add_subparsers(dest="command")
 
     backends = sub.add_parser("backends", help="Manage backend plug-ins")
     backend_sub = backends.add_subparsers(dest="backend_command", required=True)
@@ -394,6 +450,13 @@ def main(argv: Optional[List[str]] = None) -> int:
             file=sys.stderr,
         )
     args = parser.parse_args(argv)
+    if getattr(args, "mcp", False):
+        from plugins import mcp_adapter
+
+        mcp_adapter.serve(load_registry(raw=True))
+        return 0
+    if not hasattr(args, "func"):
+        parser.error("a command is required")
     return args.func(args)
 
 

--- a/scripts/update_registry.py
+++ b/scripts/update_registry.py
@@ -46,7 +46,10 @@ def sync_registry(data: dict[str, object]) -> bool:
 
     Returns ``True`` if ``data`` was modified.
     """
-    expected_plugins = plugins.PLUGIN_REGISTRY
+    expected_plugins = {
+        name: {"package": pkg, "mcp": {}}
+        for name, pkg in plugins.PLUGIN_REGISTRY.items()
+    }
     expected_recipes = plugins.RECIPE_REGISTRY
     changed = False
     if data.get("plugins") != expected_plugins:

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,11 +1,10 @@
-import importlib.metadata
 import sys
 import types
 
-from plugins import mcp
+from plugins import mcp, mcp_adapter
 
 
-def test_mcp_adapter_exposes_registered_tools(monkeypatch):
+def test_mcp_adapter_exposes_registry_tools(monkeypatch):
     module = types.ModuleType("dummy_tool_mod")
 
     def tool_func():
@@ -14,17 +13,19 @@ def test_mcp_adapter_exposes_registered_tools(monkeypatch):
     module.tool = tool_func
     monkeypatch.setitem(sys.modules, "dummy_tool_mod", module)
 
-    entry = importlib.metadata.EntryPoint(
-        name="dummy", value="dummy_tool_mod:tool", group="d0ttino.tools"
-    )
-    monkeypatch.setattr(mcp, "discover_entry_points", lambda group: iter([entry]))
+    reg = {
+        "dummy": {"package": "pkg", "mcp": {"entry_point": "dummy_tool_mod:tool"}}
+    }
+    monkeypatch.setattr(mcp_adapter.registry, "load_registry", lambda raw=True: reg)
 
-    tools = mcp.get_tools()
+    tools = mcp_adapter.get_tools(reg)
     assert tools["dummy"] is tool_func
 
 
 def test_ai_cli_flag_enables_mcp(monkeypatch, tmp_path):
-    from scripts import ai_cli
+    import importlib
+
+    ai_cli = importlib.import_module("scripts.ai_cli")
 
     monkeypatch.setattr(ai_cli, "SESSION_FILE", tmp_path / "session.json")
     monkeypatch.setattr(ai_cli.cli_actions, "record_event_logged", lambda *a, **k: None)
@@ -42,7 +43,9 @@ def test_ai_cli_flag_enables_mcp(monkeypatch, tmp_path):
 
 
 def test_ai_cli_does_not_enable_mcp_without_flag(monkeypatch, tmp_path):
-    from scripts import ai_cli
+    import importlib
+
+    ai_cli = importlib.import_module("scripts.ai_cli")
 
     monkeypatch.setattr(ai_cli, "SESSION_FILE", tmp_path / "session.json")
     monkeypatch.setattr(ai_cli.cli_actions, "record_event_logged", lambda *a, **k: None)

--- a/tests/test_plugin_registry_schema.py
+++ b/tests/test_plugin_registry_schema.py
@@ -14,3 +14,9 @@ def test_plugin_registry_schema_valid() -> None:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(data, schema, format_checker=FormatChecker())
+
+
+def test_plugins_include_mcp_metadata() -> None:
+    data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    for plugin in data.get("plugins", {}).values():
+        assert "mcp" in plugin

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -200,6 +200,22 @@ def test_recipe_install(monkeypatch):
     assert "pkg" in called["cmd"]
 
 
+def test_mcp_flag_starts_server(monkeypatch):
+    called = {}
+
+    def fake_serve(registry):
+        called["registry"] = registry
+
+    from plugins import mcp_adapter
+
+    monkeypatch.setattr(mcp_adapter, "serve", fake_serve)
+    monkeypatch.setattr(plugins, "load_registry", lambda *a, **k: {})
+
+    rc = plugins.main(["--mcp"])
+    assert rc == 0
+    assert "registry" in called
+
+
 def test_recipe_remove(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- add MCP server adapter exposing registry tools
- expose registry MCP endpoints via `plugins.py --mcp`
- ensure plugin registry includes MCP metadata and schema test

## Testing
- `pre-commit run --files plugin-registry.json plugin-registry.schema.json plugins/mcp_adapter.py scripts/plugins.py scripts/update_registry.py tests/test_mcp_adapter.py tests/test_plugins_script.py tests/test_plugin_registry_schema.py`
- `pytest tests/test_mcp_adapter.py tests/test_plugins_script.py tests/test_plugin_registry_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3bac89188326972184762382cdf5