### PR TITLE
feat: support mcp metadata in plugin registry

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -27,6 +27,13 @@
     "lmql": {
       "package": "d0ttino-lmql-plugin",
       "mcp": {}
+    },
+    "example_mcp": {
+      "package": "d0ttino-example-mcp-plugin",
+      "mcp": {
+        "server_url": "https://example.com/mcp",
+        "capabilities": ["echo"]
+      }
     }
   },
   "recipes": {

--- a/plugin-registry.schema.json
+++ b/plugin-registry.schema.json
@@ -17,7 +17,20 @@
           },
           "mcp": {
             "type": "object",
-            "description": "MCP metadata for the plug-in"
+            "description": "MCP metadata for the plug-in",
+            "properties": {
+              "server_url": {
+                "type": "string",
+                "format": "uri",
+                "description": "Base URL for the MCP server"
+              },
+              "capabilities": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Capabilities exposed by the server"
+              }
+            },
+            "additionalProperties": false
           }
         },
         "additionalProperties": false

--- a/plugins/example_mcp_plugin.py
+++ b/plugins/example_mcp_plugin.py
@@ -1,0 +1,16 @@
+"""Example MCP plugin providing metadata for tests."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def mcp_tool() -> Dict[str, object]:
+    """Return example MCP metadata."""
+    return {
+        "server_url": "https://example.com/mcp",
+        "capabilities": ["echo"],
+    }
+
+
+__all__: List[str] = ["mcp_tool"]

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -45,23 +45,16 @@ def run_steps(
     risk_present = any("[risk:" in s.command for s in step_list)
     if assume_yes and not confirm and risk_present:
         print("Risky commands present. User confirmation required.", file=sys.stderr)
-        exit_code = execute_steps(
-            step_list,
-            log_path=log_path,
-            dry_run=dry_run,
-            assume_yes=False,
-            confirm=True,
-            allowed_capabilities=allowed_capabilities,
-        )
-    else:
-        exit_code = execute_steps(
-            step_list,
-            log_path=log_path,
-            dry_run=dry_run,
-            assume_yes=assume_yes,
-            confirm=confirm,
-            allowed_capabilities=allowed_capabilities,
-        )
+        return 1
+
+    exit_code = execute_steps(
+        step_list,
+        log_path=log_path,
+        dry_run=dry_run,
+        assume_yes=assume_yes,
+        confirm=confirm,
+        allowed_capabilities=allowed_capabilities,
+    )
     end = time.time()
     data = {
         "exit_code": exit_code,

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -93,17 +93,17 @@ def execute_steps(
         if missing_caps:
             skip_step = False
             for cap in sorted(missing_caps):
-                answer = input(f"Grant capability {cap}? [y/N]").strip().lower()
+                answer = input(f"Grant capability {cap.value}? [y/N]").strip().lower()
                 if answer == "y":
                     allowed.add(cap)
                     with log_path.open("a", encoding="utf-8") as log:
-                        log.write(f"[granted capability: {cap}]\n")
+                        log.write(f"[granted capability: {cap.value}]\n")
                 else:
-                    msg = f"Missing capabilities: {cap}"
+                    msg = f"Missing capabilities: {cap.value}"
                     print(msg, file=sys.stderr)
                     with log_path.open("a", encoding="utf-8") as log:
                         log.write(f"$ {step.command}\n")
-                        log.write(f"[missing capabilities: {cap}]\n")
+                        log.write(f"[missing capabilities: {cap.value}]\n")
                         log.write("(skipped)\n\n")
                     if not exit_code:
                         exit_code = 1

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -56,6 +56,7 @@ PLUGIN_REGISTRY: Dict[str, str] = {
     "anthropic": "d0ttino-anthropic-plugin",
     "mistral": "d0ttino-mistral-plugin",
     "lmql": "d0ttino-lmql-plugin",
+    "example_mcp": "d0ttino-example-mcp-plugin",
 }
 
 # Mapping of recipe name to pip package used as a fallback when a registry
@@ -233,7 +234,18 @@ def load_registry(
         mapping = data.get(section) or {}
         if isinstance(mapping, dict):
             if raw:
-                return mapping
+                result: Dict[str, Any] = {}
+                for k, v in mapping.items():
+                    if isinstance(v, str):
+                        result[str(k)] = {"package": v, "mcp": {}}
+                    elif isinstance(v, dict):
+                        pkg = v.get("package")
+                        mcp_meta = v.get("mcp")
+                        if not isinstance(mcp_meta, dict):
+                            mcp_meta = {}
+                        if isinstance(pkg, str):
+                            result[str(k)] = {"package": pkg, "mcp": mcp_meta}
+                return result
             result: Dict[str, str] = {}
             for k, v in mapping.items():
                 if isinstance(v, str):

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -470,7 +470,7 @@ def test_plan_nats_publish(monkeypatch):
     monkeypatch.setattr(ai_cli.ai_exec, "plan", lambda *a, **k: [PlanStep(1, "one")])
     published = []
 
-    def fake_publish(url, name, payload):
+    async def fake_publish(name, payload, *, url):
         published.append((url, name, payload))
         return True
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -210,6 +210,39 @@ def test_load_registry_fetches_with_zero_ttl(monkeypatch, tmp_path):
     assert registry == {"y": "pkg"}
 
 
+def test_load_registry_surfaces_mcp_metadata(monkeypatch, tmp_path):
+    cache = tmp_path / "cache.json"
+    monkeypatch.setattr(plugins, "CACHE_PATH", cache)
+
+    data = {
+        "plugins": {
+            "example": {
+                "package": "pkg",
+                "mcp": {
+                    "server_url": "https://example.com",
+                    "capabilities": ["x"],
+                },
+            }
+        }
+    }
+
+    monkeypatch.setattr(plugins, "_fetch_registry", lambda url: data)
+    monkeypatch.setenv("PLUGIN_REGISTRY_URL", "https://example.com")
+
+    registry = plugins.load_registry(raw=True, update=True)
+    meta = registry["example"]["mcp"]
+    assert meta["server_url"] == "https://example.com"
+    assert meta["capabilities"] == ["x"]
+
+
+def test_example_mcp_plugin_metadata():
+    from plugins import example_mcp_plugin
+
+    meta = example_mcp_plugin.mcp_tool()
+    assert meta["server_url"] == "https://example.com/mcp"
+    assert meta["capabilities"] == ["echo"]
+
+
 def test_builtin_plugins_present(monkeypatch, tmp_path):
     monkeypatch.setattr(plugins, "CACHE_PATH", tmp_path / "missing.json")
 


### PR DESCRIPTION
## Summary
- extend plugin registry schema with MCP server URL and capabilities
- expose MCP metadata via `load_registry`
- add example MCP plugin and tests
- ensure risky commands require confirmation and log capability values clearly

## Testing
- `ruff check scripts/cli_actions.py scripts/cli_common.py tests/test_ai_cli.py`
- `pytest tests/test_ai_cli.py::test_plan_nats_publish -q`
- `pytest tests/test_ai_do.py::test_risky_requires_confirm -q`
- `pytest tests/test_capabilities.py::test_grant_capability_allows_execution -q`
- `pytest tests/test_cli_common.py::test_execute_steps_enforces_capabilities -q`
- `pytest tests/test_plugin_registry.py tests/test_plugin_registry_schema.py tests/test_plugin_registry_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0af399bb08326b15e5999c0c08ef0