### PR TITLE
Add expiry handling for capability tokens

### DIFF
--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -12,6 +12,7 @@ import secrets
 import shlex
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Optional, Set
@@ -37,7 +38,8 @@ class PlanStep:
     capabilities: Set[str] = field(default_factory=set)
 
 
-_SESSION_TOKENS: dict[str, str] = {}
+_SESSION_TOKENS: dict[str, tuple[str, float]] = {}
+TOKEN_TTL_SECONDS = 3600
 SESSION_LOG = Path(os.environ.get("SESSION_LOG", "session.log"))
 
 
@@ -47,6 +49,13 @@ def _strip_risk_tag(command: str) -> str:
     if " [risk:" in command:
         return command.rsplit(" [risk:", 1)[0]
     return command
+
+
+def _purge_expired_tokens() -> None:
+    now = time.time()
+    expired = [cap for cap, (_, exp) in _SESSION_TOKENS.items() if exp <= now]
+    for cap in expired:
+        del _SESSION_TOKENS[cap]
 
 
 def execute_steps(
@@ -66,6 +75,8 @@ def execute_steps(
     ``confirm`` flag to be set or the function aborts before running anything.
     """
     step_list = list(steps)
+
+    _purge_expired_tokens()
 
     if dry_run:
         lines: list[str] = []
@@ -125,7 +136,7 @@ def execute_steps(
             for cap in sorted(missing_caps):
                 cap_name = cap.value if hasattr(cap, "value") else str(cap)
                 if cap_name in _SESSION_TOKENS:
-                    token = _SESSION_TOKENS[cap_name]
+                    token, _ = _SESSION_TOKENS[cap_name]
                     allowed.add(cap_name)
                     with log_path.open("a", encoding="utf-8") as log:
                         log.write(f"[using capability token: {cap_name}={token}]\n")
@@ -134,7 +145,10 @@ def execute_steps(
 
                 if answer == "y":
                     token = secrets.token_hex(8)
-                    _SESSION_TOKENS[cap_name] = token
+                    _SESSION_TOKENS[cap_name] = (
+                        token,
+                        time.time() + TOKEN_TTL_SECONDS,
+                    )
                     allowed.add(cap_name)
                     with log_path.open("a", encoding="utf-8") as log:
                         log.write(f"[granted capability: {cap_name} token={token}]\n")

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -38,7 +38,7 @@ def test_grant_capability_allows_execution(monkeypatch, tmp_path):
     match = re.search(r"\[granted capability: process\.exec token=([0-9a-f]+)\]", content)
     assert match
     token = match.group(1)
-    assert cli_common._SESSION_TOKENS["process.exec"] == token
+    assert cli_common._SESSION_TOKENS["process.exec"][0] == token
 
 
 def test_tokens_persist_for_session(monkeypatch, tmp_path):
@@ -110,3 +110,41 @@ def test_session_log_records_grants_and_denials(monkeypatch, tmp_path):
     assert "[granted capability: process.exec" in content
     assert "[denied capability: network.fetch]" in content
     assert "[granted capability: filesystem.read" in content
+
+
+def test_token_expiration(monkeypatch, tmp_path):
+    cli_common._SESSION_TOKENS.clear()
+    current = {"time": 1000.0}
+    monkeypatch.setattr(cli_common.time, "time", lambda: current["time"])
+
+    calls = {"count": 0}
+
+    def fake_input(_: str) -> str:
+        calls["count"] += 1
+        return "y"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
+
+    step = PlanStep(1, "echo hi", capabilities={Capability.PROCESS_EXEC})
+    log = tmp_path / "log.txt"
+    cli_common.execute_steps([step], log_path=log, assume_yes=True)
+    token1, expiry1 = cli_common._SESSION_TOKENS["process.exec"]
+
+    current["time"] = expiry1 + 1
+    cli_common.execute_steps([step], log_path=log, assume_yes=True)
+    token2, expiry2 = cli_common._SESSION_TOKENS["process.exec"]
+
+    assert calls["count"] == 2
+    assert token1 != token2
+    assert expiry2 > expiry1


### PR DESCRIPTION
## Summary
- expire capability tokens after a TTL and purge stale tokens
- test capability token expiration logic

## Testing
- `ruff check scripts/cli_common.py tests/test_capabilities.py`
- `pytest tests/test_capabilities.py tests/test_cli_common.py::test_execute_steps_enforces_capabilities -q`
- `pytest tests/test_cli_common.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8437026b483269642aa5724422fac