### PR TITLE
Ensure file diffs include Windows Terminal hyperlinks

### DIFF
--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -111,8 +111,12 @@ def _append_file_diffs(steps: Iterable[PlanStep]) -> None:
                 text=True,
                 check=False,
             )
-            if result.stdout:
-                diffs.append(f"{_hyperlink(file)}\n{result.stdout.strip()}")
+            diff_text = result.stdout.strip() or result.stderr.strip()
+            hyperlink = _hyperlink(file)
+            if diff_text:
+                diffs.append(f"{hyperlink}\n{diff_text}")
+            else:
+                diffs.append(hyperlink)
         if diffs:
             step.diff = "\n".join(diffs)
 

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -6,9 +6,21 @@ import pytest
 pytest.importorskip("requests")
 
 from scripts import ai_cli
+from scripts import ai_exec
 from scripts import cli_actions
 from scripts.cli_common import PlanStep
 import telemetry
+
+
+def test_append_file_diffs_hyperlink_format(tmp_path):
+    file = tmp_path / "file.txt"
+    file.write_text("hi")
+    step = PlanStep(1, f"cat {file}")
+    ai_exec._append_file_diffs([step])
+    assert step.diff is not None
+    line = step.diff.splitlines()[0]
+    expected = f"\x1b]8;;{file.resolve().as_uri()}\x1b\\{file}\x1b]8;;\x1b\\"
+    assert line == expected
 
 
 def test_send_subcommand(monkeypatch):


### PR DESCRIPTION
## Summary
- Always prepend Windows Terminal hyperlinks when generating file diffs
- Test `_append_file_diffs` hyperlink output

## Testing
- `ruff check scripts/ai_exec.py tests/test_ai_cli.py`
- `pytest tests/test_ai_cli.py::test_append_file_diffs_hyperlink_format -q`


------
https://chatgpt.com/codex/tasks/task_e_68af02c1455c832685e359a2a22f62f0