### PR TITLE
feat: add rationale and json output to ai_suggest

### DIFF
--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import json
 import shlex
 import subprocess
 import sys
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from llm import router
 from llm.backends import initialize
@@ -39,16 +40,29 @@ def _label_risk(step: str) -> str:
     return f"{step} [risk:{risk}]"
 
 
+def _split_rationale(line: str) -> tuple[str, str]:
+    """Split ``line`` into ``command`` and ``rationale`` parts."""
+    if " # " in line:
+        cmd, rationale = line.split(" # ", 1)
+        return cmd.strip(), rationale.strip()
+    return line.strip(), ""
+
+
 def suggest(
     goal: str,
     *,
     local: bool = False,
     model: str = router.DEFAULT_MODEL,
     context: str | None = None,
-) -> List[str]:
-    """Return up to three risk-tagged shell command suggestions for ``goal``."""
-    text = router.shell_suggest(goal, local=local, model=model, context=context)
-    return [_label_risk(line) for line in text[:3]]
+) -> List[Dict[str, str]]:
+    """Return up to three risk-tagged suggestions with rationales."""
+    prompt = f"{goal}\nExplain each command briefly"
+    text = router.shell_suggest(prompt, local=local, model=model, context=context)
+    suggestions: List[Dict[str, str]] = []
+    for line in text[:3]:
+        cmd, rationale = _split_rationale(line)
+        suggestions.append({"command": _label_risk(cmd), "rationale": rationale})
+    return suggestions
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -61,6 +75,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         default=router.DEFAULT_MODEL,
         help="Model name for Ollama (default: %(default)s)",
     )
+    parser.add_argument("--json", action="store_true", help="Output suggestions as JSON")
     args = parser.parse_args(argv)
     args.analytics = getattr(args, "analytics", analytics_default())
     try:
@@ -71,8 +86,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             "ai-suggest", {"exit_code": 1}, enabled=args.analytics
         )
         return 1
-    for line in suggestions:
-        print(line)
+    if args.json:
+        print(json.dumps(suggestions))
+    else:
+        for item in suggestions:
+            print(item["command"])
+            if item["rationale"]:
+                print(item["rationale"])
+            print("Press Enter to run")
     cli_actions.record_event_logged(
         "ai-suggest",
         {"exit_code": 0, "suggestion_count": len(suggestions)},

--- a/tests/test_ai_suggest.py
+++ b/tests/test_ai_suggest.py
@@ -1,5 +1,6 @@
 import contextlib
 import io
+import json
 
 import pytest
 
@@ -8,27 +9,42 @@ pytest.importorskip("requests")
 from scripts import ai_suggest
 
 
-def test_ai_suggest_risk_tagging(monkeypatch):
-    lines = [
-        "rm -rf /",
-        "sudo reboot now",
-        "ls -la",
-        "echo hi",
+def _fake_suggestions(goal, *, local=False, model=ai_suggest.router.DEFAULT_MODEL, context=None):
+    assert goal.startswith("goal")
+    return [
+        "rm -rf / # wipe everything",
+        "sudo reboot now # restart",
+        "ls -la # list",
+        "echo hi # greet",
     ]
 
-    def fake(goal, *, local=False, model=ai_suggest.router.DEFAULT_MODEL, context=None):
-        assert goal == "goal"
-        return lines
 
-    monkeypatch.setattr(ai_suggest.router, "shell_suggest", fake)
+def test_ai_suggest_risk_tagging_and_rationale(monkeypatch):
+    monkeypatch.setattr(ai_suggest.router, "shell_suggest", _fake_suggestions)
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
         rc = ai_suggest.main(["goal", "--local", "--model", "m"])
     assert rc == 0
-    suggestions = out.getvalue().splitlines()
-    assert len(suggestions) == 3
-    assert suggestions[0].endswith("[risk:rm]")
-    assert suggestions[1].endswith("[risk:reboot]")
-    assert suggestions[2].endswith("[risk:info]")
-    for line in suggestions:
-        assert "[risk:" in line
+    lines = out.getvalue().splitlines()
+    assert len(lines) == 9  # 3 suggestions * 3 lines each
+    assert lines[0].endswith("[risk:rm]")
+    assert lines[1] == "wipe everything"
+    assert lines[2] == "Press Enter to run"
+    assert lines[3].endswith("[risk:reboot]")
+    assert lines[4] == "restart"
+    assert lines[5] == "Press Enter to run"
+    assert lines[6].endswith("[risk:info]")
+    assert lines[7] == "list"
+    assert lines[8] == "Press Enter to run"
+
+
+def test_ai_suggest_json_output(monkeypatch):
+    monkeypatch.setattr(ai_suggest.router, "shell_suggest", _fake_suggestions)
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_suggest.main(["goal", "--json"])
+    assert rc == 0
+    data = json.loads(out.getvalue())
+    assert len(data) == 3
+    assert data[0]["command"].endswith("[risk:rm]")
+    assert data[0]["rationale"] == "wipe everything"


### PR DESCRIPTION
## Summary
- request rationale from model and display "Press Enter to run" prompts
- add optional `--json` output for terminal UI integration
- extend tests to cover rationale, prompts, and JSON output

## Testing
- `pre-commit run --files scripts/ai_suggest.py tests/test_ai_suggest.py`
- `pytest tests/test_ai_suggest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f509881c08326845c65310a6e596f