### PR TITLE
feat: track budget and capability tokens

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -263,9 +263,23 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_status(args: argparse.Namespace) -> int:
-    """Show remaining budget, routing mode, and last model source."""
+    """Show remaining budget, a visual meter, routing mode, and last model source."""
     budget, source = router.get_budget()
-    print(f"Budget remaining: {budget}")
+    total: int | None = None
+    load_budget = getattr(router, "_load_budget", None)
+    if callable(load_budget):
+        try:
+            total = load_budget()
+        except Exception:  # pragma: no cover - best effort
+            total = None
+    if budget is not None and total:
+        width = 10
+        filled = int(budget / total * width)
+        meter = f"[{'#' * filled}{'-' * (width - filled)}]"
+        print(f"Budget remaining: {budget}/{total}")
+        print(f"Budget meter: {meter}")
+    else:
+        print(f"Budget remaining: {budget}")
     mode = os.environ.get("LLM_ROUTING_MODE", "auto")
     print(f"Routing mode: {mode}")
     print(f"Last model source: {source or 'unknown'}")

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import secrets
 import shlex
 import subprocess
 import sys
@@ -34,6 +35,9 @@ class PlanStep:
     command: str
     diff: Optional[str] = None
     capabilities: Set[str] = field(default_factory=set)
+
+
+_SESSION_TOKENS: dict[str, str] = {}
 
 
 def _strip_risk_tag(command: str) -> str:
@@ -84,6 +88,7 @@ def execute_steps(
 
     exit_code = 0
     allowed = set(allowed_capabilities) if allowed_capabilities else set()
+    allowed.update(_SESSION_TOKENS.keys())
     for step in step_list:
         print(f"{step.number}. {step.command}")
         if step.diff:
@@ -93,17 +98,22 @@ def execute_steps(
         if missing_caps:
             skip_step = False
             for cap in sorted(missing_caps):
-                answer = input(f"Grant capability {cap}? [y/N]").strip().lower()
+                cap_name = cap.value if hasattr(cap, "value") else str(cap)
+                answer = input(f"Grant capability {cap_name}? [y/N]").strip().lower()
                 if answer == "y":
+                    token = secrets.token_hex(8)
+                    _SESSION_TOKENS[cap] = token
                     allowed.add(cap)
                     with log_path.open("a", encoding="utf-8") as log:
-                        log.write(f"[granted capability: {cap}]\n")
+                        log.write(
+                            f"[granted capability: {cap_name} token: {token}]\n"
+                        )
                 else:
-                    msg = f"Missing capabilities: {cap}"
+                    msg = f"Missing capabilities: {cap_name}"
                     print(msg, file=sys.stderr)
                     with log_path.open("a", encoding="utf-8") as log:
                         log.write(f"$ {step.command}\n")
-                        log.write(f"[missing capabilities: {cap}]\n")
+                        log.write(f"[missing capabilities: {cap_name}]\n")
                         log.write("(skipped)\n\n")
                     if not exit_code:
                         exit_code = 1

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,9 +1,12 @@
+import re
+
 from scripts import cli_common
 from scripts.cli_common import PlanStep
 from scripts.capabilities import Capability
 
 
 def test_grant_capability_allows_execution(monkeypatch, tmp_path):
+    cli_common._SESSION_TOKENS.clear()
     inputs = iter(["y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
@@ -32,4 +35,41 @@ def test_grant_capability_allows_execution(monkeypatch, tmp_path):
     assert rc == 0
     assert executed["called"] is True
     content = (tmp_path / "log.txt").read_text()
-    assert "[granted capability: process.exec]" in content
+    assert re.search(r"\[granted capability: process\.exec token: [0-9a-f]+\]", content)
+
+
+def test_tokens_persist_for_session(monkeypatch, tmp_path):
+    cli_common._SESSION_TOKENS.clear()
+    calls = {"count": 0}
+
+    def fake_input(_: str) -> str:
+        calls["count"] += 1
+        return "y"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    executed = []
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        executed.append(cmd)
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
+
+    step = PlanStep(1, "echo hi", capabilities={Capability.PROCESS_EXEC})
+    log = tmp_path / "log.txt"
+    rc1 = cli_common.execute_steps([step], log_path=log, assume_yes=True)
+    rc2 = cli_common.execute_steps([step], log_path=log, assume_yes=True)
+
+    assert rc1 == rc2 == 0
+    assert calls["count"] == 1
+    assert len(executed) == 2
+    content = log.read_text()
+    assert content.count("granted capability") == 1

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -61,7 +61,8 @@ def test_status_reports_budget_and_source(monkeypatch):
         rc = ai_cli.main(["status"])
     assert rc == 0
     assert out.getvalue().splitlines() == [
-        "Budget remaining: 3",
+        "Budget remaining: 3/5",
+        "Budget meter: [######----]",
         "Routing mode: remote",
         "Last model source: gemini",
     ]


### PR DESCRIPTION
## Summary
- add budget meter to `ai status`
- persist session-scoped capability tokens and log them
- test budget meter and capability token reuse

## Testing
- `pre-commit run --files scripts/ai_cli.py scripts/cli_common.py tests/test_capabilities.py tests/test_router_budget.py`
- `pytest tests/test_router_budget.py tests/test_capabilities.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0af3a175c83269962a4afba480f4e