### PR TITLE
feat: support mcp descriptors

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -199,6 +199,29 @@ Anthropic, Mistral and LMQL will look like:
 }
 ```
 
+### Migrating to MCP descriptors
+
+Plug-ins now require an MCP descriptor under the `mcp.descriptor` key in the
+registry. Existing entries with `server_url` and `capabilities` at the `mcp`
+level must be updated to nest these fields under `mcp.descriptor`. For example:
+
+```json
+{
+  "my_backend": {
+    "package": "my-package",
+    "mcp": {
+      "descriptor": {
+        "server_url": "https://example.com/mcp",
+        "capabilities": []
+      }
+    }
+  }
+}
+```
+
+Run `python -m scripts.update_registry` after updating entries to ensure the
+schema check passes.
+
 Add recipe packages under the `recipes` key:
 
 ```json

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -3,57 +3,73 @@
     "sample": {
       "package": "d0ttino-sample-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "descriptor": {
+          "server_url": "https://example.com",
+          "capabilities": []
+        }
       }
     },
     "openrouter": {
       "package": "d0ttino-openrouter-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "descriptor": {
+          "server_url": "https://example.com",
+          "capabilities": []
+        }
       }
     },
     "lobechat": {
       "package": "d0ttino-lobechat-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "descriptor": {
+          "server_url": "https://example.com",
+          "capabilities": []
+        }
       }
     },
     "mindbridge": {
       "package": "d0ttino-mindbridge-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "descriptor": {
+          "server_url": "https://example.com",
+          "capabilities": []
+        }
       }
     },
     "anthropic": {
       "package": "d0ttino-anthropic-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "descriptor": {
+          "server_url": "https://example.com",
+          "capabilities": []
+        }
       }
     },
     "mistral": {
       "package": "d0ttino-mistral-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "descriptor": {
+          "server_url": "https://example.com",
+          "capabilities": []
+        }
       }
     },
     "lmql": {
       "package": "d0ttino-lmql-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "descriptor": {
+          "server_url": "https://example.com",
+          "capabilities": []
+        }
       }
     },
     "example_mcp": {
       "package": "d0ttino-example-mcp-plugin",
       "mcp": {
-        "server_url": "https://example.com",
-        "capabilities": []
+        "descriptor": {
+          "server_url": "https://example.com",
+          "capabilities": []
+        }
       }
     }
   },

--- a/plugin-registry.schema.json
+++ b/plugin-registry.schema.json
@@ -19,18 +19,30 @@
             "type": "object",
             "description": "MCP metadata for the plug-in",
             "properties": {
-              "server_url": {
-                "type": "string",
-                "format": "uri",
-                "description": "Base URL for the MCP server"
+              "descriptor": {
+                "type": "object",
+                "description": "MCP descriptor for the plug-in",
+                "properties": {
+                  "server_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Base URL for the MCP server"
+                  },
+                  "capabilities": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Capabilities exposed by the server"
+                  }
+                },
+                "required": ["server_url", "capabilities"],
+                "additionalProperties": false
               },
-              "capabilities": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Capabilities exposed by the server"
+              "entry_point": {
+                "type": "string",
+                "description": "Optional Python entry point returning a descriptor"
               }
             },
-            "required": ["server_url", "capabilities"],
+            "required": ["descriptor"],
             "additionalProperties": false
           }
         },

