### PR TITLE
feat: manage MCP tools via plugin CLI

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -52,8 +52,8 @@
     "example_mcp": {
       "package": "d0ttino-example-mcp-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "server_url": "https://example.com/mcp",
+        "capabilities": ["echo"]
       }
     }
   },

--- a/plugins/mcp.py
+++ b/plugins/mcp.py
@@ -1,7 +1,13 @@
-"""MCP adapter exposing registered tools."""
+"""MCP adapter exposing registered tools.
+
+Enabled tools are loaded from ``~/.config/d0tTino/mcp.json`` and merged with
+those discovered via the ``d0ttino.tools`` entry point group.
+"""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from collections.abc import Iterator
 from typing import Any, Dict
 
@@ -11,13 +17,14 @@ __all__ = ["iter_tools", "get_tools"]
 
 
 ENTRY_POINT_GROUP = "d0ttino.tools"
+CONFIG_PATH = Path.home() / ".config" / "d0tTino" / "mcp.json"
 
 
 def iter_tools() -> Iterator[tuple[str, Any]]:
     """Yield ``(name, tool)`` for each registered MCP tool.
 
-    Tools are discovered from the :data:`ENTRY_POINT_GROUP` entry point
-    group. Any entry point that fails to load is skipped.
+    Tools are discovered from the :data:`ENTRY_POINT_GROUP` entry point group.
+    Any entry point that fails to load is skipped.
     """
     for ep in discover_entry_points(ENTRY_POINT_GROUP):
         try:
@@ -26,6 +33,22 @@ def iter_tools() -> Iterator[tuple[str, Any]]:
             continue
 
 
+def _load_config() -> Dict[str, Any]:
+    try:
+        data = json.loads(CONFIG_PATH.read_text())
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return {}
+
+
 def get_tools() -> Dict[str, Any]:
     """Return a mapping of MCP tool names to loaded objects."""
-    return {name: tool for name, tool in iter_tools()}
+    tools = _load_config()
+    for name, func in iter_tools():
+        try:
+            tools[name] = func()
+        except Exception:  # pragma: no cover - best effort loading
+            continue
+    return tools

--- a/plugins/mcp_adapter.py
+++ b/plugins/mcp_adapter.py
@@ -2,6 +2,9 @@
 
 This module converts plug-in registry entries that include ``mcp`` metadata
 into callable tools and optionally serves them over a minimal JSON protocol.
