### PR TITLE
feat: enforce dry-run log and risk classification

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -234,10 +234,12 @@ ai-cli do "git add . && git commit -m 'update' && git push" --log my.log
 Legacy commands `ai-plan` and `ai-do` now delegate to these subcommands.
 
 The `do` subcommand always prints a dry-run of the planned commands before
-execution. Review the output and re-run with `--dry-run` to preview only or
-pass `--confirm` to execute steps marked with a `[risk:*]` tag. After the dry
-run the CLI replays the output and asks for confirmation so you execute exactly
-what you approved.
+execution and refuses to run without this preview. Each step is annotated with
+`[risk:read]`, `[risk:write]`, `[risk:network]` or `[risk:elevated]` to classify
+its impact. Review the output and re-run with `--dry-run` to preview only or
+pass `--confirm` to execute steps that carry any risk tag. After the dry run the
+CLI replays the output and asks for confirmation so you execute exactly what you
+approved.
 
 This interactive review makes the workflow safer by ensuring you see and approve
 every step before it runs.

--- a/scripts/ai_do.py
+++ b/scripts/ai_do.py
@@ -7,6 +7,7 @@ Prompts before each step unless ``--yes``/``--confirm`` are supplied."""
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence
 
@@ -15,6 +16,7 @@ from llm.backends import initialize
 from scripts.cli_common import (
     send_notification,
     build_analytics_parser,
+    execute_steps,
 )
 from scripts import cli_actions
 from telemetry import analytics_default
@@ -76,6 +78,14 @@ def main(argv: Optional[List[str]] = None) -> int:
     analytics = getattr(args, "analytics", analytics_default())
     cfg_path = Path(args.config) if args.config else None
     steps = ai_exec.plan(args.goal, config_path=cfg_path, analytics=analytics)
+    dry_log: list[str] = []
+    execute_steps(steps, log_path=args.log, dry_run=True, dry_run_log=dry_log)
+    risk_present = any("[risk:" in s.command for s in steps)
+    if args.dry_run:
+        return 0
+    if risk_present and not args.confirm:
+        print("Risky commands present. Re-run with --confirm to execute.", file=sys.stderr)
+        return 1
     exit_code = cli_actions.run_steps(
         "ai-do",
         steps,
@@ -87,9 +97,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         },
         duration_key="duration_ms",
         nats_url=args.nats_url if hasattr(args, "nats_url") else None,
-        dry_run=args.dry_run,
         assume_yes=args.yes,
         confirm=args.confirm,
+        dry_run_log=dry_log,
     )
     if args.notify:
         if exit_code == 0:

--- a/scripts/ai_exec.py
+++ b/scripts/ai_exec.py
@@ -29,7 +29,22 @@ from telemetry import analytics_default
 _LAST_MODEL_REMOTE = True
 _LAST_MODEL_LOCK = Lock()
 
-RISKY_COMMANDS = {"rm", "reboot", "shutdown", "poweroff", "mkfs", "dd"}
+READ_COMMANDS = {"cat", "grep", "head", "ls", "more", "tail"}
+WRITE_COMMANDS = {
+    "chmod",
+    "chown",
+    "cp",
+    "dd",
+    "ln",
+    "mkdir",
+    "mv",
+    "rm",
+    "rmdir",
+    "tee",
+    "touch",
+    "truncate",
+    "mkfs",
+}
 NETWORK_COMMANDS = {
     "curl",
     "wget",
@@ -41,7 +56,7 @@ NETWORK_COMMANDS = {
 
 
 def _tag_risky(step: str) -> str:
-    """Append a risk tag with the command type when ``step`` is dangerous."""
+    """Append risk classification tags to ``step`` when applicable."""
     try:
         tokens = shlex.split(step)
     except ValueError:
@@ -49,15 +64,19 @@ def _tag_risky(step: str) -> str:
     if not tokens:
         return step
     cmd = tokens[0]
-    risk: Optional[str] = None
+    risks: set[str] = set()
     if cmd == "sudo":
-        risk = "sudo"
-        if len(tokens) > 1 and tokens[1] in RISKY_COMMANDS:
-            risk = tokens[1]
-    elif cmd in RISKY_COMMANDS:
-        risk = cmd
-    if risk:
-        return f"{step} [risk:{risk}]"
+        risks.add("elevated")
+        if len(tokens) > 1:
+            cmd = tokens[1]
+    if cmd in NETWORK_COMMANDS:
+        risks.add("network")
+    if cmd in WRITE_COMMANDS:
+        risks.add("write")
+    elif cmd in READ_COMMANDS:
+        risks.add("read")
+    if risks:
+        return f"{step} [risk:{','.join(sorted(risks))}]"
     return step
 
 

--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -41,7 +41,30 @@ def read_key() -> str:
 
 initialize()
 
-RISKY_COMMANDS = {"rm", "reboot", "shutdown", "poweroff", "mkfs", "dd"}
+READ_COMMANDS = {"cat", "grep", "head", "ls", "more", "tail"}
+WRITE_COMMANDS = {
+    "chmod",
+    "chown",
+    "cp",
+    "dd",
+    "ln",
+    "mkdir",
+    "mv",
+    "rm",
+    "rmdir",
+    "tee",
+    "touch",
+    "truncate",
+    "mkfs",
+}
+NETWORK_COMMANDS = {
+    "curl",
+    "wget",
+    "winget",
+    "pip",
+    "pip3",
+    "pipx",
+}
 
 
 def _label_risk(step: str) -> str:
@@ -53,14 +76,20 @@ def _label_risk(step: str) -> str:
     if not tokens:
         return f"{step} [risk:info]"
     cmd = tokens[0]
-    risk = "info"
+    risks: set[str] = set()
     if cmd == "sudo":
-        risk = "sudo"
-        if len(tokens) > 1 and tokens[1] in RISKY_COMMANDS:
-            risk = tokens[1]
-    elif cmd in RISKY_COMMANDS:
-        risk = cmd
-    return f"{step} [risk:{risk}]"
+        risks.add("elevated")
+        if len(tokens) > 1:
+            cmd = tokens[1]
+    if cmd in NETWORK_COMMANDS:
+        risks.add("network")
+    if cmd in WRITE_COMMANDS:
+        risks.add("write")
+    elif cmd in READ_COMMANDS:
+        risks.add("read")
+    if not risks:
+        risks.add("info")
+    return f"{step} [risk:{','.join(sorted(risks))}]"
 
 
 def _split_rationale(line: str) -> tuple[str, str]:

--- a/scripts/cli_actions.py
+++ b/scripts/cli_actions.py
@@ -100,6 +100,14 @@ def run_recipe(
     else:
         raw_steps = list(steps_or_callable)
     steps = [PlanStep(i + 1, s) for i, s in enumerate(raw_steps)]
+    dry_log: list[str] = []
+    execute_steps(steps, log_path=log_path, dry_run=True, dry_run_log=dry_log)
+    if dry_run:
+        return 0
+    risk_present = any("[risk:" in s.command for s in steps)
+    if risk_present and not confirm:
+        print("Risky commands present. Re-run with --confirm to execute.", file=sys.stderr)
+        return 1
     return run_steps(
         "ai-do-recipe",
         steps,
@@ -108,10 +116,10 @@ def run_recipe(
         payload={"recipe": name, "goal": goal, "step_count": len(steps)},
         nats_url=nats_url,
         jetstream=jetstream,
-        dry_run=dry_run,
         assume_yes=assume_yes,
         confirm=confirm,
         allowed_capabilities=allowed_capabilities,
+        dry_run_log=dry_log,
     )
 
 __all__ = ["record_event_logged", "run_steps", "run_recipe"]

--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -73,6 +73,7 @@ def execute_steps(
     ``dry_run`` prints the planned commands and their diffs without executing
     them. When executing, commands tagged with ``[risk:*]`` require the
     ``confirm`` flag to be set or the function aborts before running anything.
+    A non-empty ``dry_run_log`` must be supplied to proceed with execution.
     """
     step_list = list(steps)
 
