### PR TITLE
chore: update package manifests

### DIFF
--- a/scoop/tino-bucket/tino.json
+++ b/scoop/tino-bucket/tino.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Bootstrap scripts and configuration for d0tTino",
     "homepage": "https://github.com/d0tTino/d0tTino",
     "license": "MIT",
-    "url": "https://github.com/d0tTino/d0tTino/releases/download/v1.0.0/tino-windows-1.0.0.zip",
-    "hash": "f9045de4815968cf632a2a33d5c56f6234df241aa39ec259b44480b7fe3782d6",
+    "url": "https://github.com/d0tTino/d0tTino/releases/download/v1.0.1/tino-windows-1.0.1.zip",
+    "hash": "1261807f8311aac9c34283ac1b26319740ef0864e77ce5200d04cca362fbff6e",
     "pre_install": "bash \"$dir\\scripts\\install_common.sh\" --dry-run",
     "autoupdate": {
         "url": "https://github.com/d0tTino/d0tTino/releases/download/v$version/tino-windows-$version.zip"

--- a/winget/tino.yaml
+++ b/winget/tino.yaml
@@ -1,6 +1,6 @@
 PackageIdentifier: Tino.d0tTino
 # The release script fills in the version, installer URL and hash
-PackageVersion: "1.0.0"
+PackageVersion: "1.0.1"
 PackageLocale: en-US
 Publisher: d0tTino
 PackageName: d0tTino
@@ -10,7 +10,7 @@ PackageUrl: https://github.com/d0tTino/d0tTino
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v1.0.0/tino-windows-1.0.0.zip
-    Sha256: "F9045DE4815968CF632A2A33D5C56F6234DF241AA39EC259B44480B7FE3782D6"
+    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v1.0.1/tino-windows-1.0.1.zip
+    Sha256: "1261807F8311AAC9C34283AC1B26319740EF0864E77CE5200D04CCA362FBFF6E"
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- update winget manifest to version 1.0.1 with new installer URL and sha256
- update scoop manifest to version 1.0.1

## Testing
- `python3 scripts/validate_winget.py && echo "winget valid"`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd82c88c8326840cc9617c817a95