### PR TITLE
Use winget for WSL recipe

### DIFF
--- a/scripts/recipes/plugins/wsl.py
+++ b/scripts/recipes/plugins/wsl.py
@@ -7,11 +7,9 @@ from llm.backends.plugin_sdk import register_recipe
 
 
 def run(_: str) -> List[str]:
-    """Install the Windows Subsystem for Linux with required features."""
+    """Install the Windows Subsystem for Linux via winget."""
     return [
-        "dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart",
-        "dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart",
-        "wsl --install",
+        "winget install -e --id Microsoft.WSL",
         "wsl --set-default-version 2",
     ]
 


### PR DESCRIPTION
## Summary
- install WSL via winget and set default version

## Testing
- `ruff check scripts/recipes/plugins/wsl.py`
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c5e950c88326b7c3674eee2b15fb