### PR TITLE
Add plugin scaffold and Tauri dashboard

### DIFF
--- a/scripts/plugin_scaffold.py
+++ b/scripts/plugin_scaffold.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Scaffold a minimal plug-in package.
+
+Generates either a backend or recipe plug-in with entry points for both the
+LLM plug-in system and the ``d0ttino.tools`` MCP adapter.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def scaffold_plugin(
+    name: str,
+    *,
+    recipe: bool = False,
+    description: str = "A d0tTino plug-in",
+    output: str | Path = ".",
+) -> Path:
+    """Create plug-in template for ``name`` and return the project path."""
+    suffix = "recipe" if recipe else "plugin"
+    dist_name = f"d0ttino-{name}-{suffix}"
+    package = f"d0ttino_{name}_{suffix}"
+    root = Path(output).expanduser().resolve() / dist_name
+    pkg_dir = root / package
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+
+    if recipe:
+        init = f'''"""{description}"""
+from llm.backends.plugin_sdk import register_recipe
+
+
+def run(goal: str):
+    """Return shell commands for the given goal."""
+    return [f"echo {{goal}}"]
+
+
+def mcp_tool():
+    """Return MCP tool metadata."""
+    return {{}}
+
+
+register_recipe("{name}", run)
+
+__all__ = ["run", "mcp_tool"]
+'''
+        entry_group = "d0ttino.recipes"
+        entry_line = f'{name} = "{package}:run"'
+    else:
+        init = f'''"""{description}"""
+from llm.backends.plugin_sdk import register_backend
+
+
+def run(prompt: str, model: str | None = None) -> str:
+    """Generate a completion for the given prompt."""
+    return "response"
+
+
+def mcp_tool():
+    """Return MCP tool metadata."""
+    return {{}}
+
+
+register_backend("{name}", run)
+
+__all__ = ["run", "mcp_tool"]
+'''
+        entry_group = "llm.plugins"
+        entry_line = f'{name} = "{package}"'
+
+    (pkg_dir / "__init__.py").write_text(init, encoding="utf-8")
+
+    pyproject = f'''[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "{dist_name}"
+version = "0.1.0"
+dependencies = ["llm"]
+
+[project.entry-points."{entry_group}"]
+{entry_line}
+
+[project.entry-points."d0ttino.tools"]
+{name} = "{package}:mcp_tool"
+'''
+    (root / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    (root / "mcp.json").write_text(
+        json.dumps({"name": name, "version": "0.1.0"}, indent=2),
+        encoding="utf-8",
+    )
+    return root
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("name", help="Plug-in name")
+    parser.add_argument("--output", default=".", help="Destination directory")
+    parser.add_argument("--description", default="A d0tTino plug-in")
+    parser.add_argument(
+        "--recipe", action="store_true", help="Create a recipe plug-in template"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> Path:
+    args = build_parser().parse_args(argv)
+    return scaffold_plugin(
+        args.name,
+        recipe=args.recipe,
+        description=args.description,
+        output=args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -377,6 +377,19 @@ def _cmd_publish_recipes(args: argparse.Namespace) -> int:
         return exc.returncode
 
 
+def _cmd_new_plugin(args: argparse.Namespace) -> int:
+    """Scaffold a new plug-in project."""
+    from scripts import plugin_scaffold
+
+    plugin_scaffold.scaffold_plugin(
+        args.name,
+        recipe=args.recipe,
+        description=args.description,
+        output=args.output,
+    )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -390,6 +403,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Serve MCP endpoints for registered plug-ins",
     )
     sub = parser.add_subparsers(dest="command")
+
+    new = sub.add_parser("new", help="Scaffold a new plug-in")
+    new.add_argument("name", help="Plug-in name")
+    new.add_argument("--recipe", action="store_true", help="Create a recipe plug-in")
+    new.add_argument("--description", default="A d0tTino plug-in")
+    new.add_argument("--output", default=".", help="Output directory")
+    new.set_defaults(func=_cmd_new_plugin)
 
     backends = sub.add_parser("backends", help="Manage backend plug-ins")
     backend_sub = backends.add_subparsers(dest="backend_command", required=True)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,28 @@
 pub mod commands {
     use reqwest::Client;
-    use serde::Deserialize;
-    use std::{fs, path::PathBuf};
+    use serde::{Deserialize, Serialize};
+    use std::{
+        fs::{self, OpenOptions},
+        io::Write,
+        path::PathBuf,
+    };
 
     #[derive(Deserialize)]
     struct PlanResponse {
         steps: Option<Vec<String>>,
+    }
+
+    #[derive(Serialize)]
+    pub struct PluginInfo {
+        name: String,
+        enabled: bool,
+    }
+
+    #[derive(Serialize)]
+    pub struct Dashboard {
+        recent_plans: Vec<String>,
+        budget: Option<i64>,
+        plugins: Vec<PluginInfo>,
     }
 
     pub async fn plan(goal: String) -> Result<Vec<String>, String> {
@@ -17,7 +34,20 @@ pub mod commands {
             .await
             .map_err(|e| e.to_string())?;
         let plan: PlanResponse = resp.json().await.map_err(|e| e.to_string())?;
-        Ok(plan.steps.unwrap_or_default())
+        let steps = plan.steps.unwrap_or_default();
+        if let Ok(home) = std::env::var("HOME") {
+            let log_path = PathBuf::from(home)
+                .join(".cache")
+                .join("d0ttino")
+                .join("plans.log");
+            if let Some(parent) = log_path.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(log_path) {
+                let _ = writeln!(file, "{}", goal);
+            }
+        }
+        Ok(steps)
     }
 
     pub async fn exec(goal: String) -> Result<String, String> {
@@ -90,5 +120,48 @@ pub mod commands {
             log.push_str(&format!("(exit {})\n\n", code));
         }
         Ok(log)
+    }
+
+    pub async fn dashboard() -> Result<Dashboard, String> {
+        let mut plans = Vec::new();
+        if let Ok(home) = std::env::var("HOME") {
+            let log_path = PathBuf::from(&home)
+                .join(".cache")
+                .join("d0ttino")
+                .join("plans.log");
+            if let Ok(content) = fs::read_to_string(log_path) {
+                plans = content
+                    .lines()
+                    .rev()
+                    .take(5)
+                    .map(|s| s.to_string())
+                    .collect();
+            }
+        }
+
+        let budget = std::env::var("LLM_ROUTER_BUDGET")
+            .ok()
+            .and_then(|s| s.parse().ok());
+
+        let mut plugins = Vec::new();
+        let reg_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../plugin-registry.json");
+        if let Ok(data) = fs::read_to_string(reg_path) {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&data) {
+                if let Some(map) = json.get("plugins").and_then(|v| v.as_object()) {
+                    for name in map.keys() {
+                        plugins.push(PluginInfo {
+                            name: name.clone(),
+                            enabled: true,
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(Dashboard {
+            recent_plans: plans,
+            budget,
+            plugins,
+        })
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -34,6 +34,12 @@ async fn run_recipe(name: String, goal: String) -> Result<String, String> {
 }
 
 #[cfg(feature = "gui")]
+#[tauri::command]
+async fn dashboard() -> Result<ume_tauri::commands::Dashboard, String> {
+    ume_tauri::commands::dashboard().await
+}
+
+#[cfg(feature = "gui")]
 fn main() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
@@ -42,6 +48,7 @@ fn main() {
             list_recipes,
             open_prompt_file,
             run_recipe,
+            dashboard,
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application")

--- a/tests/test_plugin_scaffold.py
+++ b/tests/test_plugin_scaffold.py
@@ -1,0 +1,29 @@
+"""Integration tests for the plug-in scaffold utility."""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+from llm.backends import available_backends, clear_registry
+from llm.backends.plugin_sdk import get_registered_recipes
+from scripts import plugin_scaffold
+
+
+def _import_plugin(path: Path, module: str) -> None:
+    sys.path.insert(0, str(path))
+    importlib.import_module(module)
+    sys.path.pop(0)
+
+
+def test_scaffold_backend_registers(tmp_path: Path) -> None:
+    project = plugin_scaffold.scaffold_plugin("demo", output=tmp_path)
+    clear_registry()
+    _import_plugin(project, "d0ttino_demo_plugin")
+    assert "demo" in available_backends()
+
+
+def test_scaffold_recipe_registers(tmp_path: Path) -> None:
+    project = plugin_scaffold.scaffold_plugin("demo", output=tmp_path, recipe=True)
+    _import_plugin(project, "d0ttino_demo_recipe")
+    assert "demo" in get_registered_recipes()


### PR DESCRIPTION
## Summary
- add `tino plugin new` subcommand with MCP-aware scaffold
- expose Tauri dashboard API for plans, budgets and plugin toggles
- test plugin scaffolding registers backends and recipes

## Testing
- `ruff check scripts/plugin_scaffold.py scripts/plugins.py tests/test_plugin_scaffold.py`
- `pytest tests/test_plugin_scaffold.py -q`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f40ba78f8832690c8b6cb792fa328