### PR TITLE
feat: add help context to ai_suggest

### DIFF
--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -71,6 +71,33 @@ def _split_rationale(line: str) -> tuple[str, str]:
     return line.strip(), ""
 
 
+def _short_help(cmd: str) -> str:
+    """Return the first line of ``cmd --help`` or ``""`` on failure."""
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        return ""
+    if not tokens:
+        return ""
+    prog = tokens[0]
+    if prog == "sudo" and len(tokens) > 1:
+        prog = tokens[1]
+    try:
+        out = subprocess.run(
+            [prog, "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        line = out.stdout.splitlines()
+        if line:
+            return line[0].strip()
+    except Exception:
+        pass
+    return ""
+
+
 def suggest(
     goal: str,
     *,
@@ -84,6 +111,9 @@ def suggest(
     suggestions: List[Dict[str, str]] = []
     for line in text[:3]:
         cmd, rationale = _split_rationale(line)
+        help_text = _short_help(cmd)
+        if help_text:
+            rationale = f"{rationale} ({help_text})" if rationale else help_text
         suggestions.append({"command": _label_risk(cmd), "rationale": rationale})
     return suggestions
 

--- a/tests/test_ai_suggest.py
+++ b/tests/test_ai_suggest.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import shlex
 
 import pytest
 
@@ -19,8 +20,15 @@ def _fake_suggestions(goal, *, local=False, model=ai_suggest.router.DEFAULT_MODE
     ]
 
 
+def _fake_help(cmd: str) -> str:
+    tokens = shlex.split(cmd)
+    prog = tokens[1] if tokens and tokens[0] == "sudo" else tokens[0]
+    return f"{prog} help"
+
+
 def test_ai_suggest_risk_tagging_and_rationale(monkeypatch):
     monkeypatch.setattr(ai_suggest.router, "shell_suggest", _fake_suggestions)
+    monkeypatch.setattr(ai_suggest, "_short_help", _fake_help)
     def _fake_input(prompt: str = "") -> str:
         print(prompt)
         return ""
@@ -33,16 +41,17 @@ def test_ai_suggest_risk_tagging_and_rationale(monkeypatch):
     lines = out.getvalue().splitlines()
     assert len(lines) == 7  # 3 suggestions * 2 lines + 1 prompt
     assert lines[0].startswith("1. ") and lines[0].endswith("[risk:rm]")
-    assert lines[1] == "wipe everything"
+    assert lines[1] == "wipe everything (rm help)"
     assert lines[2].startswith("2. ") and lines[2].endswith("[risk:reboot]")
-    assert lines[3] == "restart"
+    assert lines[3] == "restart (reboot help)"
     assert lines[4].startswith("3. ") and lines[4].endswith("[risk:info]")
-    assert lines[5] == "list"
-    assert lines[6].startswith("Select command to run")
+    assert lines[5] == "list (ls help)"
+    assert lines[6].startswith("Press [1-3] to run")
 
 
 def test_ai_suggest_json_output(monkeypatch):
     monkeypatch.setattr(ai_suggest.router, "shell_suggest", _fake_suggestions)
+    monkeypatch.setattr(ai_suggest, "_short_help", _fake_help)
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
         rc = ai_suggest.main(["goal", "--json"])
@@ -50,4 +59,15 @@ def test_ai_suggest_json_output(monkeypatch):
     data = json.loads(out.getvalue())
     assert len(data) == 3
     assert data[0]["command"].endswith("[risk:rm]")
-    assert data[0]["rationale"] == "wipe everything"
+    assert data[0]["rationale"] == "wipe everything (rm help)"
+
+
+def _fake_suggestions_no_rationale(goal, *, local=False, model=ai_suggest.router.DEFAULT_MODEL, context=None):
+    return ["ls"]
+
+
+def test_ai_suggest_help_when_no_rationale(monkeypatch):
+    monkeypatch.setattr(ai_suggest.router, "shell_suggest", _fake_suggestions_no_rationale)
+    monkeypatch.setattr(ai_suggest, "_short_help", lambda cmd: "ls help")
+    suggestions = ai_suggest.suggest("goal")
+    assert suggestions[0]["rationale"] == "ls help"


### PR DESCRIPTION
## Summary
- enrich ai_suggest suggestions with the first line of each command's `--help`
- test ai_suggest help annotations, including commands without original rationales

## Testing
- `ruff check scripts/ai_suggest.py tests/test_ai_suggest.py`
- `pytest tests/test_ai_suggest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af128500b08326952baff93444e19d