### PR TITLE
feat: show budget history in dashboard

### DIFF
--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -17,6 +17,7 @@ export default function Home() {
   const [promptFile, setPromptFile] = useState('');
   const [recentPlans, setRecentPlans] = useState([]);
   const [budget, setBudget] = useState(null);
+  const [budgetHistory, setBudgetHistory] = useState([]);
   const [pluginToggles, setPluginToggles] = useState([]);
 
   useEffect(() => {
@@ -36,6 +37,7 @@ export default function Home() {
         .then((data) => {
           setRecentPlans(data.recent_plans || []);
           setBudget(data.budget ?? null);
+          setBudgetHistory(data.budget_history || []);
           setPluginToggles(data.plugins || []);
         })
         .catch(() => {});
@@ -157,6 +159,16 @@ export default function Home() {
         </div>
       )}
       {budget !== null && <p>Budget: {budget}</p>}
+      {budgetHistory.length > 0 && (
+        <div>
+          <h2>Budget History</h2>
+          <ul>
+            {budgetHistory.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+        </div>
+      )}
       {pluginToggles.length > 0 && (
         <div>
           <h2>Plugins</h2>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod commands {
     pub struct Dashboard {
         pub recent_plans: Vec<String>,
         pub budget: Option<i64>,
+        pub budget_history: Vec<i64>,
         pub plugins: Vec<PluginInfo>,
     }
 
@@ -123,10 +124,7 @@ pub mod commands {
         Ok(log)
     }
 
-    pub async fn record_event(
-        name: String,
-        payload: serde_json::Value,
-    ) -> Result<bool, String> {
+    pub async fn record_event(name: String, payload: serde_json::Value) -> Result<bool, String> {
         use tokio::process::Command;
 
         let script = r#"
@@ -166,9 +164,37 @@ raise SystemExit(0 if ok else 1)
             }
         }
 
-        let budget = std::env::var("LLM_ROUTER_BUDGET")
-            .ok()
-            .and_then(|s| s.parse().ok());
+        use tokio::process::Command;
+        let script = r#"
+import json, os, pathlib, llm.router as r
+b, _t, _s = r.get_budget()
+path = os.environ.get('LLM_BUDGET_PATH') or str(r._BUDGET_PATH)
+hist = []
+p = pathlib.Path(path)
+if p.exists():
+    try:
+        hist = json.loads(p.read_text()).get('history', [])
+    except Exception:
+        pass
+print(json.dumps({'budget': b, 'history': hist}))
+"#;
+        let output = Command::new("python3")
+            .arg("-c")
+            .arg(script)
+            .output()
+            .await
+            .map_err(|e| e.to_string())?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).to_string());
+        }
+        let val: serde_json::Value =
+            serde_json::from_slice(&output.stdout).map_err(|e| e.to_string())?;
+        let budget = val.get("budget").and_then(|v| v.as_i64());
+        let history = val
+            .get("history")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|n| n.as_i64()).collect())
+            .unwrap_or_default();
 
         let mut enabled = HashSet::new();
         if let Ok(home) = std::env::var("HOME") {
@@ -205,6 +231,7 @@ raise SystemExit(0 if ok else 1)
         Ok(Dashboard {
             recent_plans: plans,
             budget,
+            budget_history: history,
             plugins,
         })
     }

--- a/src-tauri/tests/dashboard.rs
+++ b/src-tauri/tests/dashboard.rs
@@ -1,7 +1,11 @@
+use std::sync::Mutex;
 use ume_tauri::commands::dashboard;
 
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
 #[tokio::test]
-async fn dashboard_returns_recent_plans_and_plugins() {
+async fn dashboard_returns_recent_plans_budget_and_plugins() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     use std::fs;
     let tmp = tempfile::TempDir::new().unwrap();
     let home = tmp.path();
@@ -19,11 +23,38 @@ async fn dashboard_returns_recent_plans_and_plugins() {
     )
     .unwrap();
 
-    std::env::set_var("LLM_ROUTER_BUDGET", "5");
+    let budget_file = tmp.path().join("budget.json");
+    fs::write(
+        &budget_file,
+        r#"{ "remaining": 5, "total": 10, "history": [1,2,3] }"#,
+    )
+    .unwrap();
+    std::env::set_var("LLM_BUDGET_PATH", &budget_file);
 
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    std::env::set_var("PYTHONPATH", root);
     let dash = dashboard().await.expect("dashboard");
     assert_eq!(dash.budget, Some(5));
-    assert_eq!(dash.recent_plans, vec!["two".to_string(), "one".to_string()]);
+    assert_eq!(dash.budget_history, vec![1, 2, 3]);
+    assert_eq!(
+        dash.recent_plans,
+        vec!["two".to_string(), "one".to_string()]
+    );
     let sample = dash.plugins.iter().find(|p| p.name == "sample").unwrap();
     assert!(sample.enabled);
+}
+
+#[tokio::test]
+async fn dashboard_handles_missing_budget_file() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("HOME", tmp.path());
+    let budget_file = tmp.path().join("budget.json");
+    std::env::set_var("LLM_BUDGET_PATH", &budget_file);
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    std::env::set_var("PYTHONPATH", root);
+
+    let dash = dashboard().await.expect("dashboard");
+    assert_eq!(dash.budget, None);
+    assert!(dash.budget_history.is_empty());
 }


### PR DESCRIPTION
## Summary
- display budget history and recent plans on dashboard using llm.router
- expose new dashboard fields for budget history and read from llm router
- test dashboard budget history and missing budget file

## Testing
- `npm test`
- `npm run lint`
- `(cd src-tauri && cargo test)`
- `(cd src-tauri && cargo clippy)`

------
https://chatgpt.com/codex/tasks/task_e_68b844877294832682b5065a8c310583