### PR TITLE
feat: add keystroke execution to ai suggest

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -115,9 +115,13 @@ def _cmd_suggest(args: argparse.Namespace) -> int:
         print(f"{idx}. {item['command']}")
         if item["rationale"]:
             print(item["rationale"])
-    choice = input(
-        f"Select command to run [1-{len(suggestions)}] or press Enter to skip: "
-    ).strip()
+    print(
+        f"Press [1-{len(suggestions)}] to run a command or any other key to skip: ",
+        end="",
+        flush=True,
+    )
+    choice = ai_suggest.read_key()
+    print()
     exit_code = 0
     if choice.isdigit():
         idx = int(choice)

--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -17,6 +17,28 @@ from scripts.cli_common import build_analytics_parser, PlanStep
 from scripts import cli_actions
 from telemetry import analytics_default
 
+
+def read_key() -> str:
+    """Return a single character from stdin without waiting for ``Enter``."""
+    try:  # Unix
+        import termios
+        import tty
+
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            return sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    except Exception:
+        try:  # Windows fallback
+            import msvcrt  # type: ignore[import-not-found]
+
+            return msvcrt.getch().decode()
+        except Exception:  # pragma: no cover - extremely unlikely
+            return ""
+
 initialize()
 
 RISKY_COMMANDS = {"rm", "reboot", "shutdown", "poweroff", "mkfs", "dd"}
@@ -95,9 +117,13 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(f"{idx}. {item['command']}")
             if item["rationale"]:
                 print(item["rationale"])
-        choice = input(
-            f"Select command to run [1-{len(suggestions)}] or press Enter to skip: "
-        ).strip()
+        print(
+            f"Press [1-{len(suggestions)}] to run a command or any other key to skip: ",
+            end="",
+            flush=True,
+        )
+        choice = read_key()
+        print()
         if choice.isdigit():
             idx = int(choice)
             if 1 <= idx <= len(suggestions):

--- a/tests/test_ai_cli_suggest.py
+++ b/tests/test_ai_cli_suggest.py
@@ -11,8 +11,7 @@ def test_suggest_executes_selected_command(monkeypatch):
         "suggest",
         lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
     )
-    inputs = iter(["1"])
-    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr(ai_suggest, "read_key", lambda: "1")
 
     captured = {}
 
@@ -36,15 +35,14 @@ def test_suggest_executes_selected_command(monkeypatch):
     assert payload["context"] == "ctx"
 
 
-def test_suggest_skips_on_input(monkeypatch):
+def test_suggest_skips_on_keypress(monkeypatch):
     monkeypatch.setattr(ai_cli, "_session", {})
     monkeypatch.setattr(
         ai_suggest,
         "suggest",
         lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
     )
-    inputs = iter([""])
-    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr(ai_suggest, "read_key", lambda: "q")
 
     calls = []
 


### PR DESCRIPTION
## Summary
- allow running AI suggestions via a single keypress
- forward analytics and context when executing suggestions in `ai-cli`
- test interactive suggestion flow for keystroke selection

## Testing
- `ruff check scripts/ai_suggest.py scripts/ai_cli.py tests/test_ai_cli_suggest.py`
- `pytest tests/test_ai_cli_suggest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32e2d0da08326a653d1a3fbe84cb1