@@ -98,6 +99,10 @@ def execute_steps(
             dry_run_log.extend(lines)
         return 0
 
+    if not dry_run_log and step_list:
+        print("Dry-run log required before execution.", file=sys.stderr)
+        return 1
+
     risk_present = any("[risk:" in step.command for step in step_list)
 
     if dry_run_log:
@@ -113,13 +118,6 @@ def execute_steps(
             answer = input("Proceed with execution? [y/N]").strip().lower()
             if answer != "y":
                 return 1
-    elif risk_present and not confirm:
-        print(
-            "Risky commands present. Re-run with --confirm to execute.",
-            file=sys.stderr,
-        )
-        return 1
-
     exit_code = 0
     allowed = set(allowed_capabilities) if allowed_capabilities else set()
 

--- a/tests/test_ai_cli.py
+++ b/tests/test_ai_cli.py
@@ -258,7 +258,7 @@ def test_do_requires_confirm_for_risky_steps(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         ai_cli.ai_exec,
         "plan",
-        lambda *a, **k: [PlanStep(1, "rm -rf / [risk:rm]")],
+        lambda *a, **k: [PlanStep(1, "rm -rf / [risk:write]")],
     )
     log = tmp_path / "log.txt"
     rc = ai_cli.main(["do", "goal", "--log", str(log), "--yes"])

--- a/tests/test_ai_do.py
+++ b/tests/test_ai_do.py
@@ -34,7 +34,7 @@ def test_main_runs_and_logs(monkeypatch, tmp_path):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    inputs = iter(["y", "n"])
+    inputs = iter(["y", "y", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     log = tmp_path / "log.txt"
@@ -61,9 +61,9 @@ def test_main_skips_when_declined(monkeypatch, tmp_path):
     log = tmp_path / "log.txt"
     rc = ai_do.main(["goal", "--log", str(log)])
 
-    assert rc == 0
+    assert rc == 1
     assert not run_called
-    assert not log.exists()
+    assert log.exists()
 
 
 def test_main_dry_run(monkeypatch, tmp_path):
@@ -114,11 +114,11 @@ def test_diff_preview_shown(monkeypatch, tmp_path):
     with contextlib.redirect_stdout(out):
         rc = ai_do.main(["goal", "--log", str(log)])
 
-    assert rc == 0
+    assert rc == 1
     output = out.getvalue()
     assert "--- a" in output
     assert not run_called
-    assert prompts and prompts[0].startswith("Run command")
+    assert prompts and prompts[0].startswith("Proceed")
 
 
 def test_main_yes_runs_without_prompts(monkeypatch, tmp_path):
@@ -177,7 +177,7 @@ def test_confirm_runs_without_prompts(monkeypatch, tmp_path):
 
 def test_risky_requires_confirm(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        ai_exec, "plan", lambda *a, **k: [PlanStep(1, "rm -rf / [risk:rm]")]
+        ai_exec, "plan", lambda *a, **k: [PlanStep(1, "rm -rf / [risk:write]")]
     )
     prompts = []
 
@@ -198,7 +198,7 @@ def test_risky_requires_confirm(monkeypatch, tmp_path):
 
 def test_confirm_allows_risky(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi [risk:rm]")]
+        ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi [risk:write]")]
     )
     called = []
 
@@ -238,7 +238,7 @@ def test_main_returns_failure(monkeypatch, tmp_path):
         return Result()
 
     monkeypatch.setattr(subprocess, "run", fake_run)
-    inputs = iter(["y"])
+    inputs = iter(["y", "y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     log = tmp_path / "log.txt"
@@ -252,7 +252,7 @@ def test_main_confirms_and_sanitizes(monkeypatch, tmp_path):
     monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [PlanStep(1, "echo hi")])
 
     prompts = []
-    inputs = iter(["y"])
+    inputs = iter(["y", "y"])
 
     def fake_input(prompt):
         prompts.append(prompt)
@@ -321,7 +321,7 @@ def test_main_records_event(monkeypatch, tmp_path):
 
 def test_main_records_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(ai_exec, "plan", lambda *a, **k: [PlanStep(1, "bad")])
-    inputs = iter(["y"])
+    inputs = iter(["y", "y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     class Result:
@@ -350,6 +350,19 @@ def test_main_records_failure(monkeypatch, tmp_path):
     assert payload["exit_code"] == 1
     assert "duration_ms" in payload and payload["duration_ms"] >= 0
     assert payload["model_source"] == "remote"
+
+
+def test_network_risk_requires_confirm(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        ai_exec, "plan", lambda *a, **k: [PlanStep(1, "curl example.com [risk:network]")]
+    )
+    def fail_run(*a, **k):  # pragma: no cover - should not run
+        raise AssertionError("should not run")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+    log = tmp_path / "log.txt"
+    rc = ai_do.main(["goal", "--log", str(log), "--yes"])
+    assert rc == 1
 
 
 def test_main_accepts_config_path(monkeypatch):

--- a/tests/test_ai_exec.py
+++ b/tests/test_ai_exec.py
@@ -114,7 +114,7 @@ def test_plan_tags_risky_commands(monkeypatch):
     monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
     steps = ai_exec.plan("goal")
-    assert [s.command for s in steps] == ["rm -rf / [risk:rm]", "ls"]
+    assert [s.command for s in steps] == ["rm -rf / [risk:write]", "ls [risk:read]"]
 
 
 def test_plan_tags_sudo_commands(monkeypatch):
@@ -124,7 +124,7 @@ def test_plan_tags_sudo_commands(monkeypatch):
     monkeypatch.setattr(ai_exec.router, "run_ollama", lambda *a, **k: "")
     monkeypatch.setattr(ai_exec, "get_preferred_models", lambda *a, **k: ("g", "o"))
     steps = ai_exec.plan("goal")
-    assert [s.command for s in steps] == ["sudo reboot now [risk:reboot]", "ls"]
+    assert [s.command for s in steps] == ["sudo reboot now [risk:elevated]", "ls [risk:read]"]
 
 
 def test_plan_parses_diffs(monkeypatch):
@@ -159,9 +159,9 @@ def test_plan_marks_network_commands(monkeypatch, tmp_path):
     monkeypatch.setattr("builtins.input", fake_input)
     monkeypatch.setattr(subprocess, "run", lambda *a, **k: type("R", (), {"stdout": "", "stderr": "", "returncode": 0})())
     log = tmp_path / "log.txt"
-    rc = cli_common.execute_steps(steps, log_path=log, assume_yes=True)
+    rc = cli_common.execute_steps(steps, log_path=log, assume_yes=True, dry_run_log=["1. curl https://example.com"])
     assert rc == 1
-    assert prompts == ["Grant capability network.fetch? [y/N]"]
+    assert prompts == []
 
 
 def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
@@ -278,7 +278,7 @@ def test_plan_adds_file_diff(monkeypatch, tmp_path):
 
 
 def test_execute_steps_requires_confirm(monkeypatch, tmp_path):
-    step = PlanStep(1, "rm -rf / [risk:rm]")
+    step = PlanStep(1, "rm -rf / [risk:write]")
     called = []
 
     def fake_run(cmd, shell=False, capture_output=False, text=False):
@@ -291,11 +291,19 @@ def test_execute_steps_requires_confirm(monkeypatch, tmp_path):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     log = tmp_path / "log.txt"
-    rc = cli_common.execute_steps([step], log_path=log, assume_yes=True)
+    rc = cli_common.execute_steps(
+        [step], log_path=log, assume_yes=True, dry_run_log=["1. rm -rf / [risk:write]"]
+    )
     assert rc == 1
     assert called == []
 
-    rc = cli_common.execute_steps([step], log_path=log, assume_yes=True, confirm=True)
+    rc = cli_common.execute_steps(
+        [step],
+        log_path=log,
+        assume_yes=True,
+        confirm=True,
+        dry_run_log=["1. rm -rf / [risk:write]"]
+    )
     assert rc == 0
     assert called != []
 

--- a/tests/test_ai_suggest.py
+++ b/tests/test_ai_suggest.py
@@ -40,11 +40,11 @@ def test_ai_suggest_risk_tagging_and_rationale(monkeypatch):
     assert rc == 0
     lines = out.getvalue().splitlines()
     assert len(lines) == 7  # 3 suggestions * 2 lines + 1 prompt
-    assert lines[0].startswith("1. ") and lines[0].endswith("[risk:rm]")
+    assert lines[0].startswith("1. ") and lines[0].endswith("[risk:write]")
     assert lines[1] == "wipe everything (rm help)"
-    assert lines[2].startswith("2. ") and lines[2].endswith("[risk:reboot]")
+    assert lines[2].startswith("2. ") and lines[2].endswith("[risk:elevated]")
     assert lines[3] == "restart (reboot help)"
-    assert lines[4].startswith("3. ") and lines[4].endswith("[risk:info]")
+    assert lines[4].startswith("3. ") and lines[4].endswith("[risk:read]")
     assert lines[5] == "list (ls help)"
     assert lines[6].startswith("Press [1-3] to run")
 
@@ -58,7 +58,7 @@ def test_ai_suggest_json_output(monkeypatch):
     assert rc == 0
     data = json.loads(out.getvalue())
     assert len(data) == 3
-    assert data[0]["command"].endswith("[risk:rm]")
+    assert data[0]["command"].endswith("[risk:write]")
     assert data[0]["rationale"] == "wipe everything (rm help)"
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -30,6 +30,7 @@ def test_grant_capability_allows_execution(monkeypatch, tmp_path):
         [step],
         log_path=tmp_path / "log.txt",
         assume_yes=True,
+        dry_run_log=["1. echo hi"],
     )
 
     assert rc == 0
@@ -68,8 +69,8 @@ def test_tokens_persist_for_session(monkeypatch, tmp_path):
 
     step = PlanStep(1, "echo hi", capabilities={Capability.PROCESS_EXEC})
     log = tmp_path / "log.txt"
-    rc1 = cli_common.execute_steps([step], log_path=log, assume_yes=True)
-    rc2 = cli_common.execute_steps([step], log_path=log, assume_yes=True)
+    rc1 = cli_common.execute_steps([step], log_path=log, assume_yes=True, dry_run_log=["1. echo hi"])
+    rc2 = cli_common.execute_steps([step], log_path=log, assume_yes=True, dry_run_log=["1. echo hi"])
 
     assert rc1 == rc2 == 0
     assert calls["count"] == 1
@@ -104,7 +105,12 @@ def test_session_log_records_grants_and_denials(monkeypatch, tmp_path):
         PlanStep(3, "cat file.txt", capabilities={Capability.FILESYSTEM_READ}),
     ]
 
-    cli_common.execute_steps(steps, log_path=tmp_path / "log.txt", assume_yes=True)
+    cli_common.execute_steps(
+        steps,
+        log_path=tmp_path / "log.txt",
+        assume_yes=True,
+        dry_run_log=["1. echo hi", "2. curl example.com", "3. cat file.txt"],
+    )
 
     content = (tmp_path / "session.log").read_text()
     assert "[granted capability: process.exec" in content
@@ -138,11 +144,11 @@ def test_token_expiration(monkeypatch, tmp_path):
 
     step = PlanStep(1, "echo hi", capabilities={Capability.PROCESS_EXEC})
     log = tmp_path / "log.txt"
-    cli_common.execute_steps([step], log_path=log, assume_yes=True)
+    cli_common.execute_steps([step], log_path=log, assume_yes=True, dry_run_log=["1. echo hi"])
     token1, expiry1 = cli_common._SESSION_TOKENS["process.exec"]
 
     current["time"] = expiry1 + 1
-    cli_common.execute_steps([step], log_path=log, assume_yes=True)
+    cli_common.execute_steps([step], log_path=log, assume_yes=True, dry_run_log=["1. echo hi"])
     token2, expiry2 = cli_common._SESSION_TOKENS["process.exec"]
 
     assert calls["count"] == 2

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -123,7 +123,9 @@ def test_execute_steps_parses_quoted_args(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
 
     cli_common.execute_steps(
-        [PlanStep(1, "echo 'foo bar'")], log_path=tmp_path / "log.txt"
+        [PlanStep(1, "echo 'foo bar'")],
+        log_path=tmp_path / "log.txt",
+        dry_run_log=["1. echo 'foo bar'"]
     )
 
     assert captured["cmd"] == ["echo", "foo bar"]
@@ -151,7 +153,9 @@ def test_execute_steps_fallbacks_to_shell(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
 
     cli_common.execute_steps(
-        [PlanStep(1, "python -c \"print('hi')\"")], log_path=tmp_path / "log.txt"
+        [PlanStep(1, "python -c \"print('hi')\"")],
+        log_path=tmp_path / "log.txt",
+        dry_run_log=["1. python -c \"print('hi')\""]
     )
 
     assert captured["cmd"] == "python -c \"print('hi')\""
@@ -182,6 +186,7 @@ def test_execute_steps_windows_path(monkeypatch, tmp_path):
     cli_common.execute_steps(
         [PlanStep(1, '"C:\\Program Files\\Foo Bar\\tool.exe" arg')],
         log_path=tmp_path / "log.txt",
+        dry_run_log=["1. \"C:/Program Files/Foo Bar/tool.exe\" arg"],
     )
 
     assert captured["cmd"] == ["C:\\Program Files\\Foo Bar\\tool.exe", "arg"]
@@ -214,6 +219,7 @@ def test_execute_steps_enforces_capabilities(monkeypatch, tmp_path):
         log_path=tmp_path / "log.txt",
         allowed_capabilities={Capability.FILESYSTEM_READ},
         assume_yes=True,
+        dry_run_log=["1. echo hi"],
     )
 
     assert rc == 1
@@ -242,6 +248,7 @@ def test_execute_steps_logs_capabilities(monkeypatch, tmp_path):
         [step],
         log_path=tmp_path / "log.txt",
         allowed_capabilities={Capability.PROCESS_EXEC},
+        dry_run_log=["1. echo hi"],
     )
 
     content = (tmp_path / "log.txt").read_text()


### PR DESCRIPTION
## Summary
- classify planned steps with `[risk:read|write|network|elevated]`
- require a non-empty dry-run log before executing steps
- document mandatory dry-run confirmation flow

## Testing
- `ruff check scripts/ai_exec.py scripts/ai_suggest.py scripts/cli_common.py scripts/ai_do.py scripts/cli_actions.py tests/test_cli_common.py tests/test_capabilities.py tests/test_ai_exec.py tests/test_ai_suggest.py tests/test_ai_cli.py tests/test_ai_do.py`
- `pytest tests/test_cli_common.py tests/test_capabilities.py tests/test_ai_exec.py tests/test_ai_suggest.py tests/test_ai_cli.py tests/test_ai_do.py`


------
https://chatgpt.com/codex/tasks/task_e_68b85bbb296c8326852277fd8c4f435d