--- a/plugins/mcp_adapter.py
+++ b/plugins/mcp_adapter.py
@@ -51,15 +51,13 @@ def iter_tools(registry_data: Dict[str, object] | None = None) -> Iterator[tuple
                 continue
             except Exception:  # pragma: no cover - best effort loading
                 continue
-        server_url = mcp_meta.get("server_url")
-        if isinstance(server_url, str):
-            meta_copy = {
-                "server_url": server_url,
-                "capabilities": mcp_meta.get("capabilities", []),
-            }
+        descriptor = mcp_meta.get("descriptor")
+        if isinstance(descriptor, dict):
+            desc_copy = descriptor.copy()
+            desc_copy.setdefault("name", name)
 
-            def _tool(meta=meta_copy):
-                return meta
+            def _tool(desc=desc_copy):
+                return desc
 
             yield name, _tool
 
@@ -73,36 +71,17 @@ def get_tools(registry_data: Dict[str, object] | None = None) -> Dict[str, Any]:
 def iter_tool_descriptors(
     registry_data: Dict[str, object] | None = None,
 ) -> Iterator[tuple[str, Dict[str, Any]]]:
-    """Yield ``(name, descriptor)`` for each MCP-enabled plug-in.
+    """Yield ``(name, descriptor)`` for each MCP-enabled plug-in."""
 
-    The descriptor follows the minimal structure required by the MCP tool
-    discovery specification and includes the tool ``name``, ``server_url`` and
-    ``capabilities`` list.
-    """
-
-    if registry_data is None:
-        registry_data = registry.load_registry(raw=True)
-
-    for name, meta in registry_data.items():
-        if not isinstance(meta, dict):
+    for name, tool in iter_tools(registry_data):
+        try:
+            desc = tool()
+        except Exception:  # pragma: no cover - best effort loading
             continue
-        mcp_meta = meta.get("mcp")
-        if not isinstance(mcp_meta, dict):
-            continue
-        server_url = mcp_meta.get("server_url")
-        if not isinstance(server_url, str):
-            continue
-        capabilities = mcp_meta.get("capabilities", [])
-        if not (
-            isinstance(capabilities, list)
-            and all(isinstance(c, str) for c in capabilities)
-        ):
-            capabilities = []
-        yield name, {
-            "name": name,
-            "server_url": server_url,
-            "capabilities": capabilities,
-        }
+        if isinstance(desc, dict):
+            desc_copy = desc.copy()
+            desc_copy.setdefault("name", name)
+            yield name, desc_copy
 
 
 def get_tool_descriptors(

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -117,7 +117,10 @@ def _valid_registry(data: Dict[str, object]) -> bool:
         if isinstance(val, dict):
             pkg = val.get("package")
             mcp_meta = val.get("mcp")
-            return isinstance(pkg, str) and isinstance(mcp_meta, dict)
+            if not (isinstance(pkg, str) and isinstance(mcp_meta, dict)):
+                return False
+            descriptor = mcp_meta.get("descriptor")
+            return isinstance(descriptor, dict)
         return False
 
     return (
@@ -244,17 +247,20 @@ def load_registry(
                     if isinstance(v, str):
                         raw_result[str(k)] = {
                             "package": v,
-                            "mcp": {"server_url": "", "capabilities": []},
+                            "mcp": {"descriptor": {"server_url": "", "capabilities": []}},
                         }
                     elif isinstance(v, dict):
                         pkg = v.get("package")
                         mcp_meta = v.get("mcp")
                         if not isinstance(mcp_meta, dict):
                             mcp_meta = {}
-                        server_url = mcp_meta.get("server_url")
+                        descriptor = mcp_meta.get("descriptor")
+                        if not isinstance(descriptor, dict):
+                            descriptor = {}
+                        server_url = descriptor.get("server_url")
                         if not isinstance(server_url, str):
                             server_url = ""
-                        capabilities = mcp_meta.get("capabilities")
+                        capabilities = descriptor.get("capabilities")
                         if not (
                             isinstance(capabilities, list)
                             and all(isinstance(c, str) for c in capabilities)
@@ -264,8 +270,10 @@ def load_registry(
                             raw_result[str(k)] = {
                                 "package": pkg,
                                 "mcp": {
-                                    "server_url": server_url,
-                                    "capabilities": capabilities,
+                                    "descriptor": {
+                                        "server_url": server_url,
+                                        "capabilities": capabilities,
+                                    }
                                 },
                             }
                 return raw_result
@@ -287,7 +295,9 @@ def load_registry(
             {
                 k: {
                     "package": v,
-                    "mcp": {"server_url": "", "capabilities": []},
+                    "mcp": {
+                        "descriptor": {"server_url": "", "capabilities": []}
+                    },
                 }
                 for k, v in PLUGIN_REGISTRY.items()
             },
@@ -374,11 +384,14 @@ def _cmd_mcp_enable(args: argparse.Namespace) -> int:
         print(f"Unknown MCP plug-in: {name}", file=sys.stderr)
         return 1
     mcp_meta = meta.get("mcp")
-    if not isinstance(mcp_meta, dict) or not mcp_meta.get("server_url"):
-        print(f"No MCP server info for plug-in: {name}", file=sys.stderr)
+    descriptor = None
+    if isinstance(mcp_meta, dict):
+        descriptor = mcp_meta.get("descriptor")
+    if not (isinstance(descriptor, dict) and descriptor.get("server_url")):
+        print(f"No MCP descriptor for plug-in: {name}", file=sys.stderr)
         return 1
     config = _load_mcp_config()
-    config[name] = mcp_meta
+    config[name] = descriptor
     _save_mcp_config(config)
     return 0
 

--- a/scripts/update_registry.py
+++ b/scripts/update_registry.py
@@ -46,9 +46,11 @@ def sync_registry(data: dict[str, object]) -> bool:
 
     Returns ``True`` if ``data`` was modified.
     """
-    default_mcp = {"server_url": "https://example.com", "capabilities": []}
+    default_mcp = {
+        "descriptor": {"server_url": "https://example.com", "capabilities": []}
+    }
     expected_plugins = {
-        name: {"package": pkg, "mcp": default_mcp.copy()}
+        name: {"package": pkg, "mcp": json.loads(json.dumps(default_mcp))}
         for name, pkg in plugins.PLUGIN_REGISTRY.items()
     }
     expected_recipes = plugins.RECIPE_REGISTRY

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -11,8 +11,10 @@ def test_mcp_adapter_exposes_registry_tools(monkeypatch):
         "dummy": {
             "package": "pkg",
             "mcp": {
-                "server_url": "https://example.com",
-                "capabilities": ["echo"],
+                "descriptor": {
+                    "server_url": "https://example.com",
+                    "capabilities": ["echo"],
+                }
             },
         }
     }
@@ -20,6 +22,7 @@ def test_mcp_adapter_exposes_registry_tools(monkeypatch):
 
     tools = mcp_adapter.get_tools(reg)
     assert tools["dummy"]() == {
+        "name": "dummy",
         "server_url": "https://example.com",
         "capabilities": ["echo"],
     }
@@ -30,8 +33,10 @@ def test_mcp_adapter_tool_descriptors(monkeypatch):
         "dummy": {
             "package": "pkg",
             "mcp": {
-                "server_url": "https://example.com",
-                "capabilities": ["echo"],
+                "descriptor": {
+                    "server_url": "https://example.com",
+                    "capabilities": ["echo"],
+                }
             },
         }
     }
@@ -125,8 +130,10 @@ def test_mcp_adapter_serve_lists_descriptors(monkeypatch):
         "dummy": {
             "package": "pkg",
             "mcp": {
-                "server_url": "https://example.com",
-                "capabilities": ["echo"],
+                "descriptor": {
+                    "server_url": "https://example.com",
+                    "capabilities": ["echo"],
+                }
             },
         }
     }

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -219,8 +219,10 @@ def test_load_registry_surfaces_mcp_metadata(monkeypatch, tmp_path):
             "example": {
                 "package": "pkg",
                 "mcp": {
-                    "server_url": "https://example.com",
-                    "capabilities": ["x"],
+                    "descriptor": {
+                        "server_url": "https://example.com",
+                        "capabilities": ["x"],
+                    }
                 },
             }
         }
@@ -231,8 +233,9 @@ def test_load_registry_surfaces_mcp_metadata(monkeypatch, tmp_path):
 
     registry = plugins.load_registry(raw=True, update=True)
     meta = registry["example"]["mcp"]
-    assert meta["server_url"] == "https://example.com"
-    assert meta["capabilities"] == ["x"]
+    desc = meta["descriptor"]
+    assert desc["server_url"] == "https://example.com"
+    assert desc["capabilities"] == ["x"]
 
 
 def test_example_mcp_plugin_in_registry(monkeypatch, tmp_path):
@@ -245,8 +248,9 @@ def test_example_mcp_plugin_in_registry(monkeypatch, tmp_path):
 
     registry = plugins.load_registry(raw=True, update=True)
     meta = registry["example_mcp"]["mcp"]
-    assert meta["server_url"] == "https://example.com"
-    assert meta["capabilities"] == []
+    desc = meta["descriptor"]
+    assert desc["server_url"] == "https://example.com"
+    assert desc["capabilities"] == []
 
 
 def test_example_mcp_plugin_metadata():

--- a/tests/test_plugin_registry_schema.py
+++ b/tests/test_plugin_registry_schema.py
@@ -21,5 +21,7 @@ def test_plugins_include_mcp_metadata() -> None:
     for plugin in data.get("plugins", {}).values():
         mcp = plugin.get("mcp")
         assert isinstance(mcp, dict)
-        assert "server_url" in mcp
-        assert "capabilities" in mcp
+        descriptor = mcp.get("descriptor")
+        assert isinstance(descriptor, dict)
+        assert "server_url" in descriptor
+        assert "capabilities" in descriptor

--- a/tests/test_plugins_script.py
+++ b/tests/test_plugins_script.py
@@ -226,7 +226,12 @@ def test_mcp_enable_writes_config(monkeypatch, tmp_path):
             return {
                 "dummy": {
                     "package": "pkg",
-                    "mcp": {"server_url": "https://example.com", "capabilities": []},
+                    "mcp": {
+                        "descriptor": {
+                            "server_url": "https://example.com",
+                            "capabilities": [],
+                        }
+                    },
                 }
             }
         return {}
@@ -237,6 +242,7 @@ def test_mcp_enable_writes_config(monkeypatch, tmp_path):
     assert rc == 0
     data = json.loads(cfg.read_text())
     assert data["dummy"]["server_url"] == "https://example.com"
+    assert data["dummy"]["capabilities"] == []
 
 
 def test_mcp_disable_removes_config(monkeypatch, tmp_path):

--- a/tests/test_update_registry.py
+++ b/tests/test_update_registry.py
@@ -4,7 +4,10 @@ from scripts import update_registry, plugins
 
 
 def test_update_registry_check_recipes(tmp_path, monkeypatch):
-    plugin_objs = {name: {"package": pkg, "mcp": {}} for name, pkg in plugins.PLUGIN_REGISTRY.items()}
+    plugin_objs = {
+        name: {"package": pkg, "mcp": {"descriptor": {}}}
+        for name, pkg in plugins.PLUGIN_REGISTRY.items()
+    }
     data = {"plugins": plugin_objs, "recipes": {"echo": "old"}}
     reg = tmp_path / "plugin-registry.json"
     reg.write_text(json.dumps(data), encoding="utf-8")
@@ -25,7 +28,18 @@ def test_update_registry_rewrites_outdated_file(tmp_path, monkeypatch):
     rc = update_registry.main([])
     assert rc == 0
     expected = {
-        "plugins": {name: {"package": pkg, "mcp": {}} for name, pkg in plugins.PLUGIN_REGISTRY.items()},
+        "plugins": {
+            name: {
+                "package": pkg,
+                "mcp": {
+                    "descriptor": {
+                        "server_url": "https://example.com",
+                        "capabilities": [],
+                    }
+                },
+            }
+            for name, pkg in plugins.PLUGIN_REGISTRY.items()
+        },
         "recipes": plugins.RECIPE_REGISTRY,
     }
     assert json.loads(reg.read_text(encoding="utf-8")) == expected
@@ -39,7 +53,18 @@ def test_update_registry_creates_missing_file(tmp_path, monkeypatch):
     rc = update_registry.main([])
     assert rc == 0
     expected = {
-        "plugins": {name: {"package": pkg, "mcp": {}} for name, pkg in plugins.PLUGIN_REGISTRY.items()},
+        "plugins": {
+            name: {
+                "package": pkg,
+                "mcp": {
+                    "descriptor": {
+                        "server_url": "https://example.com",
+                        "capabilities": [],
+                    }
+                },
+            }
+            for name, pkg in plugins.PLUGIN_REGISTRY.items()
+        },
         "recipes": plugins.RECIPE_REGISTRY,
     }
     assert json.loads(reg.read_text(encoding="utf-8")) == expected


### PR DESCRIPTION
## Summary
- require MCP descriptors in plugin registry schema
- load tools through MCP descriptors by default
- document migration to descriptor-based registry entries

## Testing
- `ruff check plugins/mcp_adapter.py scripts/plugins.py scripts/update_registry.py tests/test_mcp_adapter.py tests/test_plugin_registry.py tests/test_plugin_registry_schema.py tests/test_plugins_script.py tests/test_update_registry.py`
- `mypy --install-types --non-interactive plugins/mcp_adapter.py scripts/plugins.py scripts/update_registry.py`
- `pytest tests/test_mcp_adapter.py tests/test_plugin_registry.py tests/test_plugin_registry_schema.py tests/test_plugins_script.py tests/test_update_registry.py -q`
- `pre-commit run --files docs/plugins.md plugin-registry.json plugin-registry.schema.json plugins/mcp_adapter.py scripts/plugins.py scripts/update_registry.py tests/test_mcp_adapter.py tests/test_plugin_registry.py tests/test_plugin_registry_schema.py tests/test_plugins_script.py tests/test_update_registry.py` *(fails: ruff found F811 redefinitions in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bef7858b2883268fa8b288658e9d3f