### PR TITLE
Add capability escalation and logging

### DIFF
--- a/scripts/capabilities.py
+++ b/scripts/capabilities.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class Capability(str, Enum):
+    """Enumerate capability scopes supported by ``execute_steps``."""
+
+    FILESYSTEM_READ = "filesystem.read"
+    PROCESS_EXEC = "process.exec"
+    NETWORK_FETCH = "network.fetch"
+
+
+ALL_CAPABILITIES = {
+    Capability.FILESYSTEM_READ,
+    Capability.PROCESS_EXEC,
+    Capability.NETWORK_FETCH,
+}

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -82,19 +82,30 @@ def execute_steps(
         return 1
 
     exit_code = 0
-    allowed = allowed_capabilities or set()
+    allowed = set(allowed_capabilities) if allowed_capabilities else set()
     for step in step_list:
         missing_caps = step.capabilities - allowed
         if missing_caps:
-            msg = f"Missing capabilities: {', '.join(sorted(missing_caps))}"
-            print(msg, file=sys.stderr)
-            with log_path.open("a", encoding="utf-8") as log:
-                log.write(f"$ {step.command}\n")
-                log.write(f"[missing capabilities: {', '.join(sorted(missing_caps))}]\n")
-                log.write("(skipped)\n\n")
-            if not exit_code:
-                exit_code = 1
-            continue
+            skip_step = False
+            for cap in sorted(missing_caps):
+                answer = input(f"Grant capability {cap.value}? [y/N]").strip().lower()
+                if answer == "y":
+                    allowed.add(cap)
+                    with log_path.open("a", encoding="utf-8") as log:
+                        log.write(f"[granted capability: {cap.value}]\n")
+                else:
+                    msg = f"Missing capabilities: {cap.value}"
+                    print(msg, file=sys.stderr)
+                    with log_path.open("a", encoding="utf-8") as log:
+                        log.write(f"$ {step.command}\n")
+                        log.write(f"[missing capabilities: {cap.value}]\n")
+                        log.write("(skipped)\n\n")
+                    if not exit_code:
+                        exit_code = 1
+                    skip_step = True
+                    break
+            if skip_step:
+                continue
         is_risky = "[risk:" in step.command
         step_assume_yes = assume_yes and (confirm or not is_risky)
 
@@ -129,7 +140,9 @@ def execute_steps(
         result = subprocess.run(cmd, shell=needs_shell, capture_output=True, text=True)
         with log_path.open("a", encoding="utf-8") as log:
             log.write(f"$ {step.command}\n")
-            log.write(f"[capabilities: {', '.join(sorted(step.capabilities))}]\n")
+            log.write(
+                f"[capabilities: {', '.join(sorted(c.value for c in step.capabilities))}]\n"
+            )
             if result.stdout:
                 log.write(result.stdout)
             if result.stderr:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,35 @@
+from scripts import cli_common
+from scripts.cli_common import PlanStep
+from scripts.capabilities import Capability
+
+
+def test_grant_capability_allows_execution(monkeypatch, tmp_path):
+    inputs = iter(["y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    executed = {}
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        executed["called"] = True
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
+
+    step = PlanStep(1, "echo hi", capabilities={Capability.PROCESS_EXEC})
+    rc = cli_common.execute_steps(
+        [step],
+        log_path=tmp_path / "log.txt",
+        assume_yes=True,
+    )
+
+    assert rc == 0
+    assert executed["called"] is True
+    content = (tmp_path / "log.txt").read_text()
+    assert "[granted capability: process.exec]" in content

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -4,6 +4,7 @@ import uuid
 pytest.importorskip("requests")
 from scripts import cli_common
 from scripts.cli_common import PlanStep
+from scripts.capabilities import Capability
 
 
 def test_record_event_skips_when_disabled(monkeypatch):
@@ -188,6 +189,9 @@ def test_execute_steps_windows_path(monkeypatch, tmp_path):
 
 
 def test_execute_steps_enforces_capabilities(monkeypatch, tmp_path):
+    inputs = iter(["n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
     captured = {}
 
     def fake_run(cmd, *, shell, capture_output, text):
@@ -203,11 +207,11 @@ def test_execute_steps_enforces_capabilities(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
 
-    step = PlanStep(1, "echo hi", capabilities={"process.exec"})
+    step = PlanStep(1, "echo hi", capabilities={Capability.PROCESS_EXEC})
     rc = cli_common.execute_steps(
         [step],
         log_path=tmp_path / "log.txt",
-        allowed_capabilities={"filesystem.read"},
+        allowed_capabilities={Capability.FILESYSTEM_READ},
         assume_yes=True,
     )
 
@@ -232,11 +236,11 @@ def test_execute_steps_logs_capabilities(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
 
-    step = PlanStep(1, "echo hi", capabilities={"process.exec"})
+    step = PlanStep(1, "echo hi", capabilities={Capability.PROCESS_EXEC})
     cli_common.execute_steps(
         [step],
         log_path=tmp_path / "log.txt",
-        allowed_capabilities={"process.exec"},
+        allowed_capabilities={Capability.PROCESS_EXEC},
     )
 
     content = (tmp_path / "log.txt").read_text()


### PR DESCRIPTION
## Summary
- define Capability enum for filesystem, process, and network scopes
- prompt for capability escalation before executing steps and log grants
- test capability escalation flow

## Testing
- `ruff check scripts/cli_common.py scripts/capabilities.py tests/test_cli_common.py tests/test_capabilities.py`
- `pytest tests/test_cli_common.py::test_execute_steps_enforces_capabilities tests/test_cli_common.py::test_execute_steps_logs_capabilities tests/test_capabilities.py::test_grant_capability_allows_execution -q`


------
https://chatgpt.com/codex/tasks/task_e_689f40ba432883268bc4af5706e8a64f