### PR TITLE
Log capability tokens with rotation and enforce deny-all

### DIFF
--- a/scripts/cli_common.py
+++ b/scripts/cli_common.py
@@ -7,6 +7,8 @@ notifications and building analytics argument parsers.
 from __future__ import annotations
 
 import argparse
+import logging
+from logging.handlers import RotatingFileHandler
 import os
 import secrets
 import shlex
@@ -43,6 +45,29 @@ TOKEN_TTL_SECONDS = 3600
 SESSION_LOG = Path(os.environ.get("SESSION_LOG", "session.log"))
 
 
+def _get_capability_logger() -> logging.Logger:
+    """Return a logger that writes capability grants and denials."""
+
+    logger = logging.getLogger("capability_tokens")
+    log_path = SESSION_LOG
+    handler_path = (
+        logger.handlers[0].baseFilename
+        if logger.handlers and isinstance(logger.handlers[0], RotatingFileHandler)
+        else None
+    )
+    if handler_path != str(log_path):
+        logger.handlers.clear()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        handler = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3)
+        formatter = logging.Formatter(
+            "%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+
+
 def _strip_risk_tag(command: str) -> str:
     """Return ``command`` without any ``[risk:*]`` suffix."""
 
@@ -74,6 +99,8 @@ def execute_steps(
     them. When executing, commands tagged with ``[risk:*]`` require the
     ``confirm`` flag to be set or the function aborts before running anything.
     A non-empty ``dry_run_log`` must be supplied to proceed with execution.
+    Capabilities are denied by default and must be explicitly granted before
+    their associated steps run.
     """
     step_list = list(steps)
 
@@ -138,6 +165,9 @@ def execute_steps(
                     allowed.add(cap_name)
                     with log_path.open("a", encoding="utf-8") as log:
                         log.write(f"[using capability token: {cap_name}={token}]\n")
+                    _get_capability_logger().info(
+                        "using capability token: %s token=%s", cap_name, token
+                    )
                     continue
                 answer = input(f"Grant capability {cap_name}? [y/N]").strip().lower()
 
@@ -150,11 +180,9 @@ def execute_steps(
                     allowed.add(cap_name)
                     with log_path.open("a", encoding="utf-8") as log:
                         log.write(f"[granted capability: {cap_name} token={token}]\n")
-                    SESSION_LOG.parent.mkdir(parents=True, exist_ok=True)
-                    with SESSION_LOG.open("a", encoding="utf-8") as slog:
-                        slog.write(
-                            f"[granted capability: {cap_name} token={token}]\n"
-                        )
+                    _get_capability_logger().info(
+                        "granted capability: %s token=%s", cap_name, token
+                    )
                 else:
                     msg = f"Missing capabilities: {cap_name}"
                     print(msg, file=sys.stderr)
@@ -163,9 +191,9 @@ def execute_steps(
                         log.write(f"[missing capabilities: {cap_name}]\n")
 
                         log.write("(skipped)\n\n")
-                    SESSION_LOG.parent.mkdir(parents=True, exist_ok=True)
-                    with SESSION_LOG.open("a", encoding="utf-8") as slog:
-                        slog.write(f"[denied capability: {cap_name}]\n")
+                    _get_capability_logger().info(
+                        "denied capability: %s", cap_name
+                    )
                     if not exit_code:
                         exit_code = 1
                     skip_step = True

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -85,6 +85,7 @@ def test_session_log_records_grants_and_denials(monkeypatch, tmp_path):
     monkeypatch.setattr(
         cli_common, "SESSION_LOG", tmp_path / "session.log"
     )
+    cli_common._get_capability_logger()
     inputs = iter(["y", "n", "y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
@@ -112,10 +113,61 @@ def test_session_log_records_grants_and_denials(monkeypatch, tmp_path):
         dry_run_log=["1. echo hi", "2. curl example.com", "3. cat file.txt"],
     )
 
-    content = (tmp_path / "session.log").read_text()
-    assert "[granted capability: process.exec" in content
-    assert "[denied capability: network.fetch]" in content
-    assert "[granted capability: filesystem.read" in content
+    lines = (tmp_path / "session.log").read_text().splitlines()
+    assert any(
+        re.match(
+            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} granted capability: process\.exec token=[0-9a-f]+",
+            line,
+        )
+        for line in lines
+    )
+    assert any(
+        re.match(
+            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} denied capability: network.fetch",
+            line,
+        )
+        for line in lines
+    )
+    assert any("granted capability: filesystem.read" in line for line in lines)
+
+
+def test_default_deny_requires_approval(monkeypatch, tmp_path):
+    cli_common._SESSION_TOKENS.clear()
+    monkeypatch.setattr(
+        cli_common, "SESSION_LOG", tmp_path / "session.log"
+    )
+    cli_common._get_capability_logger()
+
+    inputs = iter(["n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    executed = {}
+
+    def fake_run(cmd, *, shell, capture_output, text):
+        executed["called"] = True
+
+        class Result:
+            def __init__(self):
+                self.stdout = ""
+                self.stderr = ""
+                self.returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli_common.subprocess, "run", fake_run)
+
+    step = PlanStep(1, "echo hi", capabilities={Capability.PROCESS_EXEC})
+    rc = cli_common.execute_steps(
+        [step],
+        log_path=tmp_path / "log.txt",
+        assume_yes=True,
+        dry_run_log=["1. echo hi"],
+    )
+
+    assert rc == 1
+    assert executed == {}
+    log_content = (tmp_path / "session.log").read_text()
+    assert "denied capability: process.exec" in log_content
 
 
 def test_token_expiration(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- record granted/denied capability tokens to a timestamped rotating log
- require explicit approval for capabilities by default
- test logging behavior and deny-all enforcement

## Testing
- `pre-commit run --files scripts/cli_common.py tests/test_capabilities.py` *(fails: ruff reported issues in unrelated files)*
- `ruff check scripts/cli_common.py tests/test_capabilities.py`
- `mypy scripts/cli_common.py tests/test_capabilities.py`
- `pytest tests/test_capabilities.py`


------
https://chatgpt.com/codex/tasks/task_e_68c032fb3ddc8326a49422b519720ef3