### PR TITLE
feat: streamline release and package installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,13 @@ For private and ongoing work (such as **Aiga** and other closed repos), I focus 
 Install with your preferred Windows package manager:
 
 ```powershell
-winget install Tino.d0tTino
+winget install --id Tino.d0tTino -e
 ```
 
-Or register the Scoop bucket and install:
+Or use Scoop in a single line:
 
 ```powershell
-scoop bucket add tino-bucket https://github.com/d0tTino/d0tTino
-scoop install tino
+scoop bucket add tino https://github.com/d0tTino/tino-bucket; scoop install tino
 ```
 
 For advanced bootstrap options, see

--- a/docs/install-scoop.md
+++ b/docs/install-scoop.md
@@ -2,6 +2,14 @@
 
 Use [Scoop](https://scoop.sh) to install the tools from this repository on Windows.
 
+Install everything in one step:
+
+```powershell
+scoop bucket add tino https://github.com/d0tTino/tino-bucket; scoop install tino
+```
+
+Prefer manual steps? Run the commands separately:
+
 1. Add the custom bucket:
    ```powershell
    scoop bucket add tino https://github.com/d0tTino/tino-bucket
@@ -14,11 +22,5 @@ Use [Scoop](https://scoop.sh) to install the tools from this repository on Windo
    ```powershell
    scoop update tino
    ```
-
-Alternatively, perform the installation in one step:
-
-```powershell
-scoop bucket add tino https://github.com/d0tTino/tino-bucket; scoop install tino
-```
 
 The manifest downloads the versioned release archive and runs a dry-run of the common installer to verify dependencies.

--- a/docs/install-winget.md
+++ b/docs/install-winget.md
@@ -1,10 +1,10 @@
 # Install with winget
 
-After the package is published to the Windows Package Manager repository, you can install the toolkit with a single command:
+Run this one‑liner to grab the latest release from the Windows Package Manager:
 
 ```powershell
 winget install --id Tino.d0tTino -e
 ```
 
-This one‑liner downloads the latest release from GitHub and sets up the scripts. For manual setup, run `bootstrap.ps1` or `install.sh` from the repository.
+The command downloads the newest archive from GitHub and sets up the scripts. For manual setup, run `bootstrap.ps1` or `install.sh` from the repository.
 

--- a/scoop/tino-bucket/tino.json
+++ b/scoop/tino-bucket/tino.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Bootstrap scripts and configuration for d0tTino",
   "homepage": "https://github.com/d0tTino/d0tTino",
   "license": "MIT",
-  "url": "https://github.com/d0tTino/d0tTino/releases/download/v0.0.0/tino-windows-0.0.0.zip",
-  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "url": "https://github.com/d0tTino/d0tTino/releases/download/v0.1.0/tino-windows-0.1.0.zip",
+  "hash": "c1d404515b008bfcb668f4456bc6a253e8e3b741eb5d79d2d278649eab1cdbc4",
   "pre_install": "bash \"$dir\\scripts\\install_common.sh\" --dry-run"
 }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import argparse
 from pathlib import Path
 
 import yaml
@@ -116,6 +117,16 @@ def publish_scoop(manifest: Path, repo_url: str) -> None:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Update release manifests and optionally publish upstream."
+    )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help="Submit manifests to Winget and Scoop using environment credentials",
+    )
+    args = parser.parse_args()
+
     tag = latest_tag()
     version = tag_version(tag)
     archive = build_archive(tag, version)
@@ -124,17 +135,18 @@ def main() -> None:
     winget_path = update_winget(tag, version, sha)
     scoop_path = update_scoop(tag, version, sha)
 
-    token = os.environ.get("WINGET_TOKEN")
-    if token:
+    if args.publish:
+        token = os.environ.get("WINGET_TOKEN")
+        if not token:
+            raise RuntimeError("WINGET_TOKEN not set")
         publish_winget(winget_path, token)
-    else:
-        print("WINGET_TOKEN not set; skipping Winget publish")
 
-    repo_url = os.environ.get("SCOOP_BUCKET")
-    if repo_url:
+        repo_url = os.environ.get("SCOOP_BUCKET")
+        if not repo_url:
+            raise RuntimeError("SCOOP_BUCKET not set")
         publish_scoop(scoop_path, repo_url)
     else:
-        print("SCOOP_BUCKET not set; skipping Scoop publish")
+        print("Skipping publish; run with --publish to submit manifests")
 
 
 if __name__ == "__main__":

--- a/winget/tino.yaml
+++ b/winget/tino.yaml
@@ -1,6 +1,6 @@
 PackageIdentifier: Tino.d0tTino
 # The release script fills in the version, installer URL and hash
-PackageVersion: "0.0.0"
+PackageVersion: "0.1.0"
 PackageLocale: en-US
 Publisher: d0tTino
 PackageName: d0tTino
@@ -10,7 +10,7 @@ PackageUrl: https://github.com/d0tTino/d0tTino
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v0.0.0/tino-windows-0.0.0.zip
-    Sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+    InstallerUrl: https://github.com/d0tTino/d0tTino/releases/download/v0.1.0/tino-windows-0.1.0.zip
+    Sha256: "c1d404515b008bfcb668f4456bc6a253e8e3b741eb5d79d2d278649eab1cdbc4"
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- add versioned Winget and Scoop manifests
- extend release script with optional `--publish`
- document one-line package installation commands

## Testing
- `ruff check scripts/release.py`
- `pytest tests/test_validate_winget.py::test_release_updates_manifest -q`
- `pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b85bbb2be48326b889d273bb53c5e7