### PR TITLE
Automate winget release updates

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,25 +1,26 @@
 name: publish-winget
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
-  submit:
+  release:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
       - name: Install wingetcreate
-        run: |
-          dotnet tool install --global wingetcreate
-      - name: Update manifest
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          $version = $env:TAG_NAME.TrimStart('v')
-          wingetcreate update winget/tino.yaml https://github.com/d0tTino/d0tTino/releases/download/$env:TAG_NAME/d0tTino.zip $version
-      - name: Submit to winget-pkgs
+        run: dotnet tool install --global wingetcreate
+      - name: Run release script
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
-        run: |
-          wingetcreate submit winget/tino.yaml --token $env:WINGET_TOKEN
+          SCOOP_BUCKET: ${{ secrets.SCOOP_BUCKET }}
+        run: python scripts/release.py

--- a/tests/test_validate_winget.py
+++ b/tests/test_validate_winget.py
@@ -1,7 +1,10 @@
 
 import subprocess
-from pathlib import Path
 import sys
+from pathlib import Path
+
+import yaml
+from scripts import release
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -32,4 +35,22 @@ def test_validate_winget_success(tmp_path: Path) -> None:
         cwd=tmp_path,
     )
     assert result.returncode == 0
+
+
+def test_release_updates_manifest(tmp_path: Path, monkeypatch) -> None:
+    manifest_src = REPO_ROOT / "winget" / "tino.yaml"
+    manifest_dest = tmp_path / "winget" / "tino.yaml"
+    manifest_dest.parent.mkdir()
+    manifest_dest.write_text(manifest_src.read_text(), encoding="utf-8")
+    monkeypatch.setattr(release, "REPO", tmp_path)
+    tag = "v1.2.3"
+    version = "1.2.3"
+    sha = "f" * 64
+    release.update_winget(tag, version, sha)
+    data = yaml.safe_load(manifest_dest.read_text())
+    assert data["PackageVersion"] == version
+    assert data["Installers"][0]["Sha256"] == sha
+    assert data["Installers"][0]["InstallerUrl"].endswith(
+        f"/download/{tag}/tino-windows-{version}.zip"
+    )
 

--- a/winget/tino.yaml
+++ b/winget/tino.yaml
@@ -1,6 +1,6 @@
 PackageIdentifier: Tino.d0tTino
 # The release script fills in the version, installer URL and hash
-PackageVersion: "1.0.3"
+PackageVersion: "0.0.0"
 PackageLocale: en-US
 Publisher: d0tTino
 PackageName: d0tTino
@@ -10,7 +10,7 @@ PackageUrl: https://github.com/d0tTino/d0tTino
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v1.0.3/tino-windows-1.0.3.zip
-    Sha256: "774D7848B72EF1B0BB57A72872B6FA170064D35BD533FD5A84D28417601A61B0"
+    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v0.0.0/tino-windows-0.0.0.zip
+    Sha256: "0000000000000000000000000000000000000000000000000000000000000000"
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- run `scripts/release.py` in winget workflow on tag pushes
- template winget manifest for release script updates
- test release updates manifest version and hash

## Testing
- `ruff check .`
- `pytest tests/test_validate_winget.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac77ba530c83268168c5a0791f78d2