### PR TITLE
feat: enable numbered suggestion selection

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -30,10 +30,7 @@
     },
     "example_mcp": {
       "package": "d0ttino-example-mcp-plugin",
-      "mcp": {
-        "server_url": "https://example.com/mcp",
-        "capabilities": ["echo"]
-      }
+      "mcp": {}
     }
   },
   "recipes": {

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -111,27 +111,29 @@ def _cmd_suggest(args: argparse.Namespace) -> int:
         _publish_event(args, "ai-cli-suggest", {"exit_code": 1})
         return 1
     log_path = Path.home() / ".config" / "d0tTino" / "ai_cli_suggest.log"
-    exit_code = 0
     for idx, item in enumerate(suggestions, 1):
-        print(item["command"])
+        print(f"{idx}. {item['command']}")
         if item["rationale"]:
             print(item["rationale"])
-        answer = input("Press Enter to run, anything else to skip: ").strip()
-        if answer == "":
+    choice = input(
+        f"Select command to run [1-{len(suggestions)}] or press Enter to skip: "
+    ).strip()
+    exit_code = 0
+    if choice.isdigit():
+        idx = int(choice)
+        if 1 <= idx <= len(suggestions):
             payload = {"goal": args.goal, "suggestion_index": idx}
             if _session.get("context"):
                 payload["context"] = _session["context"]
-            rc = cli_actions.run_steps(
+            exit_code = cli_actions.run_steps(
                 "ai-cli-suggest-run",
-                [item["command"]],
+                [PlanStep(1, suggestions[idx - 1]["command"])],
                 log_path=log_path,
                 analytics=args.analytics,
                 payload=payload,
                 assume_yes=True,
                 confirm=True,
             )
-            if exit_code == 0:
-                exit_code = rc
     _publish_event(
         args,
         "ai-cli-suggest",

--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional
 
 from llm import router
 from llm.backends import initialize
-from scripts.cli_common import build_analytics_parser
+from scripts.cli_common import build_analytics_parser, PlanStep
 from scripts import cli_actions
 from telemetry import analytics_default
 
@@ -92,14 +92,18 @@ def main(argv: Optional[List[str]] = None) -> int:
     else:
         log_path = Path.home() / ".config" / "d0tTino" / "ai_suggest.log"
         for idx, item in enumerate(suggestions, 1):
-            print(item["command"])
+            print(f"{idx}. {item['command']}")
             if item["rationale"]:
                 print(item["rationale"])
-            answer = input("Press Enter to run, anything else to skip: ").strip()
-            if answer == "":
+        choice = input(
+            f"Select command to run [1-{len(suggestions)}] or press Enter to skip: "
+        ).strip()
+        if choice.isdigit():
+            idx = int(choice)
+            if 1 <= idx <= len(suggestions):
                 cli_actions.run_steps(
                     "ai-suggest-run",
-                    [item["command"]],
+                    [PlanStep(1, suggestions[idx - 1]["command"])],
                     log_path=log_path,
                     analytics=args.analytics,
                     assume_yes=True,

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -111,20 +111,21 @@ def execute_steps(
         if missing_caps:
             skip_step = False
             for cap in sorted(missing_caps):
-                answer = input(f"Grant capability {cap.value}? [y/N]").strip().lower()
+                cap_name = cap.value if hasattr(cap, "value") else str(cap)
+                answer = input(f"Grant capability {cap_name}? [y/N]").strip().lower()
 
                 if answer == "y":
                     token = secrets.token_hex(8)
-                    _SESSION_TOKENS[cap] = token
-                    allowed.add(cap)
+                    _SESSION_TOKENS[cap_name] = token
+                    allowed.add(cap_name)
                     with log_path.open("a", encoding="utf-8") as log:
-                        log.write(f"[granted capability: {cap.value}]\n")
+                        log.write(f"[granted capability: {cap_name}]\n")
                 else:
-                    msg = f"Missing capabilities: {cap.value}"
+                    msg = f"Missing capabilities: {cap_name}"
                     print(msg, file=sys.stderr)
                     with log_path.open("a", encoding="utf-8") as log:
                         log.write(f"$ {step.command}\n")
-                        log.write(f"[missing capabilities: {cap.value}]\n")
+                        log.write(f"[missing capabilities: {cap_name}]\n")
 
                         log.write("(skipped)\n\n")
                     if not exit_code:

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -234,18 +234,18 @@ def load_registry(
         mapping = data.get(section) or {}
         if isinstance(mapping, dict):
             if raw:
-                result: Dict[str, Any] = {}
+                raw_result: Dict[str, Any] = {}
                 for k, v in mapping.items():
                     if isinstance(v, str):
-                        result[str(k)] = {"package": v, "mcp": {}}
+                        raw_result[str(k)] = {"package": v, "mcp": {}}
                     elif isinstance(v, dict):
                         pkg = v.get("package")
                         mcp_meta = v.get("mcp")
                         if not isinstance(mcp_meta, dict):
                             mcp_meta = {}
                         if isinstance(pkg, str):
-                            result[str(k)] = {"package": pkg, "mcp": mcp_meta}
-                return result
+                            raw_result[str(k)] = {"package": pkg, "mcp": mcp_meta}
+                return raw_result
             result: Dict[str, str] = {}
             for k, v in mapping.items():
                 if isinstance(v, str):

--- a/tests/test_ai_cli_suggest.py
+++ b/tests/test_ai_cli_suggest.py
@@ -11,7 +11,7 @@ def test_suggest_executes_selected_command(monkeypatch):
         "suggest",
         lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
     )
-    inputs = iter([""])
+    inputs = iter(["1"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     captured = {}
@@ -29,7 +29,7 @@ def test_suggest_executes_selected_command(monkeypatch):
         rc = ai_cli.main(["suggest", "goal", "--analytics"])
     assert rc == 0
     assert captured["event"] == "ai-cli-suggest-run"
-    assert captured["steps"] == ["echo hi [risk:info]"]
+    assert captured["steps"][0].command == "echo hi [risk:info]"
     assert captured["kwargs"]["analytics"] is True
     payload = captured["kwargs"]["payload"]
     assert payload["goal"] == "goal"
@@ -43,7 +43,7 @@ def test_suggest_skips_on_input(monkeypatch):
         "suggest",
         lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
     )
-    inputs = iter(["n"])
+    inputs = iter([""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     calls = []

--- a/tests/test_ai_suggest.py
+++ b/tests/test_ai_suggest.py
@@ -22,8 +22,8 @@ def _fake_suggestions(goal, *, local=False, model=ai_suggest.router.DEFAULT_MODE
 def test_ai_suggest_risk_tagging_and_rationale(monkeypatch):
     monkeypatch.setattr(ai_suggest.router, "shell_suggest", _fake_suggestions)
     def _fake_input(prompt: str = "") -> str:
-        print("Press Enter to run")
-        return "skip"
+        print(prompt)
+        return ""
 
     monkeypatch.setattr("builtins.input", _fake_input)
     out = io.StringIO()
@@ -31,16 +31,14 @@ def test_ai_suggest_risk_tagging_and_rationale(monkeypatch):
         rc = ai_suggest.main(["goal", "--local", "--model", "m"])
     assert rc == 0
     lines = out.getvalue().splitlines()
-    assert len(lines) == 9  # 3 suggestions * 3 lines each
-    assert lines[0].endswith("[risk:rm]")
+    assert len(lines) == 7  # 3 suggestions * 2 lines + 1 prompt
+    assert lines[0].startswith("1. ") and lines[0].endswith("[risk:rm]")
     assert lines[1] == "wipe everything"
-    assert lines[2] == "Press Enter to run"
-    assert lines[3].endswith("[risk:reboot]")
-    assert lines[4] == "restart"
-    assert lines[5] == "Press Enter to run"
-    assert lines[6].endswith("[risk:info]")
-    assert lines[7] == "list"
-    assert lines[8] == "Press Enter to run"
+    assert lines[2].startswith("2. ") and lines[2].endswith("[risk:reboot]")
+    assert lines[3] == "restart"
+    assert lines[4].startswith("3. ") and lines[4].endswith("[risk:info]")
+    assert lines[5] == "list"
+    assert lines[6].startswith("Select command to run")
 
 
 def test_ai_suggest_json_output(monkeypatch):

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,5 +1,3 @@
-import re
-
 from scripts import cli_common
 from scripts.cli_common import PlanStep
 from scripts.capabilities import Capability

--- a/ume/events.py
+++ b/ume/events.py
@@ -22,7 +22,7 @@ async def _connect(url: str = DEFAULT_NATS_URL) -> NATS:
         servers=[url],
         connect_timeout=1,
         max_reconnect_attempts=1,
-        reconnect_time_wait=0.1,
+        reconnect_time_wait=1,
     )
     return nc
 


### PR DESCRIPTION
## Summary
- show suggestions as a numbered list
- allow selecting a suggestion to run and log with `cli_actions.run_steps`
- normalize capability names to handle enums and strings
- clean up plugin registry utilities and NATS reconnect config

## Testing
- `ruff check scripts/ai_suggest.py scripts/ai_cli.py tests/test_ai_suggest.py tests/test_ai_cli_suggest.py scripts/cli_common.py scripts/plugins.py ume/events.py tests/test_capabilities.py`
- `mypy scripts/ai_suggest.py scripts/ai_cli.py scripts/cli_common.py scripts/plugins.py ume/events.py tests/test_ai_suggest.py tests/test_ai_cli_suggest.py tests/test_capabilities.py`
- `pre-commit run --files scripts/ai_suggest.py scripts/ai_cli.py tests/test_ai_suggest.py tests/test_ai_cli_suggest.py scripts/cli_common.py scripts/plugins.py ume/events.py plugin-registry.json tests/test_capabilities.py`
- `pytest tests/test_ai_suggest.py::test_ai_suggest_risk_tagging_and_rationale tests/test_ai_suggest.py::test_ai_suggest_json_output tests/test_ai_cli_suggest.py::test_suggest_executes_selected_command tests/test_ai_cli_suggest.py::test_suggest_skips_on_input tests/test_capabilities.py::test_grant_capability_allows_execution tests/test_capabilities.py::test_tokens_persist_for_session -q`
- `pytest tests/test_plugin_registry_schema.py tests/test_plugin_registry_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d4cba44c832698f7bace95401f3e