### PR TITLE
feat: add package manager manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ For private and ongoing work (such as **Aiga** and other closed repos), I focus 
 Install with your preferred Windows package manager:
 
 ```powershell
-winget install tino
-scoop install tino
+winget install tino # or: scoop bucket add tino https://github.com/d0tTino/tino-bucket; scoop install tino
 ```
 
 For advanced bootstrap options, see

--- a/scoop/tino-bucket/tino.json
+++ b/scoop/tino-bucket/tino.json
@@ -1,10 +1,10 @@
 {
-    "version": "{{VERSION}}",
+    "version": "1.0.0",
     "description": "Bootstrap scripts and configuration for d0tTino",
     "homepage": "https://github.com/d0tTino/d0tTino",
     "license": "MIT",
-    "url": "https://github.com/d0tTino/d0tTino/releases/download/v{{VERSION}}/tino-windows-{{VERSION}}.zip",
-    "hash": "{{SHA256}}",
+    "url": "https://github.com/d0tTino/d0tTino/releases/download/v1.0.0/tino-windows-1.0.0.zip",
+    "hash": "f9045de4815968cf632a2a33d5c56f6234df241aa39ec259b44480b7fe3782d6",
     "pre_install": "bash \"$dir\\scripts\\install_common.sh\" --dry-run",
     "autoupdate": {
         "url": "https://github.com/d0tTino/d0tTino/releases/download/v$version/tino-windows-$version.zip"

--- a/winget/tino.yaml
+++ b/winget/tino.yaml
@@ -1,6 +1,6 @@
 PackageIdentifier: Tino.d0tTino
 # The release script fills in the version, installer URL and hash
-PackageVersion: "{{VERSION}}"
+PackageVersion: "1.0.0"
 PackageLocale: en-US
 Publisher: d0tTino
 PackageName: d0tTino
@@ -10,7 +10,7 @@ PackageUrl: https://github.com/d0tTino/d0tTino
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v{{VERSION}}/tino-windows-{{VERSION}}.zip
-    Sha256: "{{SHA256}}"
+    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v1.0.0/tino-windows-1.0.0.zip
+    Sha256: "F9045DE4815968CF632A2A33D5C56F6234DF241AA39EC259B44480B7FE3782D6"
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- update winget manifest to version 1.0.0 with release hash
- add Scoop bucket manifest for `tino`
- document one-line install for winget or Scoop

## Testing
- `pre-commit run --files winget/tino.yaml scoop/tino-bucket/tino.json README.md`
- `python scripts/validate_winget.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0af38d4b88326871b7aac5ac1cb36