### PR TITLE
feat: adopt winget configs for recipes

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -2,44 +2,56 @@
 
 The recipe plug-ins under `scripts/recipes/plugins/` provide reusable command
 sequences for setting up a Windows development environment. Each recipe returns
-a list of shell commands that can be executed on a Windows host.
+a list of shell commands that can be executed on a Windows host. Many recipes
+use [winget configuration](https://learn.microsoft.com/windows/package-manager/configuration/) files located in `scripts/recipes/config/` to install
+packages in a declarative manner.
 
 ## wsl
 - **Usage:** Installs WSL and sets version 2 as the default.
+- **Config:** `scripts/recipes/config/wsl.yaml`
 - **Prerequisites:** Requires Windows 10 or later with virtualization enabled.
 
 ## docker_desktop
 - **Usage:** Installs Docker Desktop and configures WSL 2 as the container backend.
+- **Config:** `scripts/recipes/config/docker_desktop.yaml`
 - **Prerequisites:** Requires WSL 2 and a 64‑bit system.
 
 ## vscode
 - **Usage:** Installs Visual Studio Code and recommended Python and Jupyter extensions.
+- **Config:** `scripts/recipes/config/vscode.yaml`
 - **Prerequisites:** None.
 
 ## gpu_drivers
 - **Usage:** Installs NVIDIA display drivers and the CUDA toolkit.
+- **Config:** `scripts/recipes/config/gpu_drivers.yaml`
 - **Prerequisites:** NVIDIA GPU hardware.
 
 ## windows_terminal
 - **Usage:** Installs Windows Terminal from the Microsoft Store using `winget`.
+- **Config:** `scripts/recipes/config/windows_terminal.yaml`
 - **Prerequisites:** None.
 
 ## powershell
 - **Usage:** Installs the latest PowerShell.
+- **Config:** `scripts/recipes/config/powershell.yaml`
 - **Prerequisites:** None.
 
 ## nodejs
 - **Usage:** Installs the LTS version of Node.js.
+- **Config:** `scripts/recipes/config/nodejs.yaml`
 - **Prerequisites:** None.
 
 ## git
 - **Usage:** Installs Git for Windows.
+- **Config:** `scripts/recipes/config/git.yaml`
 - **Prerequisites:** None.
 
 ## starship
 - **Usage:** Installs the Starship prompt.
+- **Config:** `scripts/recipes/config/starship.yaml`
 - **Prerequisites:** None.
 
 ## fastfetch
 - **Usage:** Installs Fastfetch for quick system information.
+- **Config:** `scripts/recipes/config/fastfetch.yaml`
 - **Prerequisites:** None.

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -69,5 +69,17 @@
     "git": "d0ttino-git-recipe",
     "starship": "d0ttino-starship-recipe",
     "fastfetch": "d0ttino-fastfetch-recipe"
+  },
+  "recipe_configs": {
+    "wsl": "scripts/recipes/config/wsl.yaml",
+    "docker_desktop": "scripts/recipes/config/docker_desktop.yaml",
+    "vscode": "scripts/recipes/config/vscode.yaml",
+    "gpu_drivers": "scripts/recipes/config/gpu_drivers.yaml",
+    "windows_terminal": "scripts/recipes/config/windows_terminal.yaml",
+    "powershell": "scripts/recipes/config/powershell.yaml",
+    "nodejs": "scripts/recipes/config/nodejs.yaml",
+    "git": "scripts/recipes/config/git.yaml",
+    "starship": "scripts/recipes/config/starship.yaml",
+    "fastfetch": "scripts/recipes/config/fastfetch.yaml"
   }
 }

--- a/plugin-registry.schema.json
+++ b/plugin-registry.schema.json
@@ -44,6 +44,13 @@
         "format": "uri",
         "description": "URL to the pip package containing the recipe"
       }
+    },
+    "recipe_configs": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "description": "Path to winget configuration file for the recipe"
+      }
     }
   },
   "additionalProperties": false

--- a/scripts/recipes/config/docker_desktop.yaml
+++ b/scripts/recipes/config/docker_desktop.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Docker.DockerDesktop

--- a/scripts/recipes/config/fastfetch.yaml
+++ b/scripts/recipes/config/fastfetch.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Fastfetch.Fastfetch

--- a/scripts/recipes/config/git.yaml
+++ b/scripts/recipes/config/git.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Git.Git