+Entries can either expose a Python ``entry_point`` or provide remote
+``server_url`` details. For the latter a trivial callable returning the
+metadata is generated.
 """
 
 from __future__ import annotations
@@ -17,7 +20,7 @@ __all__ = ["iter_tools", "get_tools", "serve"]
 
 
 def iter_tools(registry_data: Dict[str, object] | None = None) -> Iterator[tuple[str, Any]]:
-    """Yield ``(name, tool)`` for each plug-in exposing an MCP entry point.
+    """Yield ``(name, tool)`` for each plug-in exposing MCP metadata.
 
     ``registry_data`` should be a mapping in the format returned by
     :func:`scripts.plugins.load_registry` when ``raw=True``. When omitted, the
@@ -34,14 +37,25 @@ def iter_tools(registry_data: Dict[str, object] | None = None) -> Iterator[tuple
         if not isinstance(mcp_meta, dict):
             continue
         entry = mcp_meta.get("entry_point")
-        if not isinstance(entry, str):
-            continue
-        try:
-            module_name, obj_name = entry.split(":", 1)
-            module = importlib.import_module(module_name)
-            yield name, getattr(module, obj_name)
-        except Exception:  # pragma: no cover - best effort loading
-            continue
+        if isinstance(entry, str):
+            try:
+                module_name, obj_name = entry.split(":", 1)
+                module = importlib.import_module(module_name)
+                yield name, getattr(module, obj_name)
+                continue
+            except Exception:  # pragma: no cover - best effort loading
+                continue
+        server_url = mcp_meta.get("server_url")
+        if isinstance(server_url, str):
+            meta_copy = {
+                "server_url": server_url,
+                "capabilities": mcp_meta.get("capabilities", []),
+            }
+
+            def _tool(meta=meta_copy):
+                return meta
+
+            yield name, _tool
 
 
 def get_tools(registry_data: Dict[str, object] | None = None) -> Dict[str, Any]:

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -86,6 +86,9 @@ DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/d0tTino/d0tTino/main/p
 # Cache file for the remote registry
 CACHE_PATH = Path.home() / ".cache" / "d0ttino" / "plugin_registry.json"
 
+# Configuration file for enabled MCP tools
+MCP_CONFIG_PATH = Path.home() / ".config" / "d0tTino" / "mcp.json"
+
 # Default TTL for the cached registry (24 hours)
 DEFAULT_CACHE_TTL = max(0, int(os.environ.get("PLUGIN_REGISTRY_TTL", "86400")))
 
@@ -300,6 +303,18 @@ def _is_installed(package: str) -> bool:
         return False
 
 
+def _load_mcp_config() -> Dict[str, Any]:
+    try:
+        return json.loads(MCP_CONFIG_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def _save_mcp_config(data: Dict[str, Any]) -> None:
+    MCP_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    MCP_CONFIG_PATH.write_text(json.dumps(data, indent=2))
+
+
 def _cmd_list_impl(section: str, update: bool) -> int:
     registry = load_registry(section, update=update)
     for name, package in sorted(registry.items()):
@@ -349,6 +364,33 @@ def _cmd_remove_impl(args: argparse.Namespace, section: str) -> int:
 
 def _cmd_remove_backend(args: argparse.Namespace) -> int:
     return _cmd_remove_impl(args, "plugins")
+
+
+def _cmd_mcp_enable(args: argparse.Namespace) -> int:
+    registry = load_registry(raw=True, update=args.update)
+    name = args.name
+    meta = registry.get(name)
+    if not isinstance(meta, dict):
+        print(f"Unknown MCP plug-in: {name}", file=sys.stderr)
+        return 1
+    mcp_meta = meta.get("mcp")
+    if not isinstance(mcp_meta, dict) or not mcp_meta.get("server_url"):
+        print(f"No MCP server info for plug-in: {name}", file=sys.stderr)
+        return 1
+    config = _load_mcp_config()
+    config[name] = mcp_meta
+    _save_mcp_config(config)
+    return 0
+
+
+def _cmd_mcp_disable(args: argparse.Namespace) -> int:
+    config = _load_mcp_config()
+    if args.name in config:
+        del config[args.name]
+        _save_mcp_config(config)
+        return 0
+    print(f"MCP plug-in not enabled: {args.name}", file=sys.stderr)
+    return 1
 
 
 def _cmd_list_recipes(args: argparse.Namespace) -> int:
@@ -467,6 +509,17 @@ def build_parser() -> argparse.ArgumentParser:
     b_remove = backend_sub.add_parser("remove", help="Remove a backend")
     b_remove.add_argument("name", help="Backend name")
     b_remove.set_defaults(func=_cmd_remove_backend)
+
+    mcp = sub.add_parser("mcp", help="Manage MCP tools")
+    mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
+
+    m_enable = mcp_sub.add_parser("enable", help="Enable an MCP tool")
+    m_enable.add_argument("name", help="Tool name")
+    m_enable.set_defaults(func=_cmd_mcp_enable)
+
+    m_disable = mcp_sub.add_parser("disable", help="Disable an MCP tool")
+    m_disable.add_argument("name", help="Tool name")
+    m_disable.set_defaults(func=_cmd_mcp_disable)
 
     recipe = sub.add_parser("recipes", help="Manage recipe plug-ins")
     recipe_sub = recipe.add_subparsers(dest="recipe_command", required=True)

--- a/tests/test_ai_cli_plugins.py
+++ b/tests/test_ai_cli_plugins.py
@@ -43,3 +43,16 @@ def test_plugin_remove_delegates(monkeypatch):
     rc = ai_cli.main(['plugin', 'backends', 'remove', 'x'])
     assert rc == 0
     assert called['argv'] == ['backends', 'remove', 'x']
+
+
+def test_plugin_mcp_enable_delegates(monkeypatch):
+    called = {}
+
+    def fake_main(argv):
+        called['argv'] = argv
+        return 0
+
+    monkeypatch.setattr(ai_cli.plugins, 'main', fake_main)
+    rc = ai_cli.main(['plugin', 'mcp', 'enable', 'x'])
+    assert rc == 0
+    assert called['argv'] == ['mcp', 'enable', 'x']

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,25 +1,23 @@
-import sys
-import types
-
 from plugins import mcp, mcp_adapter
 
 
 def test_mcp_adapter_exposes_registry_tools(monkeypatch):
-    module = types.ModuleType("dummy_tool_mod")
-
-    def tool_func():
-        return "ok"
-
-    module.tool = tool_func
-    monkeypatch.setitem(sys.modules, "dummy_tool_mod", module)
-
     reg = {
-        "dummy": {"package": "pkg", "mcp": {"entry_point": "dummy_tool_mod:tool"}}
+        "dummy": {
+            "package": "pkg",
+            "mcp": {
+                "server_url": "https://example.com",
+                "capabilities": ["echo"],
+            },
+        }
     }
     monkeypatch.setattr(mcp_adapter.registry, "load_registry", lambda raw=True: reg)
 
     tools = mcp_adapter.get_tools(reg)
-    assert tools["dummy"] is tool_func
+    assert tools["dummy"]() == {
+        "server_url": "https://example.com",
+        "capabilities": ["echo"],
+    }
 
 
 def test_ai_cli_flag_enables_mcp(monkeypatch, tmp_path):

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import json
 
 import pytest
 
@@ -214,6 +215,38 @@ def test_mcp_flag_starts_server(monkeypatch):
     rc = plugins.main(["--mcp"])
     assert rc == 0
     assert "registry" in called
+
+
+def test_mcp_enable_writes_config(monkeypatch, tmp_path):
+    cfg = tmp_path / "mcp.json"
+    monkeypatch.setattr(plugins, "MCP_CONFIG_PATH", cfg)
+
+    def fake_load(section="plugins", update=False, *, raw=False):
+        if raw:
+            return {
+                "dummy": {
+                    "package": "pkg",
+                    "mcp": {"server_url": "https://example.com", "capabilities": []},
+                }
+            }
+        return {}
+
+    monkeypatch.setattr(plugins, "load_registry", fake_load)
+
+    rc = plugins.main(["mcp", "enable", "dummy"])
+    assert rc == 0
+    data = json.loads(cfg.read_text())
+    assert data["dummy"]["server_url"] == "https://example.com"
+
+
+def test_mcp_disable_removes_config(monkeypatch, tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"dummy": {"server_url": "u", "capabilities": []}}))
+    monkeypatch.setattr(plugins, "MCP_CONFIG_PATH", cfg)
+
+    rc = plugins.main(["mcp", "disable", "dummy"])
+    assert rc == 0
+    assert json.loads(cfg.read_text()) == {}
 
 
 def test_recipe_remove(monkeypatch):


### PR DESCRIPTION
## Summary
- handle MCP server info entries in registry and expose them as tools
- add `ai-cli plugin mcp enable|disable` commands to manage MCP tools
- load enabled MCP tools from `~/.config/d0tTino/mcp.json`

## Testing
- `ruff check scripts/plugins.py plugins/mcp_adapter.py plugins/mcp.py tests/test_mcp_adapter.py tests/test_plugins_script.py tests/test_ai_cli_plugins.py`
- `pytest tests/test_mcp_adapter.py tests/test_plugins_script.py tests/test_ai_cli_plugins.py tests/test_plugin_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5d54121cc832691441a181b545459