### PR TITLE
feat: add budget meter and capability tokens

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -57,12 +57,15 @@ def _load_budget() -> int | None:
     return int(budget_val) if isinstance(budget_val, int) else None
 
 
-_BUDGET = _load_budget()
+_TOTAL_BUDGET = _load_budget()
+_BUDGET = _TOTAL_BUDGET
 _LAST_MODEL_SOURCE: str | None = None
 
 
-def get_budget() -> tuple[int | None, str | None]:
-    return _BUDGET, _LAST_MODEL_SOURCE
+def get_budget() -> tuple[int | None, int | None, str | None]:
+    """Return remaining and total budget along with the last model source."""
+
+    return _BUDGET, _TOTAL_BUDGET, _LAST_MODEL_SOURCE
 
 
 def _decrement_budget(tokens: int) -> None:

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -298,14 +298,7 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 def _cmd_status(args: argparse.Namespace) -> int:
     """Show remaining budget, a visual meter, routing mode, and last model source."""
-    budget, source = router.get_budget()
-    total: int | None = None
-    load_budget = getattr(router, "_load_budget", None)
-    if callable(load_budget):
-        try:
-            total = load_budget()
-        except Exception:  # pragma: no cover - best effort
-            total = None
+    budget, total, source = router.get_budget()
     if budget is not None and total:
         width = 10
         filled = int(budget / total * width)

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -112,6 +112,12 @@ def execute_steps(
             skip_step = False
             for cap in sorted(missing_caps):
                 cap_name = cap.value if hasattr(cap, "value") else str(cap)
+                if cap_name in _SESSION_TOKENS:
+                    token = _SESSION_TOKENS[cap_name]
+                    allowed.add(cap_name)
+                    with log_path.open("a", encoding="utf-8") as log:
+                        log.write(f"[using capability token: {cap_name}={token}]\n")
+                    continue
                 answer = input(f"Grant capability {cap_name}? [y/N]").strip().lower()
 
                 if answer == "y":
@@ -119,7 +125,7 @@ def execute_steps(
                     _SESSION_TOKENS[cap_name] = token
                     allowed.add(cap_name)
                     with log_path.open("a", encoding="utf-8") as log:
-                        log.write(f"[granted capability: {cap_name}]\n")
+                        log.write(f"[granted capability: {cap_name} token={token}]\n")
                 else:
                     msg = f"Missing capabilities: {cap_name}"
                     print(msg, file=sys.stderr)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,3 +1,5 @@
+import re
+
 from scripts import cli_common
 from scripts.cli_common import PlanStep
 from scripts.capabilities import Capability
@@ -33,7 +35,10 @@ def test_grant_capability_allows_execution(monkeypatch, tmp_path):
     assert rc == 0
     assert executed["called"] is True
     content = (tmp_path / "log.txt").read_text()
-    assert "[granted capability: process.exec]" in content
+    match = re.search(r"\[granted capability: process\.exec token=([0-9a-f]+)\]", content)
+    assert match
+    token = match.group(1)
+    assert cli_common._SESSION_TOKENS["process.exec"] == token
 
 
 def test_tokens_persist_for_session(monkeypatch, tmp_path):
@@ -67,7 +72,8 @@ def test_tokens_persist_for_session(monkeypatch, tmp_path):
     rc2 = cli_common.execute_steps([step], log_path=log, assume_yes=True)
 
     assert rc1 == rc2 == 0
-    assert calls["count"] == 2
+    assert calls["count"] == 1
     assert len(executed) == 2
     content = log.read_text()
-    assert content.count("granted capability") == 2
+    assert content.count("granted capability") == 1
+    assert "using capability token: process.exec" in content

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -32,9 +32,9 @@ def test_budget_decrements_and_exhausts(monkeypatch):
     monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
     monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
 
-    assert router.get_budget() == (2, None)
+    assert router.get_budget() == (2, 2, None)
     router.send_prompt("hello world", model="g1")
-    assert router.get_budget() == (0, "gemini")
+    assert router.get_budget() == (0, 2, "gemini")
     with pytest.raises(RuntimeError):
         router.send_prompt("again", model="g1")
 
@@ -45,7 +45,7 @@ def test_local_does_not_use_budget(monkeypatch):
     monkeypatch.setattr(router, "run_ollama", lambda prompt, model: "local")
 
     router.send_prompt("hi there", local=True, model="o1")
-    assert router.get_budget() == (2, "ollama")
+    assert router.get_budget() == (2, 2, "ollama")
 
 
 def test_status_reports_budget_and_source(monkeypatch):


### PR DESCRIPTION
## Summary
- show remaining budget with meter using router.get_budget
- reuse capability tokens across session and log granted tokens
- test router budget and capability token behavior

## Testing
- `python -m ruff check llm/router.py scripts/ai_cli.py scripts/cli_common.py tests/test_router_budget.py tests/test_capabilities.py`
- `pytest tests/test_router_budget.py tests/test_capabilities.py`

------
https://chatgpt.com/codex/tasks/task_e_68a32e2f4b24832681a8ce075328d343