### PR TITLE
feat: add daily token cap to router

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 from pathlib import Path
+from datetime import date
 
 from typing import Any, Callable, List, cast
 
@@ -47,8 +48,14 @@ _REMOTE_BACKENDS = {
 _BUDGET_PATH = Path(os.environ.get("LLM_BUDGET_PATH", _DEFAULT_CONFIG.with_name("budget.json")))
 
 
-def _save_budget(remaining: int, total: int, *, spend: int | None = None) -> None:
-    """Persist remaining and total budget and optional token ``spend``."""
+def _save_budget(
+    remaining: int | None,
+    total: int | None,
+    *,
+    spend: int | None = None,
+    daily: tuple[str, int] | None = None,
+) -> None:
+    """Persist remaining/total budget and optional token ``spend`` and ``daily`` usage."""
     try:
         history: list[int] = []
         if _BUDGET_PATH.exists():
@@ -57,9 +64,15 @@ def _save_budget(remaining: int, total: int, *, spend: int | None = None) -> Non
                 history = data.get("history", [])
         if spend is not None:
             history.append(spend)
-        payload: dict[str, Any] = {"remaining": remaining, "total": total}
+        payload: dict[str, Any] = {}
+        if remaining is not None:
+            payload["remaining"] = remaining
+        if total is not None:
+            payload["total"] = total
         if history:
             payload["history"] = history
+        if daily is not None:
+            payload["daily"] = {"date": daily[0], "used": daily[1]}
         with _BUDGET_PATH.open("w", encoding="utf-8") as fh:
             json.dump(payload, fh)
     except Exception:  # pragma: no cover - best effort persistence
@@ -95,7 +108,28 @@ def _load_budget() -> tuple[int | None, int | None]:
     return None, None
 
 
+def _load_daily_usage() -> tuple[str, int]:
+    today = date.today().isoformat()
+    if _BUDGET_PATH.exists():
+        try:
+            with _BUDGET_PATH.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+            daily = data.get("daily")
+            if isinstance(daily, dict):
+                if daily.get("date") == today and isinstance(daily.get("used"), int):
+                    return today, daily["used"]
+        except Exception:  # pragma: no cover - ignore corrupt file
+            pass
+    return today, 0
+
+
 _BUDGET, _TOTAL_BUDGET = _load_budget()
+_DAILY_DATE, _DAILY_USAGE = _load_daily_usage()
+_daily_limit_env = os.environ.get("LLM_DAILY_LIMIT")
+try:
+    _DAILY_LIMIT = int(_daily_limit_env) if _daily_limit_env else None
+except ValueError:  # pragma: no cover - invalid env value
+    _DAILY_LIMIT = None
 _LAST_MODEL_SOURCE: str | None = None
 
 
@@ -106,14 +140,20 @@ def get_budget() -> tuple[int | None, int | None, str | None]:
 
 
 def _decrement_budget(tokens: int) -> None:
-    global _BUDGET
-    if _BUDGET is None:
-        return
-    if _BUDGET < tokens:
-        raise RuntimeError("LLM budget exhausted")
-    _BUDGET -= tokens
-    if _TOTAL_BUDGET is not None:
-        _save_budget(_BUDGET, _TOTAL_BUDGET, spend=tokens)
+    global _BUDGET, _DAILY_USAGE, _DAILY_DATE
+    if _DAILY_LIMIT is not None:
+        today = date.today().isoformat()
+        if _DAILY_DATE != today:
+            _DAILY_DATE, _DAILY_USAGE = today, 0
+        if _DAILY_USAGE + tokens > _DAILY_LIMIT:
+            raise RuntimeError("LLM daily limit exceeded")
+        _DAILY_USAGE += tokens
+    if _BUDGET is not None:
+        if _BUDGET < tokens:
+            raise RuntimeError("LLM budget exhausted")
+        _BUDGET -= tokens
+    if _TOTAL_BUDGET is not None or _DAILY_LIMIT is not None:
+        _save_budget(_BUDGET, _TOTAL_BUDGET, spend=tokens, daily=(_DAILY_DATE, _DAILY_USAGE))
 
 
 def estimate_prompt_complexity(prompt: str) -> int:

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -1,7 +1,9 @@
 import contextlib
 import importlib
 import io
+import json
 import sys
+from datetime import date
 
 import pytest
 
@@ -13,16 +15,19 @@ def reset_router(monkeypatch):
     yield
     monkeypatch.delenv("LLM_ROUTER_BUDGET", raising=False)
     monkeypatch.delenv("LLM_BUDGET_PATH", raising=False)
+    monkeypatch.delenv("LLM_DAILY_LIMIT", raising=False)
     sys.modules.pop("llm.router", None)
     router = importlib.import_module("llm.router")
     importlib.reload(router)
     monkeypatch.setattr(ai_cli, "router", router, raising=False)
 
 
-def _reload_router(monkeypatch, tmp_path, budget: str = "1"):
+def _reload_router(monkeypatch, tmp_path, budget: str = "1", daily_limit: str | None = None):
     monkeypatch.setenv("LLM_ROUTER_BUDGET", budget)
     monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
     monkeypatch.setenv("LLM_BUDGET_PATH", str(tmp_path / "budget.json"))
+    if daily_limit is not None:
+        monkeypatch.setenv("LLM_DAILY_LIMIT", daily_limit)
     sys.modules.pop("llm.router", None)
     router = importlib.import_module("llm.router")
     importlib.reload(router)
@@ -81,4 +86,42 @@ def test_budget_persists_across_sessions(monkeypatch, tmp_path):
     router2 = importlib.import_module("llm.router")
     importlib.reload(router2)
     assert router2.get_budget() == (3, 5, None)
+
+
+def test_daily_limit_enforced_and_persisted(monkeypatch, tmp_path):
+    router = _reload_router(monkeypatch, tmp_path, "100", daily_limit="5")
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+    router.send_prompt("one two", model="g1")
+    router.send_prompt("three four", model="g1")
+    with (tmp_path / "budget.json").open() as fh:
+        data = json.load(fh)
+    today = date.today().isoformat()
+    assert data["daily"] == {"date": today, "used": 4}
+    router = _reload_router(monkeypatch, tmp_path, "100", daily_limit="5")
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+    with pytest.raises(RuntimeError):
+        router.send_prompt("five six", model="g1")
+
+
+def test_daily_usage_resets_next_day(monkeypatch, tmp_path):
+    router = _reload_router(monkeypatch, tmp_path, "100", daily_limit="5")
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+    router.send_prompt("hello world", model="g1")
+    budget_file = tmp_path / "budget.json"
+    with budget_file.open() as fh:
+        data = json.load(fh)
+    data["daily"]["date"] = "2000-01-01"
+    with budget_file.open("w") as fh:
+        json.dump(data, fh)
+    router = _reload_router(monkeypatch, tmp_path, "100", daily_limit="5")
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+    router.send_prompt("one two three four five", model="g1")
+    with budget_file.open() as fh:
+        data = json.load(fh)
+    today = date.today().isoformat()
+    assert data["daily"] == {"date": today, "used": 5}
 


### PR DESCRIPTION
## Summary
- add optional daily token limit and persist usage
- test daily limit enforcement and reset behavior

## Testing
- `pre-commit run --files llm/router.py tests/test_router_budget.py`
- `pytest tests/test_router_budget.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6e4f0939083269ae5c3d6beba75cb