### PR TITLE
chore: update Winget and Scoop manifests for 1.0.3

### DIFF
--- a/scoop/tino-bucket/tino.json
+++ b/scoop/tino-bucket/tino.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Bootstrap scripts and configuration for d0tTino",
   "homepage": "https://github.com/d0tTino/d0tTino",
   "license": "MIT",
-  "url": "https://github.com/d0tTino/d0tTino/releases/download/v1.0.2/tino-windows-1.0.2.zip",
-  "hash": "5d23761fbde033368238ad5562e7134eafccb23698b2521612b2905de750f317",
+  "url": "https://github.com/d0tTino/d0tTino/releases/download/v1.0.3/tino-windows-1.0.3.zip",
+  "hash": "774d7848b72ef1b0bb57a72872b6fa170064d35bd533fd5a84d28417601a61b0",
   "pre_install": "bash \"$dir\\scripts\\install_common.sh\" --dry-run",
   "autoupdate": {
     "url": "https://github.com/d0tTino/d0tTino/releases/download/v$version/tino-windows-$version.zip"

--- a/winget/tino.yaml
+++ b/winget/tino.yaml
@@ -1,6 +1,6 @@
 PackageIdentifier: Tino.d0tTino
 # The release script fills in the version, installer URL and hash
-PackageVersion: "1.0.2"
+PackageVersion: "1.0.3"
 PackageLocale: en-US
 Publisher: d0tTino
 PackageName: d0tTino
@@ -10,7 +10,7 @@ PackageUrl: https://github.com/d0tTino/d0tTino
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v1.0.2/tino-windows-1.0.2.zip
-    Sha256: "5D23761FBDE033368238AD5562E7134EAFCCB23698B2521612B2905DE750F317"
+    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v1.0.3/tino-windows-1.0.3.zip
+    Sha256: "774D7848B72EF1B0BB57A72872B6FA170064D35BD533FD5A84D28417601A61B0"
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- bump Winget manifest to 1.0.3 with new download URL and checksum
- align Scoop bucket manifest with version 1.0.3

## Testing
- `SKIP=update-plugin-registry pre-commit run --files winget/tino.yaml scoop/tino-bucket/tino.json`
- `pytest tests/test_validate_winget.py`
- `python scripts/validate_winget.py winget-packages.json`


------
https://chatgpt.com/codex/tasks/task_e_68a335c4182c8326ba04a86e426dd563