### PR TITLE
Add curated recipe plugins and tests

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -5,19 +5,19 @@ sequences for setting up a Windows development environment. Each recipe returns
 a list of shell commands that can be executed on a Windows host.
 
 ## wsl
-- **Usage:** Enables and installs the Windows Subsystem for Linux.
+- **Usage:** Enables required optional features, installs WSL, and sets version 2 as the default.
 - **Prerequisites:** Requires Windows 10 or later with virtualization enabled.
 
 ## docker_desktop
-- **Usage:** Installs Docker Desktop via `winget`.
+- **Usage:** Installs Docker Desktop and configures WSL 2 as the container backend.
 - **Prerequisites:** Requires WSL 2 and a 64‑bit system.
 
 ## vscode
-- **Usage:** Installs Visual Studio Code using `winget`.
+- **Usage:** Installs Visual Studio Code and recommended Python and Jupyter extensions.
 - **Prerequisites:** None.
 
 ## gpu_drivers
-- **Usage:** Installs NVIDIA GPU drivers through `winget`.
+- **Usage:** Installs NVIDIA display drivers and the CUDA toolkit.
 - **Prerequisites:** NVIDIA GPU hardware.
 
 ## windows_terminal

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -61,15 +61,16 @@ PLUGIN_REGISTRY: Dict[str, str] = {
 # Mapping of recipe name to pip package used as a fallback when a registry
 # cannot be loaded from the network or cache.
 RECIPE_REGISTRY: Dict[str, str] = {
-    "echo": "d0ttino-echo-recipe",
-    "wsl": "d0ttino-wsl-recipe",
+    # Curated recipes shipped with the repository
     "docker_desktop": "d0ttino-docker-desktop-recipe",
-    "vscode": "d0ttino-vscode-recipe",
-    "gpu_drivers": "d0ttino-gpu-drivers-recipe",
-    "windows_terminal": "d0ttino-windows-terminal-recipe",
-    "powershell": "d0ttino-powershell-recipe",
-    "nodejs": "d0ttino-nodejs-recipe",
     "git": "d0ttino-git-recipe",
+    "gpu_drivers": "d0ttino-gpu-drivers-recipe",
+    "nodejs": "d0ttino-nodejs-recipe",
+    "powershell": "d0ttino-powershell-recipe",
+    "vscode": "d0ttino-vscode-recipe",
+    "windows_terminal": "d0ttino-windows-terminal-recipe",
+    "wsl": "d0ttino-wsl-recipe",
+    "echo": "d0ttino-echo-recipe",
 }
 
 # Default directory for recipe packages downloaded via ``recipes sync``

--- a/scripts/recipes/plugins/docker_desktop.py
+++ b/scripts/recipes/plugins/docker_desktop.py
@@ -7,8 +7,11 @@ from llm.backends.plugin_sdk import register_recipe
 
 
 def run(_: str) -> List[str]:
-    """Install Docker Desktop using winget."""
-    return ["winget install -e --id Docker.DockerDesktop"]
+    """Install Docker Desktop and configure the WSL 2 backend."""
+    return [
+        "winget install -e --id Docker.DockerDesktop",
+        "wsl --set-default-version 2",
+    ]
 
 
 register_recipe("docker_desktop", run)

--- a/scripts/recipes/plugins/gpu_drivers.py
+++ b/scripts/recipes/plugins/gpu_drivers.py
@@ -7,8 +7,11 @@ from llm.backends.plugin_sdk import register_recipe
 
 
 def run(_: str) -> List[str]:
-    """Install NVIDIA GPU drivers via winget."""
-    return ["winget install -e --id Nvidia.DisplayDriver"]
+    """Install NVIDIA GPU drivers and CUDA toolkit."""
+    return [
+        "winget install -e --id Nvidia.DisplayDriver",
+        "winget install -e --id Nvidia.CUDA",
+    ]
 
 
 register_recipe("gpu_drivers", run)

--- a/scripts/recipes/plugins/vscode.py
+++ b/scripts/recipes/plugins/vscode.py
@@ -7,8 +7,12 @@ from llm.backends.plugin_sdk import register_recipe
 
 
 def run(_: str) -> List[str]:
-    """Install Visual Studio Code via winget."""
-    return ["winget install -e --id Microsoft.VisualStudioCode"]
+    """Install Visual Studio Code and common extensions."""
+    return [
+        "winget install -e --id Microsoft.VisualStudioCode",
+        "code --install-extension ms-python.python",
+        "code --install-extension ms-toolsai.jupyter",
+    ]
 
 
 register_recipe("vscode", run)

--- a/scripts/recipes/plugins/wsl.py
+++ b/scripts/recipes/plugins/wsl.py
@@ -7,8 +7,13 @@ from llm.backends.plugin_sdk import register_recipe
 
 
 def run(_: str) -> List[str]:
-    """Install the Windows Subsystem for Linux."""
-    return ["wsl --install"]
+    """Install the Windows Subsystem for Linux with required features."""
+    return [
+        "dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart",
+        "dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart",
+        "wsl --install",
+        "wsl --set-default-version 2",
+    ]
 
 
 register_recipe("wsl", run)

--- a/tests/test_recipe_plugins.py
+++ b/tests/test_recipe_plugins.py
@@ -71,3 +71,26 @@ def test_discover_recipes_loads_entry_points_py310(monkeypatch):
     mapping = recipes.discover_recipes()
     assert "dummy" in mapping
 
+
+def test_builtin_curated_recipes():
+    mapping = recipes.discover_recipes()
+    assert mapping["wsl"]("") == [
+        "dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart",
+        "dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart",
+        "wsl --install",
+        "wsl --set-default-version 2",
+    ]
+    assert mapping["docker_desktop"]("") == [
+        "winget install -e --id Docker.DockerDesktop",
+        "wsl --set-default-version 2",
+    ]
+    assert mapping["vscode"]("") == [
+        "winget install -e --id Microsoft.VisualStudioCode",
+        "code --install-extension ms-python.python",
+        "code --install-extension ms-toolsai.jupyter",
+    ]
+    assert mapping["gpu_drivers"]("") == [
+        "winget install -e --id Nvidia.DisplayDriver",
+        "winget install -e --id Nvidia.CUDA",
+    ]
+


### PR DESCRIPTION
## Summary
- enrich WSL, Docker Desktop, VS Code, and GPU driver recipes with curated command sequences
- register curated recipes in plugin registry and document usage
- verify new recipes with unit tests

## Testing
- `ruff check scripts tests/test_recipe_plugins.py`
- `pytest tests/test_recipe_plugins.py`


------
https://chatgpt.com/codex/tasks/task_e_689f509919188326a67080ea581320ad