--- a/scripts/recipes/config/gpu_drivers.yaml
+++ b/scripts/recipes/config/gpu_drivers.yaml
@@ -1,0 +1,4 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Nvidia.DisplayDriver
+  - packageIdentifier: Nvidia.CUDA

--- a/scripts/recipes/config/nodejs.yaml
+++ b/scripts/recipes/config/nodejs.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: OpenJS.NodeJS.LTS

--- a/scripts/recipes/config/powershell.yaml
+++ b/scripts/recipes/config/powershell.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Microsoft.PowerShell

--- a/scripts/recipes/config/starship.yaml
+++ b/scripts/recipes/config/starship.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Starship.Starship

--- a/scripts/recipes/config/vscode.yaml
+++ b/scripts/recipes/config/vscode.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Microsoft.VisualStudioCode

--- a/scripts/recipes/config/windows_terminal.yaml
+++ b/scripts/recipes/config/windows_terminal.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Microsoft.WindowsTerminal

--- a/scripts/recipes/config/wsl.yaml
+++ b/scripts/recipes/config/wsl.yaml
@@ -1,0 +1,3 @@
+$schema: https://aka.ms/winget-schema
+packages:
+  - packageIdentifier: Microsoft.WSL

--- a/scripts/recipes/plugins/docker_desktop.py
+++ b/scripts/recipes/plugins/docker_desktop.py
@@ -2,14 +2,17 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "docker_desktop.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install Docker Desktop and configure the WSL 2 backend."""
     return [
-        "winget install -e --id Docker.DockerDesktop",
+        f"winget configure -f {CONFIG}",
         "wsl --set-default-version 2",
     ]
 

--- a/scripts/recipes/plugins/fastfetch.py
+++ b/scripts/recipes/plugins/fastfetch.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "fastfetch.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install Fastfetch via winget."""
-    return ["winget install -e --id Fastfetch.Fastfetch"]
+    return [f"winget configure -f {CONFIG}"]
 
 
 register_recipe("fastfetch", run)

--- a/scripts/recipes/plugins/git.py
+++ b/scripts/recipes/plugins/git.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "git.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install Git via winget."""
-    return ["winget install -e --id Git.Git"]
+    return [f"winget configure -f {CONFIG}"]
 
 
 register_recipe("git", run)

--- a/scripts/recipes/plugins/gpu_drivers.py
+++ b/scripts/recipes/plugins/gpu_drivers.py
@@ -2,15 +2,17 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "gpu_drivers.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install NVIDIA GPU drivers and CUDA toolkit."""
     return [
-        "winget install -e --id Nvidia.DisplayDriver",
-        "winget install -e --id Nvidia.CUDA",
+        f"winget configure -f {CONFIG}",
     ]
 
 

--- a/scripts/recipes/plugins/nodejs.py
+++ b/scripts/recipes/plugins/nodejs.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "nodejs.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install Node.js via winget."""
-    return ["winget install -e --id OpenJS.NodeJS.LTS"]
+    return [f"winget configure -f {CONFIG}"]
 
 
 register_recipe("nodejs", run)

--- a/scripts/recipes/plugins/powershell.py
+++ b/scripts/recipes/plugins/powershell.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "powershell.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install PowerShell via winget."""
-    return ["winget install -e --id Microsoft.PowerShell"]
+    return [f"winget configure -f {CONFIG}"]
 
 
 register_recipe("powershell", run)

--- a/scripts/recipes/plugins/starship.py
+++ b/scripts/recipes/plugins/starship.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "starship.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install the Starship prompt via winget."""
-    return ["winget install -e --id Starship.Starship"]
+    return [f"winget configure -f {CONFIG}"]
 
 
 register_recipe("starship", run)

--- a/scripts/recipes/plugins/vscode.py
+++ b/scripts/recipes/plugins/vscode.py
@@ -2,14 +2,17 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "vscode.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install Visual Studio Code and common extensions."""
     return [
-        "winget install -e --id Microsoft.VisualStudioCode",
+        f"winget configure -f {CONFIG}",
         "code --install-extension ms-python.python",
         "code --install-extension ms-toolsai.jupyter",
     ]

--- a/scripts/recipes/plugins/windows_terminal.py
+++ b/scripts/recipes/plugins/windows_terminal.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "windows_terminal.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install Windows Terminal via winget."""
-    return ["winget install -e --id Microsoft.WindowsTerminal"]
+    return [f"winget configure -f {CONFIG}"]
 
 
 register_recipe("windows_terminal", run)

