### PR TITLE
Add MCP subcommand to AI CLI

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -51,6 +51,17 @@ python -m scripts.plugins backends install openrouter
 ```
 
 
+## MCP Adapter
+
+Expose registered plug-ins over the [Model Context Protocol](https://github.com/modelcontextprotocol) with the CLI:
+
+```bash
+python -m scripts.ai_cli mcp
+```
+
+The command reads JSON requests on standard input and writes responses on standard output, making plug-in tools available to any MCP client.
+
+
 ## LLM Routing CLI
 
 Use the `ai` command to route prompts to your configured language model. By

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -274,6 +274,13 @@ def _cmd_plugin(args: argparse.Namespace) -> int:
     return plugins.main(args.plugin_args)
 
 
+def _cmd_mcp(args: argparse.Namespace) -> int:
+    from plugins import mcp_adapter
+
+    mcp_adapter.serve()
+    return 0
+
+
 def _cmd_sources(args: argparse.Namespace) -> int:
     matches = query_sources.find_sources(
         name=args.name,
@@ -681,6 +688,11 @@ def build_parser() -> argparse.ArgumentParser:
     plugin = sub.add_parser("plugin", help="Manage plug-ins")
     plugin.add_argument("plugin_args", nargs=argparse.REMAINDER)
     plugin.set_defaults(func=_cmd_plugin)
+
+    mcp = sub.add_parser(
+        "mcp", help="Serve MCP endpoints for registered plug-ins"
+    )
+    mcp.set_defaults(func=_cmd_mcp)
 
     finance = sub.add_parser(
         "finance", help="Financial decision support", parents=[analytics]

--- a/tests/test_ai_cli_plugins.py
+++ b/tests/test_ai_cli_plugins.py
@@ -1,11 +1,28 @@
 import contextlib
 import io
+import sys
+import types
 
 import pytest
 
 pytest.importorskip("requests")
 
-from scripts import ai_cli
+nats = types.ModuleType("nats")
+aio = types.ModuleType("aio")
+client = types.ModuleType("client")
+js = types.ModuleType("js")
+setattr(client, "Client", object)
+setattr(js, "JetStreamContext", object)
+aio.client = client
+nats.js = js
+nats.aio = aio
+sys.modules.setdefault("nats", nats)
+sys.modules.setdefault("nats.aio", aio)
+sys.modules.setdefault("nats.aio.client", client)
+sys.modules.setdefault("nats.js", js)
+
+from scripts import ai_cli  # noqa: E402
+from plugins import mcp_adapter  # noqa: E402
 
 
 def test_plugin_list_delegates(monkeypatch):
@@ -56,3 +73,15 @@ def test_plugin_mcp_enable_delegates(monkeypatch):
     rc = ai_cli.main(['plugin', 'mcp', 'enable', 'x'])
     assert rc == 0
     assert called['argv'] == ['mcp', 'enable', 'x']
+
+
+def test_mcp_subcommand_runs_server(monkeypatch):
+    called = {'value': False}
+
+    def fake_serve():
+        called['value'] = True
+
+    monkeypatch.setattr(mcp_adapter, 'serve', fake_serve)
+    rc = ai_cli.main(['mcp'])
+    assert rc == 0
+    assert called['value']


### PR DESCRIPTION
## Summary
- add `mcp` subcommand to `ai_cli` that serves MCP plug-ins
- document MCP adapter usage in AI automation guide
- test CLI delegates to MCP adapter

## Testing
- `ruff check scripts/ai_cli.py tests/test_ai_cli_plugins.py`
- `pytest tests/test_ai_cli_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_68af1d9631388326a1a7c6eade6e1abd