### PR TITLE
feat(ai_cli): add budget usage progress bar

### DIFF
--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -318,15 +318,16 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_status(args: argparse.Namespace) -> int:
-    """Show remaining budget, a visual meter, routing mode, and last model source."""
+    """Show remaining budget, a usage meter, routing mode, and last model source."""
     budget, total, source = router.get_budget()
     if budget is not None and total:
         width = 10
-        filled = int(budget / total * width)
+        used = total - budget
+        filled = int(used / total * width)
         meter = f"[{'#' * filled}{'-' * (width - filled)}]"
         pct = int(budget / total * 100)
         print(f"Budget remaining: {budget}/{total} ({pct}%)")
-        print(f"Budget meter: {meter}")
+        print(f"Usage meter: {meter}")
     else:
         print(f"Budget remaining: {budget}")
     mode = os.environ.get("LLM_ROUTING_MODE", "auto")

--- a/tests/test_ai_cli_status.py
+++ b/tests/test_ai_cli_status.py
@@ -25,7 +25,32 @@ def test_status_reports_budget_depletion(monkeypatch, tmp_path):
     assert rc == 0
     assert out.getvalue().splitlines() == [
         "Budget remaining: 0/1 (0%)",
-        "Budget meter: [----------]",
+        "Usage meter: [##########]",
+        "Routing mode: remote",
+        "Last model source: gemini",
+    ]
+
+
+def test_status_reports_partial_budget_usage(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_ROUTER_BUDGET", "2")
+    monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
+    monkeypatch.setenv("LLM_BUDGET_PATH", str(tmp_path / "budget.json"))
+    sys.modules.pop("llm.router", None)
+    router = importlib.import_module("llm.router")
+    importlib.reload(router)
+    monkeypatch.setattr(ai_cli, "router", router)
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+
+    ai_cli.main(["send", "hi"])
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["status"])
+    assert rc == 0
+    assert out.getvalue().splitlines() == [
+        "Budget remaining: 1/2 (50%)",
+        "Usage meter: [#####-----]",
         "Routing mode: remote",
         "Last model source: gemini",
     ]

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -64,7 +64,7 @@ def test_status_reports_budget_and_source(monkeypatch, tmp_path):
     assert rc == 0
     assert out.getvalue().splitlines() == [
         "Budget remaining: 3/5 (60%)",
-        "Budget meter: [######----]",
+        "Usage meter: [####------]",
         "Routing mode: remote",
         "Last model source: gemini",
     ]


### PR DESCRIPTION
## Summary
- show textual progress bar for LLM budget usage in `ai status`
- test full and partial budget usage meters
- rename output label to "Usage meter"

## Testing
- `pre-commit run --files scripts/ai_cli.py tests/test_ai_cli_status.py tests/test_router_budget.py`
- `pytest tests/test_ai_cli_status.py tests/test_router_budget.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e4f200948326b1c9d86554e577d5