### PR TITLE
feat: dashboard telemetry and plugin toggle display

### DIFF
--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -15,6 +15,9 @@ export default function Home() {
   const [recipes, setRecipes] = useState([]);
   const [selected, setSelected] = useState('');
   const [promptFile, setPromptFile] = useState('');
+  const [recentPlans, setRecentPlans] = useState([]);
+  const [budget, setBudget] = useState(null);
+  const [pluginToggles, setPluginToggles] = useState([]);
 
   useEffect(() => {
     fetch('/api/health')
@@ -29,6 +32,14 @@ export default function Home() {
 
     if (window && window.__TAURI__) {
       invoke('list_recipes').then(setRecipes).catch(() => {});
+      invoke('dashboard')
+        .then((data) => {
+          setRecentPlans(data.recent_plans || []);
+          setBudget(data.budget ?? null);
+          setPluginToggles(data.plugins || []);
+        })
+        .catch(() => {});
+      invoke('record_event', { name: 'dashboard_open', payload: {} }).catch(() => {});
       listen('prompt-file', (e) => {
         setPrompt(e.payload);
       }).then((unsub) => {
@@ -134,6 +145,29 @@ export default function Home() {
         <p>
           Queries: {stats.queries}, Memory: {stats.memory}
         </p>
+      )}
+      {recentPlans.length > 0 && (
+        <div>
+          <h2>Recent Plans</h2>
+          <ul>
+            {recentPlans.map((p, i) => (
+              <li key={i}>{p}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {budget !== null && <p>Budget: {budget}</p>}
+      {pluginToggles.length > 0 && (
+        <div>
+          <h2>Plugins</h2>
+          {pluginToggles.map((p) => (
+            <div key={p.name}>
+              <label>
+                <input type="checkbox" checked={p.enabled} readOnly /> {p.name}
+              </label>
+            </div>
+          ))}
+        </div>
       )}
       <div>
         <input value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="prompt" />

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -52,8 +52,8 @@
     "example_mcp": {
       "package": "d0ttino-example-mcp-plugin",
       "mcp": {
-        "server_url": "https://example.com/mcp",
-        "capabilities": ["echo"]
+        "server_url": "https://example.com",
+        "capabilities": []
       }
     }
   },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ pub mod commands {
     use reqwest::Client;
     use serde::{Deserialize, Serialize};
     use std::{
+        collections::HashSet,
         fs::{self, OpenOptions},
         io::Write,
         path::PathBuf,
@@ -14,15 +15,15 @@ pub mod commands {
 
     #[derive(Serialize)]
     pub struct PluginInfo {
-        name: String,
-        enabled: bool,
+        pub name: String,
+        pub enabled: bool,
     }
 
     #[derive(Serialize)]
     pub struct Dashboard {
-        recent_plans: Vec<String>,
-        budget: Option<i64>,
-        plugins: Vec<PluginInfo>,
+        pub recent_plans: Vec<String>,
+        pub budget: Option<i64>,
+        pub plugins: Vec<PluginInfo>,
     }
 
     pub async fn plan(goal: String) -> Result<Vec<String>, String> {
@@ -122,6 +123,32 @@ pub mod commands {
         Ok(log)
     }
 
+    pub async fn record_event(
+        name: String,
+        payload: serde_json::Value,
+    ) -> Result<bool, String> {
+        use tokio::process::Command;
+
+        let script = r#"
+import json,sys,telemetry
+name=sys.argv[1]
+payload=json.loads(sys.argv[2])
+ok=telemetry.record_event(name,payload,enabled=True)
+raise SystemExit(0 if ok else 1)
+"#;
+
+        let output = Command::new("python3")
+            .arg("-c")
+            .arg(script)
+            .arg(name)
+            .arg(payload.to_string())
+            .output()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(output.status.success())
+    }
+
     pub async fn dashboard() -> Result<Dashboard, String> {
         let mut plans = Vec::new();
         if let Ok(home) = std::env::var("HOME") {
@@ -143,6 +170,23 @@ pub mod commands {
             .ok()
             .and_then(|s| s.parse().ok());
 
+        let mut enabled = HashSet::new();
+        if let Ok(home) = std::env::var("HOME") {
+            let cfg_path = PathBuf::from(&home)
+                .join(".config")
+                .join("d0tTino")
+                .join("mcp.json");
+            if let Ok(content) = fs::read_to_string(cfg_path) {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if let Some(map) = json.as_object() {
+                        for name in map.keys() {
+                            enabled.insert(name.clone());
+                        }
+                    }
+                }
+            }
+        }
+
         let mut plugins = Vec::new();
         let reg_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../plugin-registry.json");
         if let Ok(data) = fs::read_to_string(reg_path) {
@@ -151,7 +195,7 @@ pub mod commands {
                     for name in map.keys() {
                         plugins.push(PluginInfo {
                             name: name.clone(),
-                            enabled: true,
+                            enabled: enabled.contains(name),
                         });
                     }
                 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -40,6 +40,15 @@ async fn dashboard() -> Result<ume_tauri::commands::Dashboard, String> {
 }
 
 #[cfg(feature = "gui")]
+#[tauri::command]
+async fn record_event(
+    name: String,
+    payload: serde_json::Value,
+) -> Result<bool, String> {
+    ume_tauri::commands::record_event(name, payload).await
+}
+
+#[cfg(feature = "gui")]
 fn main() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
@@ -49,6 +58,7 @@ fn main() {
             open_prompt_file,
             run_recipe,
             dashboard,
+            record_event,
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application")

--- a/src-tauri/tests/dashboard.rs
+++ b/src-tauri/tests/dashboard.rs
@@ -1,0 +1,29 @@
+use ume_tauri::commands::dashboard;
+
+#[tokio::test]
+async fn dashboard_returns_recent_plans_and_plugins() {
+    use std::fs;
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path();
+    std::env::set_var("HOME", home);
+
+    let cache = home.join(".cache/d0ttino");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("plans.log"), "one\ntwo\n").unwrap();
+
+    let config = home.join(".config/d0tTino");
+    fs::create_dir_all(&config).unwrap();
+    fs::write(
+        config.join("mcp.json"),
+        r#"{ "sample": { "server_url": "u", "capabilities": [] } }"#,
+    )
+    .unwrap();
+
+    std::env::set_var("LLM_ROUTER_BUDGET", "5");
+
+    let dash = dashboard().await.expect("dashboard");
+    assert_eq!(dash.budget, Some(5));
+    assert_eq!(dash.recent_plans, vec!["two".to_string(), "one".to_string()]);
+    let sample = dash.plugins.iter().find(|p| p.name == "sample").unwrap();
+    assert!(sample.enabled);
+}


### PR DESCRIPTION
## Summary
- show recent plans, budgets, and plugin enable state on dashboard
- expose telemetry IPC command and invoke on dashboard load
- keep plugin registry current

## Testing
- `pre-commit run --files src-tauri/src/lib.rs src-tauri/src.main.rs dashboard/pages/index.js src-tauri/tests/dashboard.rs plugin-registry.json`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pytest tests/test_dashboard_build.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7201ebfd48326b7147851f46b8580