### PR TITLE
feat: score risks in command suggestions

### DIFF
--- a/docs/ai-automation.md
+++ b/docs/ai-automation.md
@@ -236,10 +236,11 @@ Legacy commands `ai-plan` and `ai-do` now delegate to these subcommands.
 The `do` subcommand always prints a dry-run of the planned commands before
 execution and refuses to run without this preview. Each step is annotated with
 `[risk:read]`, `[risk:write]`, `[risk:network]` or `[risk:elevated]` to classify
-its impact. Review the output and re-run with `--dry-run` to preview only or
-pass `--confirm` to execute steps that carry any risk tag. After the dry run the
-CLI replays the output and asks for confirmation so you execute exactly what you
-approved.
+its impact. Suggestions now include a numeric score based on the highest-risk
+tag so you can quickly gauge severity. Review the output and re-run with
+`--dry-run` to preview only or pass `--confirm` to execute steps that carry any
+risk tag. After the dry run the CLI replays the output and asks for confirmation
+so you execute exactly what you approved.
 
 This interactive review makes the workflow safer by ensuring you see and approve
 every step before it runs.

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -112,7 +112,9 @@ def _cmd_suggest(args: argparse.Namespace) -> int:
         return 1
     log_path = Path.home() / ".config" / "d0tTino" / "ai_cli_suggest.log"
     for idx, item in enumerate(suggestions, 1):
-        print(f"{idx}. {item['command']}")
+        tags = ",".join(item["risk"]["tags"])
+        score = item["risk"]["score"]
+        print(f"{idx}. {item['command']} [risk:{tags}] (score:{score})")
         if item["rationale"]:
             print(item["rationale"])
     print(
@@ -138,9 +140,11 @@ def _cmd_suggest(args: argparse.Namespace) -> int:
                 )
                 exit_code = _cmd_plan(plan_args)
             else:
