### PR TITLE
Prompt for each step unless confirmed

### DIFF
--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -98,7 +98,7 @@ def execute_steps(
                 file=sys.stderr,
             )
             return 1
-        if not assume_yes:
+        if not (assume_yes or confirm):
             answer = input("Proceed with execution? [y/N]").strip().lower()
             if answer != "y":
                 return 1
@@ -160,8 +160,7 @@ def execute_steps(
                     break
             if skip_step:
                 continue
-        is_risky = "[risk:" in step.command
-        step_assume_yes = assume_yes and (confirm or not is_risky)
+        step_assume_yes = assume_yes or confirm
 
         cmd_text = _strip_risk_tag(step.command)
         try:

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -148,6 +148,33 @@ def test_main_yes_runs_without_prompts(monkeypatch, tmp_path):
     assert called == [["echo", "hi"]]
 
 
+def test_confirm_runs_without_prompts(monkeypatch, tmp_path):
+    monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi")])
+
+    called = []
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        called.append(cmd)
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    def fail_input(_):  # pragma: no cover - should not be called
+        raise AssertionError("input called")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", fail_input)
+    log = tmp_path / "log.txt"
+    rc = ai_do.main(["goal", "--log", str(log), "--confirm"])
+    assert rc == 0
+    assert called == [["echo", "hi"]]
+
+
 def test_risky_requires_confirm(monkeypatch, tmp_path):
     monkeypatch.setattr(
         ai_exec, "plan", lambda *a, **k: [PlanStep(1, "rm -rf / [risk:rm]")]
@@ -192,7 +219,7 @@ def test_confirm_allows_risky(monkeypatch, tmp_path):
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr("builtins.input", fail_input)
     log = tmp_path / "log.txt"
-    rc = ai_do.main(["goal", "--log", str(log), "--yes", "--confirm"])
+    rc = ai_do.main(["goal", "--log", str(log), "--confirm"])
     assert rc == 0
     assert called == [["echo", "hi"]]
 


### PR DESCRIPTION
## Summary
- Prompt user before executing each command step unless `--yes` or `--confirm` flags are provided
- Test `ai_do` flow for confirmation-based non-interactive execution, including risky commands

## Testing
- `ruff check scripts/cli_common.py tests/test_ai_do.py`
- `pytest tests/test_ai_do.py tests/test_cli_common.py`


------
https://chatgpt.com/codex/tasks/task_e_68af02c0b7a48326af48c238f80f5287