### PR TITLE
Add Scoop release workflow and manifest validation

### DIFF
--- a/.github/workflows/scoop.yml
+++ b/.github/workflows/scoop.yml
@@ -1,0 +1,20 @@
+name: publish-scoop
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  submit:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Update Scoop manifest
+        env:
+          SCOOP_BUCKET: ${{ secrets.SCOOP_BUCKET }}
+        run: |
+          python -m pip install pyyaml
+          python scripts/release.py --scoop

--- a/scoop/tino-bucket/tino.json
+++ b/scoop/tino-bucket/tino.json
@@ -1,10 +1,9 @@
 {
-  "version": "main",
+  "version": "0.0.0",
   "description": "Bootstrap scripts and configuration for d0tTino",
   "homepage": "https://github.com/d0tTino/d0tTino",
   "license": "MIT",
-  "url": "https://github.com/d0tTino/d0tTino/archive/refs/heads/main.zip",
-  "hash": "0d4f4a16d336fb63a507c02281f74e507c2854ee330ac8e3353d872d2c883e92",
+  "url": "https://github.com/d0tTino/d0tTino/releases/download/v0.0.0/tino-windows-0.0.0.zip",
+  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
   "pre_install": "bash \"$dir\\scripts\\install_common.sh\" --dry-run"
-
 }

--- a/tests/test_validate_scoop.py
+++ b/tests/test_validate_scoop.py
@@ -1,0 +1,20 @@
+import json
+import urllib.request
+from pathlib import Path
+
+import jsonschema
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_validate_scoop_manifest() -> None:
+    manifest_path = REPO_ROOT / "scoop" / "tino-bucket" / "tino.json"
+    with manifest_path.open(encoding="utf-8") as fh:
+        manifest = json.load(fh)
+
+    with urllib.request.urlopen(
+        "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json"
+    ) as resp:
+        schema = json.load(resp)
+
+    jsonschema.validate(manifest, schema)


### PR DESCRIPTION
## Summary
- create Scoop publish workflow running release helper
- use version placeholders and release URLs in Scoop manifest
- validate Scoop manifest against upstream schema

## Testing
- `pre-commit run --files .github/workflows/scoop.yml scoop/tino-bucket/tino.json tests/test_validate_scoop.py`
- `pytest tests/test_validate_scoop.py tests/test_validate_winget.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac77bafa60832696df4716ef76c602