### PR TITLE
feat: persist budget and show status details

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -43,22 +44,58 @@ _REMOTE_BACKENDS = {
 }
 
 
-def _load_budget() -> int | None:
+_BUDGET_PATH = Path(os.environ.get("LLM_BUDGET_PATH", _DEFAULT_CONFIG.with_name("budget.json")))
+
+
+def _save_budget(remaining: int, total: int, *, spend: int | None = None) -> None:
+    """Persist remaining and total budget and optional token ``spend``."""
+    try:
+        history: list[int] = []
+        if _BUDGET_PATH.exists():
+            with _BUDGET_PATH.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+                history = data.get("history", [])
+        if spend is not None:
+            history.append(spend)
+        payload = {"remaining": remaining, "total": total}
+        if history:
+            payload["history"] = history
+        with _BUDGET_PATH.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+    except Exception:  # pragma: no cover - best effort persistence
+        pass
+
+
+def _load_budget() -> tuple[int | None, int | None]:
+    if _BUDGET_PATH.exists():
+        try:
+            with _BUDGET_PATH.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+            remaining = data.get("remaining")
+            total = data.get("total")
+            if isinstance(remaining, int) and isinstance(total, int):
+                return remaining, total
+        except Exception:  # pragma: no cover - ignore corrupt file
+            pass
     env_val = os.environ.get("LLM_ROUTER_BUDGET")
     if env_val:
         try:
-            return int(env_val)
+            total = int(env_val)
         except ValueError:  # pragma: no cover - invalid env value
-            return None
+            return None, None
+        _save_budget(total, total)
+        return total, total
     path = os.environ.get("LLM_CONFIG_PATH")
     cfg_path = Path(path) if path else _DEFAULT_CONFIG
     cfg = _load_config(cfg_path)
     budget_val = cfg.get("budget")
-    return int(budget_val) if isinstance(budget_val, int) else None
+    if isinstance(budget_val, int):
+        _save_budget(budget_val, budget_val)
+        return budget_val, budget_val
+    return None, None
 
 
-_TOTAL_BUDGET = _load_budget()
-_BUDGET = _TOTAL_BUDGET
+_BUDGET, _TOTAL_BUDGET = _load_budget()
 _LAST_MODEL_SOURCE: str | None = None
 
 
@@ -75,6 +112,8 @@ def _decrement_budget(tokens: int) -> None:
     if _BUDGET < tokens:
         raise RuntimeError("LLM budget exhausted")
     _BUDGET -= tokens
+    if _TOTAL_BUDGET is not None:
+        _save_budget(_BUDGET, _TOTAL_BUDGET, spend=tokens)
 
 
 def estimate_prompt_complexity(prompt: str) -> int:

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -308,7 +308,8 @@ def _cmd_status(args: argparse.Namespace) -> int:
         width = 10
         filled = int(budget / total * width)
         meter = f"[{'#' * filled}{'-' * (width - filled)}]"
-        print(f"Budget remaining: {budget}/{total}")
+        pct = int(budget / total * 100)
+        print(f"Budget remaining: {budget}/{total} ({pct}%)")
         print(f"Budget meter: {meter}")
     else:
         print(f"Budget remaining: {budget}")

--- a/tests/test_ai_cli_status.py
+++ b/tests/test_ai_cli_status.py
@@ -6,9 +6,10 @@ import sys
 from scripts import ai_cli
 
 
-def test_status_reports_budget_depletion(monkeypatch):
+def test_status_reports_budget_depletion(monkeypatch, tmp_path):
     monkeypatch.setenv("LLM_ROUTER_BUDGET", "1")
     monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
+    monkeypatch.setenv("LLM_BUDGET_PATH", str(tmp_path / "budget.json"))
     sys.modules.pop("llm.router", None)
     router = importlib.import_module("llm.router")
     importlib.reload(router)
