### PR TITLE
feat: add token cap warnings and usage tracking

### DIFF
--- a/llm/router.py
+++ b/llm/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 from datetime import date
 
@@ -133,10 +134,36 @@ except ValueError:  # pragma: no cover - invalid env value
 _LAST_MODEL_SOURCE: str | None = None
 
 
+def get_daily_usage() -> tuple[int, int | None]:
+    """Return current daily usage and the configured daily limit."""
+
+    return _DAILY_USAGE, _DAILY_LIMIT
+
+
 def get_budget() -> tuple[int | None, int | None, str | None]:
     """Return remaining and total budget along with the last model source."""
 
     return _BUDGET, _TOTAL_BUDGET, _LAST_MODEL_SOURCE
+
+
+def _warn_if_approaching_caps() -> None:
+    """Emit a warning when budget or daily usage nears its limit."""
+
+    if _TOTAL_BUDGET is not None and _BUDGET is not None:
+        threshold = max(1, _TOTAL_BUDGET // 10)
+        if _BUDGET <= threshold:
+            print(
+                f"Warning: budget nearly exhausted ({_BUDGET} tokens remaining)",
+                file=sys.stderr,
+            )
+    if _DAILY_LIMIT is not None:
+        remaining = _DAILY_LIMIT - _DAILY_USAGE
+        threshold = max(1, _DAILY_LIMIT // 10)
+        if remaining <= threshold:
+            print(
+                f"Warning: daily limit nearly exhausted ({remaining} tokens remaining)",
+                file=sys.stderr,
+            )
 
 
 def _decrement_budget(tokens: int) -> None:
@@ -153,7 +180,10 @@ def _decrement_budget(tokens: int) -> None:
             raise RuntimeError("LLM budget exhausted")
         _BUDGET -= tokens
     if _TOTAL_BUDGET is not None or _DAILY_LIMIT is not None:
-        _save_budget(_BUDGET, _TOTAL_BUDGET, spend=tokens, daily=(_DAILY_DATE, _DAILY_USAGE))
+        _save_budget(
+            _BUDGET, _TOTAL_BUDGET, spend=tokens, daily=(_DAILY_DATE, _DAILY_USAGE)
+        )
+        _warn_if_approaching_caps()
 
 
 def estimate_prompt_complexity(prompt: str) -> int:
@@ -389,4 +419,5 @@ __all__ = [
     "send_prompt",
     "shell_suggest",
     "get_budget",
+    "get_daily_usage",
 ]

--- a/scripts/ai_cli.py
+++ b/scripts/ai_cli.py
@@ -337,6 +337,14 @@ def _cmd_status(args: argparse.Namespace) -> int:
     mode = os.environ.get("LLM_ROUTING_MODE", "auto")
     print(f"Routing mode: {mode}")
     print(f"Last model source: {source or 'unknown'}")
+    usage, limit = router.get_daily_usage()
+    if limit is not None:
+        width = 10
+        filled = int(usage / limit * width)
+        meter = f"[{'#' * filled}{'-' * (width - filled)}]"
+        pct = int(usage / limit * 100)
+        print(f"Daily usage: {usage}/{limit} ({pct}%)")
+        print(f"Daily meter: {meter}")
     return 0
 
 

--- a/tests/test_ai_cli_status.py
+++ b/tests/test_ai_cli_status.py
@@ -4,6 +4,7 @@ import io
 import sys
 
 from scripts import ai_cli
+import pytest
 
 
 def test_status_reports_budget_depletion(monkeypatch, tmp_path):
@@ -53,4 +54,70 @@ def test_status_reports_partial_budget_usage(monkeypatch, tmp_path):
         "Usage meter: [#####-----]",
         "Routing mode: remote",
         "Last model source: gemini",
+    ]
+
+
+def test_warns_when_budget_low(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_ROUTER_BUDGET", "10")
+    monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
+    monkeypatch.setenv("LLM_BUDGET_PATH", str(tmp_path / "budget.json"))
+    sys.modules.pop("llm.router", None)
+    router = importlib.import_module("llm.router")
+    importlib.reload(router)
+    monkeypatch.setattr(ai_cli, "router", router)
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        ai_cli.main(["send", "one two three four five six seven eight nine"])
+    assert "budget nearly exhausted" in err.getvalue()
+
+
+def test_daily_limit_warning_and_enforcement(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_ROUTER_BUDGET", "100")
+    monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
+    monkeypatch.setenv("LLM_BUDGET_PATH", str(tmp_path / "budget.json"))
+    monkeypatch.setenv("LLM_DAILY_LIMIT", "5")
+    sys.modules.pop("llm.router", None)
+    router = importlib.import_module("llm.router")
+    importlib.reload(router)
+    monkeypatch.setattr(ai_cli, "router", router)
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+
+    ai_cli.main(["send", "one two three four"])
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        ai_cli.main(["send", "five"])
+    assert "daily limit nearly exhausted" in err.getvalue()
+    with pytest.raises(RuntimeError):
+        ai_cli.main(["send", "six"])
+
+
+def test_status_reports_daily_usage(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_ROUTER_BUDGET", "100")
+    monkeypatch.setenv("LLM_ROUTING_MODE", "remote")
+    monkeypatch.setenv("LLM_BUDGET_PATH", str(tmp_path / "budget.json"))
+    monkeypatch.setenv("LLM_DAILY_LIMIT", "10")
+    sys.modules.pop("llm.router", None)
+    router = importlib.import_module("llm.router")
+    importlib.reload(router)
+    monkeypatch.setattr(ai_cli, "router", router)
+    monkeypatch.setattr(router, "_preferred_backends", lambda: ("gemini", None))
+    monkeypatch.setattr(router, "run_gemini", lambda prompt, model=None: "ok")
+
+    ai_cli.main(["send", "one two three"])
+
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ai_cli.main(["status"])
+    assert rc == 0
+    assert out.getvalue().splitlines() == [
+        "Budget remaining: 97/100 (97%)",
+        "Usage meter: [----------]",
+        "Routing mode: remote",
+        "Last model source: gemini",
+        "Daily usage: 3/10 (30%)",
+        "Daily meter: [###-------]",
     ]


### PR DESCRIPTION
## Summary
- warn when daily or total token limits are nearly exhausted
- show daily usage in `ai_cli status`
- test token cap enforcement and reporting

## Testing
- `ruff check llm/router.py scripts/ai_cli.py tests/test_ai_cli_status.py`
- `pytest tests/test_ai_cli_status.py tests/test_router_budget.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef78654088326a1c4cb62fe3d8de4