### PR TITLE
Add dashboard metrics and plugin scaffold command

### DIFF
--- a/dashboard/pages/index.js
+++ b/dashboard/pages/index.js
@@ -139,6 +139,19 @@ export default function Home() {
       .catch(() => setLogs('error'));
   };
 
+  const togglePlugin = (name, enabled) => {
+    if (!window.__TAURI__) return;
+    invoke('toggle_plugin', { name, enable: enabled })
+      .then(() => {
+        setPluginToggles((prev) =>
+          prev.map((p) =>
+            p.name === name ? { ...p, enabled } : p
+          )
+        );
+      })
+      .catch(() => {});
+  };
+
   return (
     <div>
       <h1>UME Dashboard</h1>
@@ -158,7 +171,16 @@ export default function Home() {
           </ul>
         </div>
       )}
-      {budget !== null && <p>Budget: {budget}</p>}
+      {budget !== null && (
+        <div>
+          <h2>Budget</h2>
+          <progress
+            value={budget}
+            max={Math.max(budget, ...budgetHistory, 1)}
+          ></progress>
+          <p>{budget}</p>
+        </div>
+      )}
       {budgetHistory.length > 0 && (
         <div>
           <h2>Budget History</h2>
@@ -175,7 +197,12 @@ export default function Home() {
           {pluginToggles.map((p) => (
             <div key={p.name}>
               <label>
-                <input type="checkbox" checked={p.enabled} readOnly /> {p.name}
+                <input
+                  type="checkbox"
+                  checked={p.enabled}
+                  onChange={(e) => togglePlugin(p.name, e.target.checked)}
+                />{' '}
+                {p.name}
               </label>
             </div>
           ))}

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -11,3 +11,9 @@ The Tauri application offers a minimal interface for sending prompts, reviewing 
 5. Hit **Run** to execute the steps or choose a recipe from the drop-down and run it.
 
 Dropped files trigger the `prompt-file` event and populate the prompt field. The loaded file path is shown below the drop zone so you can confirm which prompt was imported.
+
+The dashboard also surfaces additional context from the backend:
+
+* **Recent Plans** – the last five planning requests are listed for quick reference.
+* **Budget Meter** – remaining LLM budget is visualised with a progress bar and accompanying history.
+* **Plug-in Toggles** – checkboxes enable or disable MCP tools, updating `~/.config/d0tTino/mcp.json`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -39,6 +39,12 @@ python -m scripts.plugin_scaffold demo
 python -m scripts.plugin_scaffold demo --recipe
 ```
 
+The plug-in helper exposes an equivalent command:
+
+```bash
+python -m scripts.plugins plugin new demo
+```
+
 The script creates a directory with a minimal `pyproject.toml`, an `mcp.json`
 file and a plug-in module that defines a sample `run` function along with
 `mcp_tool` metadata. Edit these stubs to implement your plug-in.

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -488,6 +488,18 @@ def _cmd_new_plugin(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_plugin_new(args: argparse.Namespace) -> int:
+    """Scaffold an MCP-compliant plug-in."""
+    from scripts import plugin_scaffold
+
+    plugin_scaffold.scaffold_plugin(
+        args.name,
+        description=args.description,
+        output=args.output,
+    )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -508,6 +520,15 @@ def build_parser() -> argparse.ArgumentParser:
     new.add_argument("--description", default="A d0tTino plug-in")
     new.add_argument("--output", default=".", help="Output directory")
     new.set_defaults(func=_cmd_new_plugin)
+
+    plugin_cmd = sub.add_parser("plugin", help="Manage MCP plug-ins")
+    plugin_sub = plugin_cmd.add_subparsers(dest="plugin_command", required=True)
+
+    p_new = plugin_sub.add_parser("new", help="Scaffold a new MCP plug-in")
+    p_new.add_argument("name", help="Plug-in name")
+    p_new.add_argument("--description", default="A d0tTino plug-in")
+    p_new.add_argument("--output", default=".", help="Output directory")
+    p_new.set_defaults(func=_cmd_plugin_new)
 
     backends = sub.add_parser("backends", help="Manage backend plug-ins")
     backend_sub = backends.add_subparsers(dest="backend_command", required=True)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,6 +147,54 @@ raise SystemExit(0 if ok else 1)
         Ok(output.status.success())
     }
 
+    pub async fn toggle_plugin(name: String, enable: bool) -> Result<bool, String> {
+        let cfg_path = if let Ok(home) = std::env::var("HOME") {
+            PathBuf::from(home)
+                .join(".config")
+                .join("d0tTino")
+                .join("mcp.json")
+        } else {
+            return Err("HOME not set".into());
+        };
+        let mut data: serde_json::Map<String, serde_json::Value> = fs::read_to_string(&cfg_path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .and_then(|v: serde_json::Value| v.as_object().cloned())
+            .unwrap_or_default();
+
+        if enable {
+            let reg_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../plugin-registry.json");
+            let reg_json: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(reg_path).map_err(|e| e.to_string())?,
+            )
+            .map_err(|e| e.to_string())?;
+            let descriptor = reg_json
+                .get("plugins")
+                .and_then(|p| p.get(&name))
+                .and_then(|meta| meta.get("mcp"))
+                .and_then(|m| m.get("descriptor"))
+                .cloned();
+            if let Some(desc) = descriptor {
+                data.insert(name, desc);
+            } else {
+                return Err("plugin not found".into());
+            }
+        } else {
+            data.remove(&name);
+        }
+
+        if let Some(parent) = cfg_path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let val = serde_json::Value::Object(data);
+        fs::write(
+            &cfg_path,
+            serde_json::to_string_pretty(&val).map_err(|e| e.to_string())?,
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(true)
+    }
+
     pub async fn dashboard() -> Result<Dashboard, String> {
         let mut plans = Vec::new();
         if let Ok(home) = std::env::var("HOME") {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -49,6 +49,12 @@ async fn record_event(
 }
 
 #[cfg(feature = "gui")]
+#[tauri::command]
+async fn toggle_plugin(name: String, enable: bool) -> Result<bool, String> {
+    ume_tauri::commands::toggle_plugin(name, enable).await
+}
+
+#[cfg(feature = "gui")]
 fn main() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
@@ -59,6 +65,7 @@ fn main() {
             run_recipe,
             dashboard,
             record_event,
+            toggle_plugin,
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application")


### PR DESCRIPTION
## Summary
- show recent plans, budget meter, and interactive plug-in toggles on dashboard
- add Tauri command to toggle MCP plug-ins
- expose `plugin new` helper to scaffold MCP plug-ins
- document dashboard metrics and plug-in scaffolding

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid Options)*
- `ruff check scripts/plugins.py`
- `pytest tests/test_plugins_script.py tests/test_plugin_scaffold.py -q`
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c032fbd29883269ee6830a679145a5