### PR TITLE
feat: scaffold MCP-aware plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -30,6 +30,19 @@ backend becomes available to the routing utilities.
    [plugin-registry.json](../plugin-registry.json) so others can install it via
    the registry.
 
+## Scaffolding a Plug-in
+
+Use `scripts/plugin_scaffold.py` to bootstrap a backend or recipe package:
+
+```bash
+python -m scripts.plugin_scaffold demo
+python -m scripts.plugin_scaffold demo --recipe
+```
+
+The script creates a directory with a minimal `pyproject.toml`, an `mcp.json`
+file and a plug-in module that defines a sample `run` function along with
+`mcp_tool` metadata. Edit these stubs to implement your plug-in.
+
 ## Required Entry Point
 
 Expose the plug-in module via the `llm.plugins` entry point group in your

--- a/scripts/plugin_scaffold.py
+++ b/scripts/plugin_scaffold.py
@@ -28,6 +28,7 @@ def scaffold_plugin(
 
     if recipe:
         init = f'''"""{description}"""
+from typing import Dict, List
 from llm.backends.plugin_sdk import register_recipe
 
 
@@ -36,19 +37,23 @@ def run(goal: str):
     return [f"echo {{goal}}"]
 
 
-def mcp_tool():
+def mcp_tool() -> Dict[str, object]:
     """Return MCP tool metadata."""
-    return {{}}
+    return {{
+        "server_url": "https://example.com/mcp",
+        "capabilities": ["echo"],
+    }}
 
 
 register_recipe("{name}", run)
 
-__all__ = ["run", "mcp_tool"]
+__all__: List[str] = ["run", "mcp_tool"]
 '''
         entry_group = "d0ttino.recipes"
         entry_line = f'{name} = "{package}:run"'
     else:
         init = f'''"""{description}"""
+from typing import Dict, List
 from llm.backends.plugin_sdk import register_backend
 
 
@@ -57,14 +62,17 @@ def run(prompt: str, model: str | None = None) -> str:
     return "response"
 
 
-def mcp_tool():
+def mcp_tool() -> Dict[str, object]:
     """Return MCP tool metadata."""
-    return {{}}
+    return {{
+        "server_url": "https://example.com/mcp",
+        "capabilities": ["echo"],
+    }}
 
 
 register_backend("{name}", run)
 
-__all__ = ["run", "mcp_tool"]
+__all__: List[str] = ["run", "mcp_tool"]
 '''
         entry_group = "llm.plugins"
         entry_line = f'{name} = "{package}"'

--- a/tests/test_plugin_scaffold.py
+++ b/tests/test_plugin_scaffold.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import sys
 from pathlib import Path
 
@@ -23,7 +24,31 @@ def test_scaffold_backend_registers(tmp_path: Path) -> None:
     assert "demo" in available_backends()
 
 
+def test_scaffold_backend_mcp_metadata(tmp_path: Path) -> None:
+    project = plugin_scaffold.scaffold_plugin("demo", output=tmp_path)
+    _import_plugin(project, "d0ttino_demo_plugin")
+    plugin = sys.modules["d0ttino_demo_plugin"]
+    assert plugin.mcp_tool() == {
+        "server_url": "https://example.com/mcp",
+        "capabilities": ["echo"],
+    }
+    data = json.loads((project / "mcp.json").read_text())
+    assert data == {"name": "demo", "version": "0.1.0"}
+
+
 def test_scaffold_recipe_registers(tmp_path: Path) -> None:
     project = plugin_scaffold.scaffold_plugin("demo", output=tmp_path, recipe=True)
     _import_plugin(project, "d0ttino_demo_recipe")
     assert "demo" in get_registered_recipes()
+
+
+def test_scaffold_recipe_mcp_metadata(tmp_path: Path) -> None:
+    project = plugin_scaffold.scaffold_plugin("demo", output=tmp_path, recipe=True)
+    _import_plugin(project, "d0ttino_demo_recipe")
+    plugin = sys.modules["d0ttino_demo_recipe"]
+    assert plugin.mcp_tool() == {
+        "server_url": "https://example.com/mcp",
+        "capabilities": ["echo"],
+    }
+    data = json.loads((project / "mcp.json").read_text())
+    assert data == {"name": "demo", "version": "0.1.0"}


### PR DESCRIPTION
## Summary
- add MCP-aware plugin templates with default server metadata
- document scaffolding usage for backend and recipe plugins
- verify scaffolded plugins register and expose MCP metadata

## Testing
- `ruff check scripts/plugin_scaffold.py tests/test_plugin_scaffold.py`
- `pytest tests/test_plugin_scaffold.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84488abec83269729898dceb6efc6