### PR TITLE
chore: update package manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,7 @@ For private and ongoing work (such as **Aiga** and other closed repos), I focus 
 Install with your preferred Windows package manager:
 
 ```powershell
-# Winget
-winget install tino
-```
-
-```powershell
-# Scoop
-scoop bucket add tino https://github.com/d0tTino/tino-bucket
-scoop install tino
+winget install Tino.d0tTino # or: scoop bucket add tino-bucket https://github.com/d0tTino/d0tTino && scoop install tino
 ```
 
 For advanced bootstrap options, see

--- a/scoop/tino-bucket/tino.json
+++ b/scoop/tino-bucket/tino.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Bootstrap scripts and configuration for d0tTino",
   "homepage": "https://github.com/d0tTino/d0tTino",
   "license": "MIT",
-  "url": "https://github.com/d0tTino/d0tTino/releases/download/v1.0.0/tino-windows-1.0.0.zip",
-  "hash": "f9045de4815968cf632a2a33d5c56f6234df241aa39ec259b44480b7fe3782d6",
+  "url": "https://github.com/d0tTino/d0tTino/releases/download/v1.0.2/tino-windows-1.0.2.zip",
+  "hash": "5d23761fbde033368238ad5562e7134eafccb23698b2521612b2905de750f317",
   "pre_install": "bash \"$dir\\scripts\\install_common.sh\" --dry-run",
   "autoupdate": {
     "url": "https://github.com/d0tTino/d0tTino/releases/download/v$version/tino-windows-$version.zip"

--- a/winget/tino.yaml
+++ b/winget/tino.yaml
@@ -1,6 +1,6 @@
 PackageIdentifier: Tino.d0tTino
 # The release script fills in the version, installer URL and hash
-PackageVersion: "1.0.1"
+PackageVersion: "1.0.2"
 PackageLocale: en-US
 Publisher: d0tTino
 PackageName: d0tTino
@@ -10,7 +10,7 @@ PackageUrl: https://github.com/d0tTino/d0tTino
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v1.0.1/tino-windows-1.0.1.zip
-    Sha256: "1261807F8311AAC9C34283AC1B26319740EF0864E77CE5200D04CCA362FBFF6E"
+    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v1.0.2/tino-windows-1.0.2.zip
+    Sha256: "5D23761FBDE033368238AD5562E7134EAFCCB23698B2521612B2905DE750F317"
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- bump Winget manifest to v1.0.2
- update Scoop bucket manifest and hash
- streamline README with single-line install snippet for Winget or Scoop

## Testing
- `python scripts/validate_winget.py`
- `pytest`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a32e2c21d0832696926be6282c465a