### PR TITLE
feat(ai_exec): flag network commands

### DIFF
--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -23,12 +23,21 @@ from scripts.cli_common import (
     build_analytics_parser,
 )
 from scripts import cli_actions
+from scripts.capabilities import Capability
 from telemetry import analytics_default
 
 _LAST_MODEL_REMOTE = True
 _LAST_MODEL_LOCK = Lock()
 
 RISKY_COMMANDS = {"rm", "reboot", "shutdown", "poweroff", "mkfs", "dd"}
+NETWORK_COMMANDS = {
+    "curl",
+    "wget",
+    "winget",
+    "pip",
+    "pip3",
+    "pipx",
+}
 
 
 def _tag_risky(step: str) -> str:
@@ -51,6 +60,20 @@ def _tag_risky(step: str) -> str:
         return f"{step} [risk:{risk}]"
     return step
 
+
+def _detect_capabilities(step: str) -> set[str]:
+    """Return capability tags inferred from ``step``."""
+    try:
+        tokens = shlex.split(step)
+    except ValueError:
+        return set()
+    if not tokens:
+        return set()
+    cmd = tokens[1] if tokens[0] == "sudo" and len(tokens) > 1 else tokens[0]
+    if cmd in NETWORK_COMMANDS:
+        return {Capability.NETWORK_FETCH}
+    return set()
+
 def last_model_remote() -> bool:
     """Return ``True`` if the last plan used a remote model."""
     with _LAST_MODEL_LOCK:
@@ -72,13 +95,23 @@ def _parse_steps(text: str) -> List[PlanStep]:
             continue
         if current is not None:
             steps.append(
-                PlanStep(len(steps) + 1, _tag_risky(current), "\n".join(diff_lines) or None)
+                PlanStep(
+                    len(steps) + 1,
+                    _tag_risky(current),
+                    "\n".join(diff_lines) or None,
+                    capabilities=_detect_capabilities(current),
+                )
             )
             diff_lines = []
         current = line.strip()
     if current is not None:
         steps.append(
-            PlanStep(len(steps) + 1, _tag_risky(current), "\n".join(diff_lines) or None)
+            PlanStep(
+                len(steps) + 1,
+                _tag_risky(current),
+                "\n".join(diff_lines) or None,
+                capabilities=_detect_capabilities(current),
+            )
         )
     return steps
 

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -13,6 +13,7 @@ pytest.importorskip("requests")
 from scripts import ai_exec, cli_actions
 from scripts.cli_common import PlanStep
 import scripts.cli_common as cli_common
+from scripts.capabilities import Capability
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -136,6 +137,31 @@ def test_plan_parses_diffs(monkeypatch):
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
     steps = ai_exec.plan("goal")
     assert steps[0].diff == "--- a.txt\n+++ b.txt\n+hi"
+
+
+def test_plan_marks_network_commands(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        ai_exec.router,
+        "run_gemini",
+        lambda *a, **k: "curl https://example.com",  # network tool
+    )
+    monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
+    monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
+    steps = ai_exec.plan("goal")
+    assert steps[0].capabilities == {Capability.NETWORK_FETCH}
+
+    prompts: list[str] = []
+
+    def fake_input(msg: str) -> str:
+        prompts.append(msg)
+        return "n"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: type("R", (), {"stdout": "", "stderr": "", "returncode": 0})())
+    log = tmp_path / "log.txt"
+    rc = cli_common.execute_steps(steps, log_path=log, assume_yes=True)
+    assert rc == 1
+    assert prompts == ["Grant capability network.fetch? [y/N]"]
 
 
 def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:


### PR DESCRIPTION
## Summary
- flag common network utilities with `network.fetch` capability in plan steps
- test that network steps prompt for capability grants

## Testing
- `ruff check scripts/ai_exec.py tests/test_ai_exec.py`
- `pytest tests/test_ai_exec.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84370911c8326919e40c872f3b55f