+                item = suggestions[idx - 1]
+                cmd = f"{item['command']} [risk:{','.join(item['risk']['tags'])}]"
                 exit_code = cli_actions.run_steps(
                     "ai-cli-suggest-run",
-                    [PlanStep(1, suggestions[idx - 1]["command"])],
+                    [PlanStep(1, cmd)],
                     log_path=log_path,
                     analytics=args.analytics,
                     payload=payload,

--- a/scripts/ai_suggest.py
+++ b/scripts/ai_suggest.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Suggest up to three shell commands for a goal with risk labels."""
+"""Suggest up to three shell commands for a goal with risk labels and scores."""
 
 from __future__ import annotations
 
@@ -66,15 +66,18 @@ NETWORK_COMMANDS = {
     "pipx",
 }
 
+# Numeric score associated with each risk tag
+RISK_SCORES = {"info": 0, "read": 1, "network": 2, "write": 3, "elevated": 4}
 
-def _label_risk(step: str) -> str:
-    """Append a risk tag to ``step`` describing potential danger."""
+
+def _score_risk(step: str) -> tuple[List[str], int]:
+    """Return risk tags for ``step`` and a numeric score."""
     try:
         tokens = shlex.split(step)
     except ValueError:
-        return f"{step} [risk:info]"
+        return ["info"], RISK_SCORES["info"]
     if not tokens:
-        return f"{step} [risk:info]"
+        return ["info"], RISK_SCORES["info"]
     cmd = tokens[0]
     risks: set[str] = set()
     if cmd == "sudo":
@@ -89,7 +92,9 @@ def _label_risk(step: str) -> str:
         risks.add("read")
     if not risks:
         risks.add("info")
-    return f"{step} [risk:{','.join(sorted(risks))}]"
+    tags = sorted(risks)
+    score = max(RISK_SCORES[tag] for tag in tags)
+    return tags, score
 
 
 def _split_rationale(line: str) -> tuple[str, str]:
@@ -133,17 +138,20 @@ def suggest(
     local: bool = False,
     model: str = router.DEFAULT_MODEL,
     context: str | None = None,
-) -> List[Dict[str, str]]:
-    """Return up to three risk-tagged suggestions with rationales."""
+) -> List[Dict[str, object]]:
+    """Return up to three suggestions with rationales and risk scores."""
     prompt = f"{goal}\nExplain each command briefly"
     text = router.shell_suggest(prompt, local=local, model=model, context=context)
-    suggestions: List[Dict[str, str]] = []
+    suggestions: List[Dict[str, object]] = []
     for line in text[:3]:
         cmd, rationale = _split_rationale(line)
         help_text = _short_help(cmd)
         if help_text:
             rationale = f"{rationale} ({help_text})" if rationale else help_text
-        suggestions.append({"command": _label_risk(cmd), "rationale": rationale})
+        tags, score = _score_risk(cmd)
+        suggestions.append(
+            {"command": cmd, "rationale": rationale, "risk": {"tags": tags, "score": score}}
+        )
     return suggestions
 
 
@@ -173,7 +181,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     else:
         log_path = Path.home() / ".config" / "d0tTino" / "ai_suggest.log"
         for idx, item in enumerate(suggestions, 1):
-            print(f"{idx}. {item['command']}")
+            tags = ",".join(item["risk"]["tags"])
+            score = item["risk"]["score"]
+            print(f"{idx}. {item['command']} [risk:{tags}] (score:{score})")
             if item["rationale"]:
                 print(item["rationale"])
         print(
@@ -186,9 +196,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         if choice.isdigit():
             idx = int(choice)
             if 1 <= idx <= len(suggestions):
+                item = suggestions[idx - 1]
+                cmd = f"{item['command']} [risk:{','.join(item['risk']['tags'])}]"
                 cli_actions.run_steps(
                     "ai-suggest-run",
-                    [PlanStep(1, suggestions[idx - 1]["command"])],
+                    [PlanStep(1, cmd)],
                     log_path=log_path,
                     analytics=args.analytics,
                     assume_yes=True,

--- a/tests/test_ai_cli_suggest.py
+++ b/tests/test_ai_cli_suggest.py
@@ -1,6 +1,9 @@
 import contextlib
 import io
 
+import contextlib
+import io
+
 from scripts import ai_cli, ai_suggest, cli_actions
 
 
@@ -9,7 +12,9 @@ def test_suggest_executes_selected_command(monkeypatch):
     monkeypatch.setattr(
         ai_suggest,
         "suggest",
-        lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
+        lambda goal, **kwargs: [
+            {"command": "echo hi", "rationale": "", "risk": {"tags": ["info"], "score": 0}}
+        ],
     )
     monkeypatch.setattr(ai_suggest, "read_key", lambda: "1")
 
@@ -40,7 +45,9 @@ def test_suggest_skips_on_keypress(monkeypatch):
     monkeypatch.setattr(
         ai_suggest,
         "suggest",
-        lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
+        lambda goal, **kwargs: [
+            {"command": "echo hi", "rationale": "", "risk": {"tags": ["info"], "score": 0}}
+        ],
     )
     monkeypatch.setattr(ai_suggest, "read_key", lambda: "q")
 
@@ -64,7 +71,9 @@ def test_suggest_forwards_to_plan(monkeypatch):
     monkeypatch.setattr(
         ai_suggest,
         "suggest",
-        lambda goal, **kwargs: [{"command": "echo hi [risk:info]", "rationale": ""}],
+        lambda goal, **kwargs: [
+            {"command": "echo hi", "rationale": "", "risk": {"tags": ["info"], "score": 0}}
+        ],
     )
     monkeypatch.setattr(ai_suggest, "read_key", lambda: "1")
 
@@ -85,5 +94,5 @@ def test_suggest_forwards_to_plan(monkeypatch):
     with contextlib.redirect_stdout(out):
         rc = ai_cli.main(["suggest", "goal", "--to-plan", "--analytics"])
     assert rc == 0
-    assert captured["goal"] == "echo hi [risk:info]"
+    assert captured["goal"] == "echo hi"
     assert captured["analytics"] is True

--- a/tests/test_ai_suggest.py
+++ b/tests/test_ai_suggest.py
@@ -1,5 +1,7 @@
 import contextlib
 import io
+import contextlib
+import io
 import json
 import shlex
 
@@ -29,22 +31,18 @@ def _fake_help(cmd: str) -> str:
 def test_ai_suggest_risk_tagging_and_rationale(monkeypatch):
     monkeypatch.setattr(ai_suggest.router, "shell_suggest", _fake_suggestions)
     monkeypatch.setattr(ai_suggest, "_short_help", _fake_help)
-    def _fake_input(prompt: str = "") -> str:
-        print(prompt)
-        return ""
-
-    monkeypatch.setattr("builtins.input", _fake_input)
+    monkeypatch.setattr(ai_suggest, "read_key", lambda: "")
     out = io.StringIO()
     with contextlib.redirect_stdout(out):
         rc = ai_suggest.main(["goal", "--local", "--model", "m"])
     assert rc == 0
     lines = out.getvalue().splitlines()
     assert len(lines) == 7  # 3 suggestions * 2 lines + 1 prompt
-    assert lines[0].startswith("1. ") and lines[0].endswith("[risk:write]")
+    assert lines[0].startswith("1. rm -rf /") and "[risk:write] (score:3)" in lines[0]
     assert lines[1] == "wipe everything (rm help)"
-    assert lines[2].startswith("2. ") and lines[2].endswith("[risk:elevated]")
+    assert lines[2].startswith("2. sudo reboot now") and "[risk:elevated] (score:4)" in lines[2]
     assert lines[3] == "restart (reboot help)"
-    assert lines[4].startswith("3. ") and lines[4].endswith("[risk:read]")
+    assert lines[4].startswith("3. ls -la") and "[risk:read] (score:1)" in lines[4]
     assert lines[5] == "list (ls help)"
     assert lines[6].startswith("Press [1-3] to run")
 
@@ -58,7 +56,9 @@ def test_ai_suggest_json_output(monkeypatch):
     assert rc == 0
     data = json.loads(out.getvalue())
     assert len(data) == 3
-    assert data[0]["command"].endswith("[risk:write]")
+    assert data[0]["command"] == "rm -rf /"
+    assert data[0]["risk"]["tags"] == ["write"]
+    assert data[0]["risk"]["score"] == 3
     assert data[0]["rationale"] == "wipe everything (rm help)"
 
 


### PR DESCRIPTION
## Summary
- add numeric risk scores to suggestions in `ai_suggest`
- display risk tags and scores in `ai_cli` and accept with single keypress
- document risk scoring in `ai-automation.md`

## Testing
- `ruff check scripts/ai_suggest.py scripts/ai_cli.py`
- `pytest tests/test_ai_suggest.py tests/test_ai_cli_suggest.py`


------
https://chatgpt.com/codex/tasks/task_e_68b860f5c5608326b77f52ea1a1b95cf