### PR TITLE
feat: require confirmation after dry-run

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -223,24 +223,25 @@ Legacy commands `ai-plan` and `ai-do` now delegate to these subcommands.
 
 The `do` subcommand always prints a dry-run of the planned commands before
 execution. Review the output and re-run with `--dry-run` to preview only or
-pass `--confirm` to execute steps marked with a `[risk:*]` tag. The dry-run
-output is replayed during the confirmed run so you execute exactly what you
-approved.
+pass `--confirm` to execute steps marked with a `[risk:*]` tag. After the dry
+run the CLI replays the output and asks for confirmation so you execute exactly
+what you approved.
 
 This interactive review makes the workflow safer by ensuring you see and approve
 every step before it runs.
 
 ### Default flow
 
-Running `ai-cli do` is the recommended default. The command performs four
+Running `ai-cli do` is the recommended default. The command performs five
 stages:
 
 1. **Plan** – draft shell commands for the goal.
 2. **Dry-run** – write the numbered steps to `ai_do.log` and print them for
    review.
-3. **Capability prompts** – grant required scopes such as
+3. **Confirm** – replay the dry-run and require approval to continue.
+4. **Capability prompts** – grant required scopes such as
    `filesystem.read`, `process.exec` or `network.fetch` before each step.
-4. **Execute** – only steps marked without a `[risk:*]` tag run
+5. **Execute** – only steps marked without a `[risk:*]` tag run
    automatically. Commands tagged with `[risk:...]` require `--confirm`.
 
 Example:

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -194,9 +194,10 @@ def _cmd_do(args: argparse.Namespace) -> int:
     dry_log: list[str] = []
     args.log.parent.mkdir(parents=True, exist_ok=True)
     execute_steps(plan_steps, log_path=args.log, dry_run=True, dry_run_log=dry_log)
+    risk_present = any("[risk:" in s.command for s in plan_steps)
     if getattr(args, "dry_run", False):
         return 0
-    if any("[risk:" in s.command for s in plan_steps) and not getattr(args, "confirm", False):
+    if risk_present and not getattr(args, "confirm", False):
         print(
             "Risky commands present. Re-run with --confirm to execute.",
             file=sys.stderr,

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -55,6 +55,7 @@ def run_steps(
         assume_yes=assume_yes,
         confirm=confirm,
         allowed_capabilities=allowed_capabilities,
+        dry_run_log=dry_run_log,
     )
 
     end = time.time()

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -86,7 +86,22 @@ def execute_steps(
             dry_run_log.extend(lines)
         return 0
 
-    if any("[risk:" in step.command for step in step_list) and not confirm:
+    risk_present = any("[risk:" in step.command for step in step_list)
+
+    if dry_run_log:
+        for line in dry_run_log:
+            print(line)
+        if risk_present and not confirm:
+            print(
+                "Risky commands present. Re-run with --confirm to execute.",
+                file=sys.stderr,
+            )
+            return 1
+        if not assume_yes:
+            answer = input("Proceed with execution? [y/N]").strip().lower()
+            if answer != "y":
+                return 1
+    elif risk_present and not confirm:
         print(
             "Risky commands present. Re-run with --confirm to execute.",
             file=sys.stderr,
@@ -95,10 +110,6 @@ def execute_steps(
 
     exit_code = 0
     allowed = set(allowed_capabilities) if allowed_capabilities else set()
-
-    if dry_run_log:
-        for line in dry_run_log:
-            print(line)
 
 
     for step in step_list:

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -269,3 +269,32 @@ def test_execute_steps_reuses_dry_run_log(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out.splitlines()
     assert out.count("1. echo hi") == 1
     assert "$ echo hi" in out
+
+
+def test_execute_steps_requires_confirmation_after_dry_run(monkeypatch, tmp_path, capsys):
+    step = PlanStep(1, "echo hi")
+    log = tmp_path / "log.txt"
+    dry_log: list[str] = []
+    cli_common.execute_steps([step], log_path=log, dry_run=True, dry_run_log=dry_log)
+    assert dry_log
+    capsys.readouterr()
+
+    called = False
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        nonlocal called
+        called = True
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    rc = cli_common.execute_steps([step], log_path=log, dry_run_log=dry_log)
+    assert rc == 1
+    assert not called


### PR DESCRIPTION
## Summary
- replay dry-run output and ask for confirmation before executing planned steps
- ensure `ai-cli do` enforces `--confirm` for risky commands
- document the confirmation flow in ai automation guide

## Testing
- `ruff check scripts/ai_cli.py scripts/cli_actions.py scripts/cli_common.py tests/test_cli_common.py tests/test_ai_cli.py`
- `pytest tests/test_cli_common.py::test_execute_steps_requires_confirmation_after_dry_run tests/test_cli_common.py::test_execute_steps_reuses_dry_run_log tests/test_ai_cli.py::test_do_subcommand tests/test_ai_cli.py::test_do_creates_log_dir tests/test_ai_cli.py::test_do_requests_clarification tests/test_ai_do.py::test_main_runs_and_logs tests/test_ai_do.py::test_main_yes_runs_without_prompts tests/test_ai_do.py::test_risky_requires_confirm tests/test_ai_do.py::test_confirm_allows_risky -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32e2cb33083268e8ed7f5014c09c9