@@ -23,7 +24,7 @@ def test_status_reports_budget_depletion(monkeypatch):
         rc = ai_cli.main(["status"])
     assert rc == 0
     assert out.getvalue().splitlines() == [
-        "Budget remaining: 0/1",
+        "Budget remaining: 0/1 (0%)",
         "Budget meter: [----------]",
         "Routing mode: remote",
         "Last model source: gemini",

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -12,23 +12,25 @@ from scripts import ai_cli
 def reset_router(monkeypatch):
     yield
     monkeypatch.delenv("LLM_ROUTER_BUDGET", raising=False)
+    monkeypatch.delenv("LLM_BUDGET_PATH", raising=False)
     sys.modules.pop("llm.router", None)
     router = importlib.import_module("llm.router")
     importlib.reload(router)
     monkeypatch.setattr(ai_cli, "router", router, raising=False)
 
 
-def _reload_router(monkeypatch, budget: str = "1"):
+def _reload_router(monkeypatch, tmp_path, budget: str = "1"):
     monkeypatch.setenv("LLM_ROUTER_BUDGET", budget)
     monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
+    monkeypatch.setenv("LLM_BUDGET_PATH", str(tmp_path / "budget.json"))
     sys.modules.pop("llm.router", None)
     router = importlib.import_module("llm.router")
     importlib.reload(router)
     return router
 
 
-def test_budget_decrements_and_exhausts(monkeypatch):
-    router = _reload_router(monkeypatch, "2")
+def test_budget_decrements_and_exhausts(monkeypatch, tmp_path):
+    router = _reload_router(monkeypatch, tmp_path, "2")
     monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
     monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
 
@@ -39,8 +41,8 @@ def test_budget_decrements_and_exhausts(monkeypatch):
         router.send_prompt("again", model="g1")
 
 
-def test_local_does_not_use_budget(monkeypatch):
-    router = _reload_router(monkeypatch, "2")
+def test_local_does_not_use_budget(monkeypatch, tmp_path):
+    router = _reload_router(monkeypatch, tmp_path, "2")
     monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", "ollama"))
     monkeypatch.setattr(router, "run_ollama", lambda prompt, model: "local")
 
@@ -48,8 +50,8 @@ def test_local_does_not_use_budget(monkeypatch):
     assert router.get_budget() == (2, 2, "ollama")
 
 
-def test_status_reports_budget_and_source(monkeypatch):
-    router = _reload_router(monkeypatch, "5")
+def test_status_reports_budget_and_source(monkeypatch, tmp_path):
+    router = _reload_router(monkeypatch, tmp_path, "5")
     monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
     monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
     monkeypatch.setattr(ai_cli, "router", router)
@@ -61,9 +63,22 @@ def test_status_reports_budget_and_source(monkeypatch):
         rc = ai_cli.main(["status"])
     assert rc == 0
     assert out.getvalue().splitlines() == [
-        "Budget remaining: 3/5",
+        "Budget remaining: 3/5 (60%)",
         "Budget meter: [######----]",
         "Routing mode: remote",
         "Last model source: gemini",
     ]
+
+
+def test_budget_persists_across_sessions(monkeypatch, tmp_path):
+    router = _reload_router(monkeypatch, tmp_path, "5")
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+    router.send_prompt("hello world", model="g1")
+    assert router.get_budget() == (3, 5, "gemini")
+
+    sys.modules.pop("llm.router", None)
+    router2 = importlib.import_module("llm.router")
+    importlib.reload(router2)
+    assert router2.get_budget() == (3, 5, None)
 


### PR DESCRIPTION
## Summary
- track token spend and persist remaining LLM budget between sessions
- show budget percentage and routing mode in `ai status`
- test budget persistence and updated status output

## Testing
- `ruff check llm/router.py scripts/ai_cli.py tests/test_ai_cli_status.py tests/test_router_budget.py`
- `pytest tests/test_ai_cli_status.py tests/test_router_budget.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d542bb5083268d4a31d2c35019f3