--- a/scripts/recipes/plugins/wsl.py
+++ b/scripts/recipes/plugins/wsl.py
@@ -2,14 +2,17 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from llm.backends.plugin_sdk import register_recipe
+
+CONFIG = (Path(__file__).resolve().parent.parent / "config" / "wsl.yaml").as_posix()
 
 
 def run(_: str) -> List[str]:
     """Install the Windows Subsystem for Linux via winget."""
     return [
-        "winget install -e --id Microsoft.WSL",
+        f"winget configure -f {CONFIG}",
         "wsl --set-default-version 2",
     ]
 

--- a/tests/test_recipe_plugins.py
+++ b/tests/test_recipe_plugins.py
@@ -2,6 +2,7 @@ import importlib
 import importlib.metadata
 import sys
 import types
+from pathlib import Path
 import pytest
 
 pytest.importorskip("requests")
@@ -74,39 +75,39 @@ def test_discover_recipes_loads_entry_points_py310(monkeypatch):
 
 def test_builtin_curated_recipes():
     mapping = recipes.discover_recipes()
+    config_dir = Path(__file__).resolve().parent.parent / "scripts" / "recipes" / "config"
     assert mapping["wsl"]("") == [
-        "winget install -e --id Microsoft.WSL",
+        f"winget configure -f {config_dir / 'wsl.yaml'}",
         "wsl --set-default-version 2",
     ]
     assert mapping["docker_desktop"]("") == [
-        "winget install -e --id Docker.DockerDesktop",
+        f"winget configure -f {config_dir / 'docker_desktop.yaml'}",
         "wsl --set-default-version 2",
     ]
     assert mapping["vscode"]("") == [
-        "winget install -e --id Microsoft.VisualStudioCode",
+        f"winget configure -f {config_dir / 'vscode.yaml'}",
         "code --install-extension ms-python.python",
         "code --install-extension ms-toolsai.jupyter",
     ]
     assert mapping["gpu_drivers"]("") == [
-        "winget install -e --id Nvidia.DisplayDriver",
-        "winget install -e --id Nvidia.CUDA",
+        f"winget configure -f {config_dir / 'gpu_drivers.yaml'}",
     ]
     assert mapping["powershell"]("") == [
-        "winget install -e --id Microsoft.PowerShell",
+        f"winget configure -f {config_dir / 'powershell.yaml'}",
     ]
     assert mapping["nodejs"]("") == [
-        "winget install -e --id OpenJS.NodeJS.LTS",
+        f"winget configure -f {config_dir / 'nodejs.yaml'}",
     ]
     assert mapping["git"]("") == [
-        "winget install -e --id Git.Git",
+        f"winget configure -f {config_dir / 'git.yaml'}",
     ]
     assert mapping["starship"]("") == [
-        "winget install -e --id Starship.Starship",
+        f"winget configure -f {config_dir / 'starship.yaml'}",
     ]
     assert mapping["windows_terminal"]("") == [
-        "winget install -e --id Microsoft.WindowsTerminal",
+        f"winget configure -f {config_dir / 'windows_terminal.yaml'}",
     ]
     assert mapping["fastfetch"]("") == [
-        "winget install -e --id Fastfetch.Fastfetch",
+        f"winget configure -f {config_dir / 'fastfetch.yaml'}",
     ]
 


### PR DESCRIPTION
## Summary
- manage recipe installations with winget configuration files
- document and register config-backed recipes
- test winget configure invocation

## Testing
- `pre-commit run --files docs/recipes.md plugin-registry.json plugin-registry.schema.json scripts/recipes/plugins/docker_desktop.py scripts/recipes/plugins/fastfetch.py scripts/recipes/plugins/git.py scripts/recipes/plugins/gpu_drivers.py scripts/recipes/plugins/nodejs.py scripts/recipes/plugins/powershell.py scripts/recipes/plugins/starship.py scripts/recipes/plugins/vscode.py scripts/recipes/plugins/windows_terminal.py scripts/recipes/plugins/wsl.py tests/test_recipe_plugins.py scripts/recipes/config/docker_desktop.yaml scripts/recipes/config/fastfetch.yaml scripts/recipes/config/git.yaml scripts/recipes/config/gpu_drivers.yaml scripts/recipes/config/nodejs.yaml scripts/recipes/config/powershell.yaml scripts/recipes/config/starship.yaml scripts/recipes/config/vscode.yaml scripts/recipes/config/windows_terminal.yaml scripts/recipes/config/wsl.yaml`
- `pytest tests/test_recipe_plugins.py tests/test_plugin_registry_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68b860f650288326bf4b99ce98578934