### PR TITLE
feat(cli): forward suggested command to plan

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -57,7 +57,7 @@ def _save_budget(remaining: int, total: int, *, spend: int | None = None) -> Non
                 history = data.get("history", [])
         if spend is not None:
             history.append(spend)
-        payload = {"remaining": remaining, "total": total}
+        payload: dict[str, Any] = {"remaining": remaining, "total": total}
         if history:
             payload["history"] = history
         with _BUDGET_PATH.open("w", encoding="utf-8") as fh:

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -129,15 +129,24 @@ def _cmd_suggest(args: argparse.Namespace) -> int:
             payload = {"goal": args.goal, "suggestion_index": idx}
             if _session.get("context"):
                 payload["context"] = _session["context"]
-            exit_code = cli_actions.run_steps(
-                "ai-cli-suggest-run",
-                [PlanStep(1, suggestions[idx - 1]["command"])],
-                log_path=log_path,
-                analytics=args.analytics,
-                payload=payload,
-                assume_yes=True,
-                confirm=True,
-            )
+            if getattr(args, "to_plan", False):
+                plan_args = argparse.Namespace(
+                    goal=suggestions[idx - 1]["command"],
+                    config=None,
+                    analytics=args.analytics,
+                    nats_url=getattr(args, "nats_url", None),
+                )
+                exit_code = _cmd_plan(plan_args)
+            else:
+                exit_code = cli_actions.run_steps(
+                    "ai-cli-suggest-run",
+                    [PlanStep(1, suggestions[idx - 1]["command"])],
+                    log_path=log_path,
+                    analytics=args.analytics,
+                    payload=payload,
+                    assume_yes=True,
+                    confirm=True,
+                )
     _publish_event(
         args,
         "ai-cli-suggest",
@@ -599,6 +608,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--model",
         default=router.DEFAULT_MODEL,
         help="Model name for Ollama (default: %(default)s)",
+    )
+    suggest.add_argument(
+        "--to-plan",
+        action="store_true",
+        help="Forward the chosen command to the plan subcommand",
     )
     suggest.set_defaults(func=_cmd_suggest)
 

--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -33,9 +33,9 @@ def read_key() -> str:
             termios.tcsetattr(fd, termios.TCSADRAIN, old)
     except Exception:
         try:  # Windows fallback
-            import msvcrt  # type: ignore[import-not-found]
+            import msvcrt
 
-            return msvcrt.getch().decode()
+            return msvcrt.getch().decode()  # type: ignore[attr-defined]
         except Exception:  # pragma: no cover - extremely unlikely
             return ""
 

--- a/tests/test_ai_cli_suggest.py
+++ b/tests/test_ai_cli_suggest.py
@@ -57,3 +57,33 @@ def test_suggest_skips_on_keypress(monkeypatch):
         rc = ai_cli.main(["suggest", "goal"])
     assert rc == 0
     assert calls == []
+
+
+def test_suggest_forwards_to_plan(monkeypatch):
+    monkeypatch.setattr(ai_cli, "_session", {})
+    monkeypatch.setattr(
+        ai_suggest,
+        "suggest",
+        lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
+    )
+    monkeypatch.setattr(ai_suggest, "read_key", lambda: "1")
+
+    captured = {}
+
+    def fake_plan(args):
+        captured["goal"] = args.goal
+        captured["analytics"] = args.analytics
+        return 0
+
+    def forbid_run_steps(*args, **kwargs):  # pragma: no cover - ensure not called
+        raise AssertionError("run_steps should not be called")
+
+    monkeypatch.setattr(ai_cli, "_cmd_plan", fake_plan)
+    monkeypatch.setattr(cli_actions, "run_steps", forbid_run_steps)
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["suggest", "goal", "--to-plan", "--analytics"])
+    assert rc == 0
+    assert captured["goal"] == "echo hi [risk:info]"
+    assert captured["analytics"] is True


### PR DESCRIPTION
## Summary
- add `--to-plan` option to `ai_cli suggest`
- forward selected command to `plan`
- cover suggest to plan flow with tests

## Testing
- `pre-commit run --files scripts/ai_cli.py tests/test_ai_cli_suggest.py scripts/ai_suggest.py llm/router.py`
- `pytest tests/test_ai_cli_suggest.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1285c5e48326a48a55646bce3515