### PR TITLE
feat: add tool discovery for MCP adapter

### DIFF
--- a/plugins/mcp_adapter.py
+++ b/plugins/mcp_adapter.py
@@ -16,7 +16,13 @@ from typing import Any, Dict, Iterator
 
 from scripts import plugins as registry
 
-__all__ = ["iter_tools", "get_tools", "serve"]
+__all__ = [
+    "iter_tools",
+    "get_tools",
+    "iter_tool_descriptors",
+    "get_tool_descriptors",
+    "serve",
+]
 
 
 def iter_tools(registry_data: Dict[str, object] | None = None) -> Iterator[tuple[str, Any]]:
@@ -64,6 +70,49 @@ def get_tools(registry_data: Dict[str, object] | None = None) -> Dict[str, Any]:
     return {name: tool for name, tool in iter_tools(registry_data)}
 
 
+def iter_tool_descriptors(
+    registry_data: Dict[str, object] | None = None,
+) -> Iterator[tuple[str, Dict[str, Any]]]:
+    """Yield ``(name, descriptor)`` for each MCP-enabled plug-in.
+
+    The descriptor follows the minimal structure required by the MCP tool
+    discovery specification and includes the tool ``name``, ``server_url`` and
+    ``capabilities`` list.
+    """
+
+    if registry_data is None:
+        registry_data = registry.load_registry(raw=True)
+
+    for name, meta in registry_data.items():
+        if not isinstance(meta, dict):
+            continue
+        mcp_meta = meta.get("mcp")
+        if not isinstance(mcp_meta, dict):
+            continue
+        server_url = mcp_meta.get("server_url")
+        if not isinstance(server_url, str):
+            continue
+        capabilities = mcp_meta.get("capabilities", [])
+        if not (
+            isinstance(capabilities, list)
+            and all(isinstance(c, str) for c in capabilities)
+        ):
+            capabilities = []
+        yield name, {
+            "name": name,
+            "server_url": server_url,
+            "capabilities": capabilities,
+        }
+
+
+def get_tool_descriptors(
+    registry_data: Dict[str, object] | None = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Return a mapping of tool names to MCP descriptors."""
+
+    return {name: desc for name, desc in iter_tool_descriptors(registry_data)}
+
+
 def serve(registry_data: Dict[str, object] | None = None) -> None:
     """Serve tools over a line-oriented JSON protocol on ``stdin``/``stdout``.
 
@@ -73,23 +122,29 @@ def serve(registry_data: Dict[str, object] | None = None) -> None:
     """
 
     tools = get_tools(registry_data)
+    descriptors = get_tool_descriptors(registry_data)
 
     for line in sys.stdin:
         try:
             req = json.loads(line)
         except json.JSONDecodeError:
             continue
-        name = req.get("tool")
-        args = req.get("args") or {}
-        func = tools.get(name)
-        if func is None:
-            resp = {"error": f"unknown tool: {name}"}
+        resp: Dict[str, Any]
+        command = req.get("command")
+        if command == "list_tools":
+            resp = {"result": list(descriptors.values())}
         else:
-            try:
-                result = func(**args)
-                resp = {"result": result}
-            except Exception as exc:  # pragma: no cover - propagate error
-                resp = {"error": str(exc)}
+            name = req.get("tool")
+            args = req.get("args") or {}
+            func = tools.get(name)
+            if func is None:
+                resp = {"error": f"unknown tool: {name}"}
+            else:
+                try:
+                    result = func(**args)
+                    resp = {"result": result}
+                except Exception as exc:  # pragma: no cover - propagate error
+                    resp = {"error": str(exc)}
         sys.stdout.write(json.dumps(resp) + "\n")
         sys.stdout.flush()
 

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,3 +1,8 @@
+import io
+import json
+import types
+import sys
+
 from plugins import mcp, mcp_adapter
 
 
@@ -20,8 +25,46 @@ def test_mcp_adapter_exposes_registry_tools(monkeypatch):
     }
 
 
+def test_mcp_adapter_tool_descriptors(monkeypatch):
+    reg = {
+        "dummy": {
+            "package": "pkg",
+            "mcp": {
+                "server_url": "https://example.com",
+                "capabilities": ["echo"],
+            },
+        }
+    }
+    monkeypatch.setattr(mcp_adapter.registry, "load_registry", lambda raw=True: reg)
+
+    desc = mcp_adapter.get_tool_descriptors(reg)
+    assert desc["dummy"] == {
+        "name": "dummy",
+        "server_url": "https://example.com",
+        "capabilities": ["echo"],
+    }
+
+
 def test_ai_cli_flag_enables_mcp(monkeypatch, tmp_path):
     import importlib
+
+    # Provide a minimal NATS stub so ai_cli can import without dependency.
+    nats_mod = types.ModuleType("nats")
+    nats_aio = types.ModuleType("nats.aio")
+    nats_client = types.ModuleType("nats.aio.client")
+    class Client:  # pragma: no cover - simple stub
+        ...
+    nats_client.Client = Client
+    nats_aio.client = nats_client
+    nats_mod.aio = nats_aio
+    nats_js = types.ModuleType("nats.js")
+    class JetStreamContext:  # pragma: no cover - simple stub
+        ...
+    nats_js.JetStreamContext = JetStreamContext
+    monkeypatch.setitem(sys.modules, "nats", nats_mod)
+    monkeypatch.setitem(sys.modules, "nats.aio", nats_aio)
+    monkeypatch.setitem(sys.modules, "nats.aio.client", nats_client)
+    monkeypatch.setitem(sys.modules, "nats.js", nats_js)
 
     ai_cli = importlib.import_module("scripts.ai_cli")
 
@@ -43,6 +86,23 @@ def test_ai_cli_flag_enables_mcp(monkeypatch, tmp_path):
 def test_ai_cli_does_not_enable_mcp_without_flag(monkeypatch, tmp_path):
     import importlib
 
+    nats_mod = types.ModuleType("nats")
+    nats_aio = types.ModuleType("nats.aio")
+    nats_client = types.ModuleType("nats.aio.client")
+    class Client:  # pragma: no cover - simple stub
+        ...
+    nats_client.Client = Client
+    nats_aio.client = nats_client
+    nats_mod.aio = nats_aio
+    nats_js = types.ModuleType("nats.js")
+    class JetStreamContext:  # pragma: no cover - simple stub
+        ...
+    nats_js.JetStreamContext = JetStreamContext
+    monkeypatch.setitem(sys.modules, "nats", nats_mod)
+    monkeypatch.setitem(sys.modules, "nats.aio", nats_aio)
+    monkeypatch.setitem(sys.modules, "nats.aio.client", nats_client)
+    monkeypatch.setitem(sys.modules, "nats.js", nats_js)
+
     ai_cli = importlib.import_module("scripts.ai_cli")
 
     monkeypatch.setattr(ai_cli, "SESSION_FILE", tmp_path / "session.json")
@@ -58,3 +118,32 @@ def test_ai_cli_does_not_enable_mcp_without_flag(monkeypatch, tmp_path):
 
     ai_cli.main(["login", "user"])
     assert not called["value"]
+
+
+def test_mcp_adapter_serve_lists_descriptors(monkeypatch):
+    reg = {
+        "dummy": {
+            "package": "pkg",
+            "mcp": {
+                "server_url": "https://example.com",
+                "capabilities": ["echo"],
+            },
+        }
+    }
+
+    monkeypatch.setattr(mcp_adapter.sys, "stdin", io.StringIO(json.dumps({"command": "list_tools"}) + "\n"))
+    stdout = io.StringIO()
+    monkeypatch.setattr(mcp_adapter.sys, "stdout", stdout)
+
+    mcp_adapter.serve(reg)
+    resp = json.loads(stdout.getvalue())
+    assert resp == {
+        "result": [
+            {
+                "name": "dummy",
+                "server_url": "https://example.com",
+                "capabilities": ["echo"],
+            }
+        ]
+    }
+


### PR DESCRIPTION
## Summary
- expose MCP tool descriptors in `mcp_adapter`
- support `list_tools` command in MCP adapter server
- add tests for tool discovery and command-line integration

## Testing
- `pre-commit run --files plugins/mcp_adapter.py tests/test_mcp_adapter.py`
- `pytest tests/test_mcp_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1d9556148326be1af803d58bde24