### PR TITLE
feat: add interactive suggestion execution

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -109,14 +109,34 @@ def _cmd_suggest(args: argparse.Namespace) -> int:
         print(exc, file=sys.stderr)
         _publish_event(args, "ai-cli-suggest", {"exit_code": 1})
         return 1
-    for line in suggestions:
-        print(line)
+    log_path = Path.home() / ".config" / "d0tTino" / "ai_cli_suggest.log"
+    exit_code = 0
+    for idx, item in enumerate(suggestions, 1):
+        print(item["command"])
+        if item["rationale"]:
+            print(item["rationale"])
+        answer = input("Press Enter to run, anything else to skip: ").strip()
+        if answer == "":
+            payload = {"goal": args.goal, "suggestion_index": idx}
+            if _session.get("context"):
+                payload["context"] = _session["context"]
+            rc = cli_actions.run_steps(
+                "ai-cli-suggest-run",
+                [item["command"]],
+                log_path=log_path,
+                analytics=args.analytics,
+                payload=payload,
+                assume_yes=True,
+                confirm=True,
+            )
+            if exit_code == 0:
+                exit_code = rc
     _publish_event(
         args,
         "ai-cli-suggest",
-        {"exit_code": 0, "suggestion_count": len(suggestions)},
+        {"exit_code": exit_code, "suggestion_count": len(suggestions)},
     )
-    return 0
+    return exit_code
 
 
 def _clarify_goal(

--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -8,6 +8,7 @@ import json
 import shlex
 import subprocess
 import sys
+from pathlib import Path
 from typing import Dict, List, Optional
 
 from llm import router
@@ -89,11 +90,22 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.json:
         print(json.dumps(suggestions))
     else:
-        for item in suggestions:
+        log_path = Path.home() / ".config" / "d0tTino" / "ai_suggest.log"
+        for idx, item in enumerate(suggestions, 1):
             print(item["command"])
             if item["rationale"]:
                 print(item["rationale"])
-            print("Press Enter to run")
+            answer = input("Press Enter to run, anything else to skip: ").strip()
+            if answer == "":
+                cli_actions.run_steps(
+                    "ai-suggest-run",
+                    [item["command"]],
+                    log_path=log_path,
+                    analytics=args.analytics,
+                    assume_yes=True,
+                    confirm=True,
+                    payload={"suggestion_index": idx, "goal": args.goal},
+                )
     cli_actions.record_event_logged(
         "ai-suggest",
         {"exit_code": 0, "suggestion_count": len(suggestions)},

--- a/tests/test_ai_cli_suggest.py
+++ b/tests/test_ai_cli_suggest.py
@@ -1,32 +1,61 @@
 import contextlib
 import io
-import pytest
 
-pytest.importorskip("requests")
-
-from scripts import ai_cli, ai_suggest
+from scripts import ai_cli, ai_suggest, cli_actions
 
 
-def test_suggest_subcommand(monkeypatch):
-    suggestions = [
-        "rm -rf / [risk:rm]",
-        "sudo reboot now [risk:reboot]",
-        "ls -la [risk:info]",
-    ]
+def test_suggest_executes_selected_command(monkeypatch):
+    monkeypatch.setattr(ai_cli, "_session", {"context": "ctx"})
+    monkeypatch.setattr(
+        ai_suggest,
+        "suggest",
+        lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
+    )
+    inputs = iter([""])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
-    def fake_suggest(goal, *, local=False, model=ai_cli.router.DEFAULT_MODEL, context=None):
-        assert goal == "goal"
-        assert local is True
-        assert model == "m"
-        return suggestions
+    captured = {}
 
-    monkeypatch.setattr(ai_suggest, "suggest", fake_suggest)
+    def fake_run_steps(event_name, steps, **kwargs):
+        captured["event"] = event_name
+        captured["steps"] = steps
+        captured["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(cli_actions, "run_steps", fake_run_steps)
+
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
-        rc = ai_cli.main(["suggest", "goal", "--local", "--model", "m"])
+        rc = ai_cli.main(["suggest", "goal", "--analytics"])
     assert rc == 0
-    lines = out.getvalue().splitlines()
-    assert lines == suggestions
-    assert len(lines) == 3
-    for line in lines:
-        assert "[risk:" in line
+    assert captured["event"] == "ai-cli-suggest-run"
+    assert captured["steps"] == ["echo hi [risk:info]"]
+    assert captured["kwargs"]["analytics"] is True
+    payload = captured["kwargs"]["payload"]
+    assert payload["goal"] == "goal"
+    assert payload["context"] == "ctx"
+
+
+def test_suggest_skips_on_input(monkeypatch):
+    monkeypatch.setattr(ai_cli, "_session", {})
+    monkeypatch.setattr(
+        ai_suggest,
+        "suggest",
+        lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
+    )
+    inputs = iter(["n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    calls = []
+
+    def fake_run_steps(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 0
+
+    monkeypatch.setattr(cli_actions, "run_steps", fake_run_steps)
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["suggest", "goal"])
+    assert rc == 0
+    assert calls == []


### PR DESCRIPTION
## Summary
- allow ai_suggest to optionally run suggestions after user confirmation
- enable ai_cli suggest subcommand to execute selected suggestions with analytics and context
- cover interactive suggest flow with tests

## Testing
- `ruff check scripts/ai_suggest.py scripts/ai_cli.py tests/test_ai_cli_suggest.py`
- `pytest tests/test_ai_cli_suggest.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0af3904988326b5ee8931a1ef9ea0