### PR TITLE
Refactor tino CLI layout and extend cockpit automation

### DIFF
--- a/scripts/tino_cli/actions.py
+++ b/scripts/tino_cli/actions.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List
+from typing import Any, Callable, Dict, Iterable, List, Sequence
 
 from telemetry import record_event
 
+from .main import (
+    build_state,
+    compose_command,
+    docs_publish_operation,
+    idea_submit_operation,
+    research_ingest_operation,
+    task_run_operation,
+    wishlist_add_operation,
+)
 from .models import ActionSpec, CommandResult
 from .utils import ensure_cache_dir, telemetry_status
 
@@ -21,6 +31,7 @@ class ActionStep:
 
     index: int
     command: str
+    args: Sequence[str] | None = None
 
 
 DEFAULT_ACTIONS: dict[str, ActionSpec] = {
@@ -66,6 +77,12 @@ DEFAULT_ACTIONS: dict[str, ActionSpec] = {
 
 
 def _render_steps(spec: ActionSpec, payload: str | None) -> List[ActionStep]:
+    if spec.name == "cockpit-up":
+        command = compose_command("up", "-d")
+        return [ActionStep(1, shlex.join(command), command)]
+    if spec.name == "cockpit-down":
+        command = compose_command("down")
+        return [ActionStep(1, shlex.join(command), command)]
     rendered: List[ActionStep] = []
     for idx, raw in enumerate(spec.steps, start=1):
         rendered.append(ActionStep(idx, raw.format(payload=payload or "")))
@@ -84,12 +101,20 @@ def _execute_steps(steps: Iterable[ActionStep], log_path: os.PathLike[str]) -> t
     with open(log_path, "w", encoding="utf-8") as handle:
         for step in steps:
             handle.write(f"$ {step.command}\n")
-            proc = subprocess.run(
-                _shell_command(step.command),
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+            if step.args:
+                proc = subprocess.run(
+                    list(step.args),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            else:
+                proc = subprocess.run(
+                    _shell_command(step.command),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
             if proc.stdout:
                 handle.write(proc.stdout)
             if proc.stderr:
@@ -98,6 +123,96 @@ def _execute_steps(steps: Iterable[ActionStep], log_path: os.PathLike[str]) -> t
             handle.write(f"(exit {exit_code})\n\n")
             log_entries.append(step.command)
     return exit_code, log_entries
+
+
+def _invoke_callable(
+    log_path: os.PathLike[str],
+    command: str,
+    call: Callable[[], Any],
+) -> tuple[int, list[str], dict[str, Any]]:
+    commands = [command]
+    details: dict[str, Any] = {}
+    exit_code = 0
+    with open(log_path, "w", encoding="utf-8") as handle:
+        handle.write(f"$ {command}\n")
+        try:
+            result = call()
+        except Exception as exc:  # noqa: BLE001 - bubble up error context
+            exit_code = 1
+            message = str(exc)
+            handle.write(message + "\n")
+            details["error"] = message
+        else:
+            payload = getattr(result, "payload", result)
+            if payload is not None:
+                try:
+                    serialized = json.dumps(payload, indent=2)
+                except TypeError:
+                    serialized = str(payload)
+                handle.write(serialized + "\n")
+                details["response"] = payload
+        handle.write(f"(exit {exit_code})\n")
+    return exit_code, commands, details
+
+
+def _error_action(log_path: os.PathLike[str], command: str, message: str) -> tuple[int, list[str], dict[str, Any]]:
+    commands = [command]
+    with open(log_path, "w", encoding="utf-8") as handle:
+        handle.write(f"$ {command}\n")
+        handle.write(message + "\n")
+        handle.write("(exit 1)\n")
+    return 1, commands, {"error": message}
+
+
+def _research_action_payload(raw: str) -> tuple[str, str]:
+    if "::" in raw:
+        topic, source = raw.split("::", 1)
+        topic = topic.strip() or "adhoc"
+        source = source.strip()
+        return topic, source
+    return "adhoc", raw.strip()
+
+
+def _run_special_action(
+    name: str,
+    payload: str | None,
+    confirm: bool,
+    log_path: os.PathLike[str],
+) -> tuple[int, list[str], dict[str, Any]]:
+    state = build_state(dry_run=False, confirm=confirm)
+    if name == "cockpit-new-task":
+        if not payload:
+            return _error_action(log_path, "task run <missing>", "Task description required.")
+        task_name = payload
+        command = f"task run {shlex.quote(task_name)}"
+        return _invoke_callable(log_path, command, lambda: task_run_operation(state, task_name, payload=None))
+    if name == "cockpit-inject-context":
+        if not payload:
+            return _error_action(log_path, "idea <missing>", "Context payload required.")
+        context = payload
+        command = f"idea {shlex.quote(context)}"
+        return _invoke_callable(log_path, command, lambda: idea_submit_operation(state, text=context))
+    if name == "cockpit-research-ingest":
+        if not payload:
+            return _error_action(log_path, "research ingest <missing>", "Source path or URL required.")
+        topic, source = _research_action_payload(payload)
+        command = f"research ingest {shlex.quote(topic)} {shlex.quote(source)}"
+        return _invoke_callable(
+            log_path,
+            command,
+            lambda: research_ingest_operation(state, topic=topic, source=source),
+        )
+    if name == "cockpit-wishlist-add":
+        if not payload:
+            return _error_action(log_path, "wishlist add <missing>", "Wishlist item required.")
+        item = payload
+        command = f"wishlist add {shlex.quote(item)}"
+        return _invoke_callable(log_path, command, lambda: wishlist_add_operation(state, url=item, tags=None))
+    if name == "cockpit-publish-docs":
+        target = payload or os.environ.get("TINO_DOC_TARGET", "latest")
+        command = f"docs publish {shlex.quote(target)}"
+        return _invoke_callable(log_path, command, lambda: docs_publish_operation(state, target=target, site=None, version=None))
+    raise ValueError(f"Unknown action: {name}")
 
 
 def run_action(name: str, *, payload: str | None = None, confirm: bool = False) -> CommandResult:
@@ -113,8 +228,12 @@ def run_action(name: str, *, payload: str | None = None, confirm: bool = False) 
     log_path = spec.log_path(cache_dir)
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
-    steps = _render_steps(spec, payload)
-    exit_code, rendered_commands = _execute_steps(steps, log_path)
+    details_extra: Dict[str, Any] = {}
+    if name in {"cockpit-up", "cockpit-down"}:
+        steps = _render_steps(spec, payload)
+        exit_code, rendered_commands = _execute_steps(steps, log_path)
+    else:
+        exit_code, rendered_commands, details_extra = _run_special_action(name, payload, confirm, log_path)
 
     timestamp = time.time()
     audit_path = cache_dir / "cockpit.log"
@@ -147,6 +266,8 @@ def run_action(name: str, *, payload: str | None = None, confirm: bool = False) 
     }
     if payload:
         details["payload"] = payload
+    if details_extra:
+        details.update(details_extra)
     message = f"{spec.description} (exit {exit_code})"
     return CommandResult(message=message, telemetry=telemetry, details=details)
 

--- a/scripts/tino_cli/clients/docs.py
+++ b/scripts/tino_cli/clients/docs.py
@@ -1,6 +1,8 @@
 """Client helpers for docs publishing automation."""
 from __future__ import annotations
 
+from pathlib import Path
+
 from .base import BaseClient, RequestResult
 from ..config import DOCS
 from ..state import CLIState
@@ -12,8 +14,22 @@ class DocsClient(BaseClient):
     def __init__(self) -> None:
         super().__init__(name="docs", config=DOCS)
 
-    def publish(self, state: CLIState, *, site: str, version: str | None = None) -> RequestResult | None:
-        payload = {"site": site}
+    def publish(
+        self,
+        state: CLIState,
+        *,
+        target: str,
+        site: str | None = None,
+        version: str | None = None,
+    ) -> RequestResult | None:
+        payload: dict[str, object] = {"target": target}
+        path = Path(target)
+        if path.exists():
+            payload["path"] = str(path)
+        else:
+            payload["doc_id"] = target
+        if site:
+            payload["site"] = site
         if version:
             payload["version"] = version
         return self.request(state, "post", "/docs/publish", json_payload=payload, telemetry_action="publish")

--- a/scripts/tino_cli/clients/finance.py
+++ b/scripts/tino_cli/clients/finance.py
@@ -15,6 +15,9 @@ class FinanceClient(BaseClient):
         super().__init__(name="finance", config=FINANCE)
 
     def summarize(self, state: CLIState, *, period: str) -> RequestResult | None:
+        return self.snapshot(state, period=period)
+
+    def snapshot(self, state: CLIState, *, period: str) -> RequestResult | None:
         payload = {"period": period}
         return self.request(state, "post", "/finance/report", json_payload=payload, telemetry_action="report")
 

--- a/scripts/tino_cli/clients/storm.py
+++ b/scripts/tino_cli/clients/storm.py
@@ -18,10 +18,25 @@ class StormClient(BaseClient):
         payload = {"topic": topic, "source": source}
         return self.request(state, "post", "/research/ingest", json_payload=payload, telemetry_action="ingest")
 
-    def draft(self, state: CLIState, *, topic: str, hints: Mapping[str, str] | None = None) -> RequestResult | None:
+    def draft(
+        self,
+        state: CLIState,
+        *,
+        topic: str,
+        hints: Mapping[str, object] | None = None,
+        doc: str | None = None,
+        anchor: str | None = None,
+        prompt: str | None = None,
+    ) -> RequestResult | None:
         payload: dict[str, object] = {"topic": topic}
         if hints:
             payload["hints"] = hints
+        if doc:
+            payload["doc"] = doc
+        if anchor:
+            payload["anchor"] = anchor
+        if prompt:
+            payload["prompt"] = prompt
         return self.request(state, "post", "/research/draft", json_payload=payload, telemetry_action="draft")
 
 

--- a/scripts/tino_cli/clients/taskcascadence.py
+++ b/scripts/tino_cli/clients/taskcascadence.py
@@ -23,8 +23,20 @@ class TaskCascadenceClient(BaseClient):
     def status(self, state: CLIState, task_id: str) -> RequestResult | None:
         return self.request(state, "get", f"/tasks/{task_id}", telemetry_action="status")
 
-    def signal(self, state: CLIState, task_id: str, *, signal: str) -> RequestResult | None:
-        body = {"signal": signal}
+    def signal(
+        self,
+        state: CLIState,
+        task_id: str,
+        *,
+        signal: str,
+        link: str | None = None,
+        note: str | None = None,
+    ) -> RequestResult | None:
+        body: dict[str, object] = {"signal": signal}
+        if link:
+            body["link"] = link
+        if note:
+            body["note"] = note
         return self.request(
             state,
             "post",

--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -6,29 +6,44 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, Mapping, Optional, Sequence
 
 import typer
 
 from telemetry import analytics_default
 
-from .clients import DocsClient, FinanceClient, StormClient, TaskCascadenceClient, UMEClient
+from .clients import (
+    DocsClient,
+    FinanceClient,
+    StormClient,
+    TaskCascadenceClient,
+    UMEClient,
+)
 from .config import load_env_defaults
 from .plugin_loader import register_plugin_commands
 from .state import CLIState
 
 app = typer.Typer(help="Automation interface for d0tTino tooling.", no_args_is_help=True)
 
+COMPOSE_FILE = Path("docker-compose.yml")
+WISHLIST_PATH = Path("metadata") / "wishlist.json"
 
-def _set_state(ctx: typer.Context, *, dry_run: bool, confirm: bool) -> CLIState:
+
+def build_state(*, dry_run: bool, confirm: bool) -> CLIState:
+    """Create a :class:`CLIState` populated with environment defaults."""
+
     load_env_defaults()
     log_path = Path(os.environ.get("TINO_CLI_LOG", "tino-cli.log"))
-    state = CLIState(
+    return CLIState(
         dry_run=dry_run,
         confirm=confirm,
         telemetry_enabled=analytics_default(),
         log_path=log_path,
     )
+
+
+def _set_state(ctx: typer.Context, *, dry_run: bool, confirm: bool) -> CLIState:
+    state = build_state(dry_run=dry_run, confirm=confirm)
     ctx.obj = state
     return state
 
@@ -38,6 +53,183 @@ def _get_state(ctx: typer.Context) -> CLIState:
     if isinstance(state, CLIState):
         return state
     raise RuntimeError("CLI state not initialised")
+
+
+def run_shell_command(
+    state: CLIState,
+    command: Sequence[str],
+    *,
+    require_confirm: bool = False,
+    confirm_message: str = "Use --confirm to execute this command.",
+) -> int:
+    """Execute ``command`` respecting ``dry_run`` and ``confirm`` flags."""
+
+    printable = shlex.join(command)
+    if state.dry_run:
+        typer.echo(f"[dry-run] {printable}")
+        return 0
+    if require_confirm and not state.confirm:
+        typer.echo(confirm_message, err=True)
+        return 1
+    return subprocess.call(list(command))
+
+
+def compose_command(*args: str) -> tuple[str, ...]:
+    """Return a docker compose command tuple."""
+
+    return ("docker", "compose", "-f", str(COMPOSE_FILE), *args)
+
+
+def init_tooling(state: CLIState, *, quick: bool = False) -> int:
+    script = Path("scripts") / "install.sh"
+    command = ["bash", str(script)]
+    if quick:
+        command.append("--quick")
+    return run_shell_command(state, command, require_confirm=True)
+
+
+def run_doctor(state: CLIState) -> int:
+    script = Path("scripts") / "check-hooks.sh"
+    return run_shell_command(state, ["bash", str(script)])
+
+
+def show_whoami(state: CLIState) -> dict[str, object]:
+    return {
+        "confirm": state.confirm,
+        "telemetry": state.telemetry_enabled,
+        "log_path": str(state.log_path),
+    }
+
+
+def start_services(state: CLIState, service: str | None = None) -> int:
+    command: list[str] = list(compose_command("up", "-d"))
+    if service:
+        command.append(service)
+    return run_shell_command(state, command, require_confirm=True)
+
+
+def stop_services(state: CLIState) -> int:
+    command = compose_command("down")
+    return run_shell_command(state, command, require_confirm=True)
+
+
+def stream_logs(state: CLIState, service: str) -> int:
+    command = compose_command("logs", "-f", service)
+    return run_shell_command(
+        state,
+        command,
+        require_confirm=True,
+        confirm_message="Use --confirm to stream live logs.",
+    )
+
+
+def task_run_operation(
+    state: CLIState,
+    task: str,
+    *,
+    payload: Mapping[str, object] | None = None,
+):
+    client = TaskCascadenceClient()
+    return client.run(state, task, payload=payload)
+
+
+def task_status_operation(state: CLIState, task_id: str):
+    client = TaskCascadenceClient()
+    return client.status(state, task_id)
+
+
+def task_signal_operation(
+    state: CLIState,
+    task_id: str,
+    *,
+    signal: str,
+    link: str | None = None,
+    note: str | None = None,
+):
+    client = TaskCascadenceClient()
+    return client.signal(state, task_id, signal=signal, link=link, note=note)
+
+
+def research_ingest_operation(state: CLIState, *, topic: str, source: str):
+    client = StormClient()
+    return client.ingest(state, topic=topic, source=source)
+
+
+def research_draft_operation(
+    state: CLIState,
+    *,
+    topic: str,
+    hints: Mapping[str, object] | None = None,
+    doc: str | None = None,
+    anchor: str | None = None,
+    prompt: str | None = None,
+):
+    client = StormClient()
+    return client.draft(state, topic=topic, hints=hints or None, doc=doc, anchor=anchor, prompt=prompt)
+
+
+def idea_submit_operation(state: CLIState, *, text: str):
+    client = UMEClient()
+    return client.submit_idea(state, text=text)
+
+
+def mem_query_operation(
+    state: CLIState,
+    *,
+    query: str,
+    filters: Mapping[str, object] | None = None,
+):
+    client = UMEClient()
+    return client.query(state, query=query, filters=filters)
+
+
+def finance_snapshot_operation(state: CLIState, *, period: str):
+    client = FinanceClient()
+    return client.snapshot(state, period=period)
+
+
+def finance_sync_operation(state: CLIState, *, provider: str):
+    client = FinanceClient()
+    return client.sync(state, provider=provider)
+
+
+def wishlist_add_operation(state: CLIState, *, url: str, tags: Sequence[str] | None = None) -> dict[str, object]:
+    entry: dict[str, object] = {"url": url}
+    if tags:
+        entry["tags"] = list(tags)
+    if state.dry_run:
+        return {"entry": entry, "path": str(WISHLIST_PATH)}
+    try:
+        if WISHLIST_PATH.exists():
+            data = json.loads(WISHLIST_PATH.read_text(encoding="utf-8"))
+            if not isinstance(data, list):
+                data = []
+        else:
+            data = []
+    except json.JSONDecodeError:
+        data = []
+    data.append(entry)
+    WISHLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    WISHLIST_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return {"entry": entry, "path": str(WISHLIST_PATH)}
+
+
+def docs_publish_operation(
+    state: CLIState,
+    *,
+    target: str,
+    site: str | None = None,
+    version: str | None = None,
+):
+    client = DocsClient()
+    return client.publish(state, target=target, site=site, version=version)
+
+
+def _render_response(result) -> None:
+    if result is None:
+        return
+    payload = getattr(result, "payload", result)
+    typer.echo(json.dumps(payload, indent=2))
 
 
 @app.callback()
@@ -51,222 +243,158 @@ def main(
     _set_state(ctx, dry_run=dry_run, confirm=confirm)
 
 
-# ---------------------------------------------------------------------------
-# Bootstrap helpers
-# ---------------------------------------------------------------------------
-bootstrap_app = typer.Typer(help="Bootstrap local tooling and environments.")
-
-
-def _run_command(state: CLIState, command: Iterable[str], *, require_confirm: bool = False) -> int:
-    command_list = list(command)
-    printable = " ".join(shlex.quote(arg) for arg in command_list)
-    if state.dry_run:
-        typer.echo(f"[dry-run] {printable}")
-        return 0
-    if require_confirm and not state.confirm:
-        typer.echo("Use --confirm to execute this command.", err=True)
-        return 1
-    return subprocess.call(command_list)
-
-
-@bootstrap_app.command("init")
-def bootstrap_init(ctx: typer.Context, quick: bool = typer.Option(False, "--quick", help="Skip optional setup.")) -> None:
-    """Initialise local tooling by delegating to ``install.sh``."""
-
+@app.command("init")
+def cli_init(ctx: typer.Context, quick: bool = typer.Option(False, "--quick", help="Skip optional setup.")) -> None:
     state = _get_state(ctx)
-    script = Path("scripts") / "install.sh"
-    command = ["bash", str(script)]
-    if quick:
-        command.append("--quick")
-    code = _run_command(state, command, require_confirm=True)
+    code = init_tooling(state, quick=quick)
     raise typer.Exit(code)
 
 
-@bootstrap_app.command("doctor")
-def bootstrap_doctor(ctx: typer.Context) -> None:
-    """Run repository health checks."""
-
+@app.command("doctor")
+def cli_doctor(ctx: typer.Context) -> None:
     state = _get_state(ctx)
-    script = Path("scripts") / "check-hooks.sh"
-    code = _run_command(state, ["bash", str(script)])
+    code = run_doctor(state)
     raise typer.Exit(code)
 
 
-@bootstrap_app.command("whoami")
-def bootstrap_whoami(ctx: typer.Context) -> None:
-    """Display the CLI execution context."""
-
+@app.command("whoami")
+def cli_whoami(ctx: typer.Context) -> None:
     state = _get_state(ctx)
     if state.dry_run:
         typer.echo("[dry-run] Displaying CLI state")
         raise typer.Exit(0)
-    typer.echo(json.dumps({
-        "confirm": state.confirm,
-        "telemetry": state.telemetry_enabled,
-        "log_path": str(state.log_path),
-    }, indent=2))
+    typer.echo(json.dumps(show_whoami(state), indent=2))
 
 
-app.add_typer(bootstrap_app, name="bootstrap")
-
-
-# ---------------------------------------------------------------------------
-# Stack orchestration (docker-compose)
-# ---------------------------------------------------------------------------
-stack_app = typer.Typer(help="Orchestrate local docker-compose services.")
-COMPOSE_FILE = Path("docker-compose.yml")
-
-
-def _compose_command(*args: str) -> Tuple[str, ...]:
-    return ("docker", "compose", "-f", str(COMPOSE_FILE), *args)
-
-
-@stack_app.command("up")
-def stack_up(ctx: typer.Context, service: Optional[str] = typer.Argument(None)) -> None:
-    """Start services defined in docker-compose."""
-
+@app.command("up")
+def cli_up(ctx: typer.Context, service: str | None = typer.Argument(None, help="Optional service name.")) -> None:
     state = _get_state(ctx)
-    command = list(_compose_command("up", "-d"))
-    if service:
-        command.append(service)
-    code = _run_command(state, command, require_confirm=True)
+    code = start_services(state, service)
     raise typer.Exit(code)
 
 
-@stack_app.command("down")
-def stack_down(ctx: typer.Context) -> None:
-    """Stop services defined in docker-compose."""
-
+@app.command("down")
+def cli_down(ctx: typer.Context) -> None:
     state = _get_state(ctx)
-    command = _compose_command("down")
-    code = _run_command(state, command, require_confirm=True)
+    code = stop_services(state)
     raise typer.Exit(code)
 
 
-@stack_app.command("logs")
-def stack_logs(ctx: typer.Context, service: str = typer.Argument(..., help="Service name.")) -> None:
-    """Stream logs for ``service`` via docker-compose."""
-
+@app.command("logs")
+def cli_logs(ctx: typer.Context, service: str = typer.Argument(..., help="Service name.")) -> None:
     state = _get_state(ctx)
-    command = list(_compose_command("logs", "-f", service))
-    if state.dry_run:
-        typer.echo(f"[dry-run] {' '.join(map(shlex.quote, command))}")
-        raise typer.Exit(0)
-    if not state.confirm:
-        typer.echo("Use --confirm to stream live logs.", err=True)
-        raise typer.Exit(1)
-    raise typer.Exit(subprocess.call(command))
+    code = stream_logs(state, service)
+    raise typer.Exit(code)
 
 
-app.add_typer(stack_app, name="stack")
-
-
-# ---------------------------------------------------------------------------
-# TaskCascadence
-# ---------------------------------------------------------------------------
 task_app = typer.Typer(help="Interact with TaskCascadence services.")
 
 
-def _render_response(result) -> None:
-    if result is None:
-        return
-    typer.echo(json.dumps(result.payload, indent=2))
-
-
 @task_app.command("run")
-def task_run(ctx: typer.Context, task: str = typer.Argument(..., help="Task identifier"), payload: Optional[str] = typer.Option(None, "--payload", help="JSON payload.")) -> None:
+def task_run(
+    ctx: typer.Context,
+    task: str = typer.Argument(..., help="Task identifier"),
+    payload: str | None = typer.Option(None, "--payload", help="JSON payload."),
+) -> None:
     state = _get_state(ctx)
-    client = TaskCascadenceClient()
     body = json.loads(payload) if payload else None
-    result = client.run(state, task, payload=body)
+    result = task_run_operation(state, task, payload=body)
     _render_response(result)
 
 
 @task_app.command("status")
 def task_status(ctx: typer.Context, task_id: str = typer.Argument(...)) -> None:
     state = _get_state(ctx)
-    client = TaskCascadenceClient()
-    result = client.status(state, task_id)
+    result = task_status_operation(state, task_id)
     _render_response(result)
 
 
 @task_app.command("signal")
-def task_signal(ctx: typer.Context, task_id: str = typer.Argument(...), signal: str = typer.Option(..., "--signal", help="Signal name.")) -> None:
+def task_signal(
+    ctx: typer.Context,
+    task_id: str = typer.Argument(...),
+    signal: str = typer.Option(..., "--signal", help="Signal name."),
+    link: str | None = typer.Option(None, "--link", help="Optional link payload."),
+    note: str | None = typer.Option(None, "--note", help="Optional note payload."),
+) -> None:
     state = _get_state(ctx)
     if not state.confirm:
         typer.echo("Use --confirm to send signals to remote tasks.", err=True)
         raise typer.Exit(1)
-    client = TaskCascadenceClient()
-    result = client.signal(state, task_id, signal=signal)
+    result = task_signal_operation(state, task_id, signal=signal, link=link, note=note)
     _render_response(result)
 
 
 app.add_typer(task_app, name="task")
 
 
-# ---------------------------------------------------------------------------
-# Research helpers
-# ---------------------------------------------------------------------------
 research_app = typer.Typer(help="Interact with tino-storm research services.")
 
 
 @research_app.command("ingest")
-def research_ingest(ctx: typer.Context, topic: str = typer.Argument(...), source: str = typer.Argument(...)) -> None:
+def research_ingest(
+    ctx: typer.Context,
+    topic: str = typer.Argument(..., help="Research topic."),
+    source: str = typer.Argument(..., help="Source URL or path."),
+) -> None:
     state = _get_state(ctx)
-    client = StormClient()
-    result = client.ingest(state, topic=topic, source=source)
+    result = research_ingest_operation(state, topic=topic, source=source)
     _render_response(result)
 
 
 @research_app.command("draft")
-def research_draft(ctx: typer.Context, topic: str = typer.Argument(...), hint: Optional[str] = typer.Option(None, "--hint", help="JSON object of hints.")) -> None:
+def research_draft(
+    ctx: typer.Context,
+    topic: str = typer.Argument(...),
+    hint: str | None = typer.Option(None, "--hint", help="JSON object of hints."),
+    doc: str | None = typer.Option(None, "--doc", help="Document identifier or path."),
+    anchor: str | None = typer.Option(None, "--anchor", help="Anchor identifier."),
+    prompt: str | None = typer.Option(None, "--prompt", help="Prompt override."),
+) -> None:
     state = _get_state(ctx)
     hints = json.loads(hint) if hint else None
-    client = StormClient()
-    result = client.draft(state, topic=topic, hints=hints or None)
+    result = research_draft_operation(state, topic=topic, hints=hints, doc=doc, anchor=anchor, prompt=prompt)
     _render_response(result)
 
 
 app.add_typer(research_app, name="research")
 
 
-# ---------------------------------------------------------------------------
-# UME memory helpers
-# ---------------------------------------------------------------------------
-ume_app = typer.Typer(help="Capture ideas and query UME memories.")
-
-
-@ume_app.command("idea")
+@app.command("idea")
 def ume_idea(ctx: typer.Context, text: str = typer.Argument(..., help="Idea text.")) -> None:
     state = _get_state(ctx)
-    client = UMEClient()
-    result = client.submit_idea(state, text=text)
+    result = idea_submit_operation(state, text=text)
     _render_response(result)
 
 
-@ume_app.command("mem")
-def ume_memory_query(ctx: typer.Context, query: str = typer.Argument(..., help="Query text."), filters: Optional[str] = typer.Option(None, "--filters", help="JSON filters.")) -> None:
+mem_app = typer.Typer(help="Query stored UME memories.")
+
+
+@mem_app.command("query")
+def ume_memory_query(
+    ctx: typer.Context,
+    query: str = typer.Argument(..., help="Query text."),
+    filters: str | None = typer.Option(None, "--filters", help="JSON filters."),
+) -> None:
     state = _get_state(ctx)
-    client = UMEClient()
     payload = json.loads(filters) if filters else None
-    result = client.query(state, query=query, filters=payload)
+    result = mem_query_operation(state, query=query, filters=payload)
     _render_response(result)
 
 
-app.add_typer(ume_app, name="ume")
+app.add_typer(mem_app, name="mem")
 
 
-# ---------------------------------------------------------------------------
-# Finance helpers
-# ---------------------------------------------------------------------------
 finance_app = typer.Typer(help="Finance reporting utilities.")
 
 
-@finance_app.command("report")
-def finance_report(ctx: typer.Context, period: str = typer.Option("monthly", "--period", help="Reporting period.")) -> None:
+@finance_app.command("snapshot")
+def finance_snapshot(
+    ctx: typer.Context,
+    period: str = typer.Option("monthly", "--period", help="Reporting period."),
+) -> None:
     state = _get_state(ctx)
-    client = FinanceClient()
-    result = client.summarize(state, period=period)
+    result = finance_snapshot_operation(state, period=period)
     _render_response(result)
 
 
@@ -276,35 +404,29 @@ def finance_sync(ctx: typer.Context, provider: str = typer.Argument(...)) -> Non
     if not state.confirm:
         typer.echo("Use --confirm to trigger finance synchronisation.", err=True)
         raise typer.Exit(1)
-    client = FinanceClient()
-    result = client.sync(state, provider=provider)
+    result = finance_sync_operation(state, provider=provider)
     _render_response(result)
 
 
 app.add_typer(finance_app, name="finance")
 
 
-# ---------------------------------------------------------------------------
-# Wishlist helpers
-# ---------------------------------------------------------------------------
 wishlist_app = typer.Typer(help="Track wishlist items for the platform.")
-WISHLIST_PATH = Path("metadata") / "wishlist.json"
 
 
 @wishlist_app.command("add")
-def wishlist_add(ctx: typer.Context, item: str = typer.Argument(...), link: Optional[str] = typer.Option(None, "--link", help="Optional URL.")) -> None:
+def wishlist_add(
+    ctx: typer.Context,
+    url: str = typer.Argument(..., help="Item URL."),
+    tags: str | None = typer.Option(None, "--tags", help="Comma separated tags."),
+) -> None:
     state = _get_state(ctx)
+    parsed_tags = [tag.strip() for tag in (tags.split(",") if tags else []) if tag.strip()]
+    result = wishlist_add_operation(state, url=url, tags=parsed_tags)
     if state.dry_run:
-        typer.echo(f"[dry-run] add wishlist item: {item}")
-        raise typer.Exit(0)
-    if not WISHLIST_PATH.exists():
-        data = []
-    else:
-        data = json.loads(WISHLIST_PATH.read_text(encoding="utf-8"))
-    data.append({"item": item, "link": link})
-    WISHLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
-    WISHLIST_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    typer.echo(f"Added wishlist item '{item}'.")
+        typer.echo(f"[dry-run] add wishlist item: {json.dumps(result['entry'])}")
+        return
+    typer.echo(f"Added wishlist item '{url}'.")
 
 
 @wishlist_app.command("list")
@@ -319,33 +441,81 @@ def wishlist_list(ctx: typer.Context) -> None:
 app.add_typer(wishlist_app, name="wishlist")
 
 
-# ---------------------------------------------------------------------------
-# Documentation publishing
-# ---------------------------------------------------------------------------
 docs_app = typer.Typer(help="Publish documentation updates.")
 
 
 @docs_app.command("publish")
-def docs_publish(ctx: typer.Context, site: str = typer.Argument(...), version: Optional[str] = typer.Option(None, "--version", help="Version label.")) -> None:
+def docs_publish(
+    ctx: typer.Context,
+    target: str = typer.Argument(..., help="Document path or identifier."),
+    site: str | None = typer.Option(None, "--site", help="Documentation site."),
+    version: str | None = typer.Option(None, "--version", help="Version label."),
+) -> None:
     state = _get_state(ctx)
-    client = DocsClient()
-    result = client.publish(state, site=site, version=version)
+    result = docs_publish_operation(state, target=target, site=site, version=version)
     _render_response(result)
 
 
 app.add_typer(docs_app, name="docs")
 
 
-# ---------------------------------------------------------------------------
-# Legacy compatibility
-# ---------------------------------------------------------------------------
+# Compatibility shims -------------------------------------------------------
+
+bootstrap_app = typer.Typer(help="Bootstrap local tooling and environments.", hidden=True)
+
+
+@bootstrap_app.command("init")
+def bootstrap_init(ctx: typer.Context, quick: bool = typer.Option(False, "--quick")) -> None:
+    state = _get_state(ctx)
+    code = init_tooling(state, quick=quick)
+    raise typer.Exit(code)
+
+
+@bootstrap_app.command("doctor")
+def bootstrap_doctor(ctx: typer.Context) -> None:
+    state = _get_state(ctx)
+    code = run_doctor(state)
+    raise typer.Exit(code)
+
+
+@bootstrap_app.command("whoami")
+def bootstrap_whoami(ctx: typer.Context) -> None:
+    cli_whoami(ctx)
+
+
+app.add_typer(bootstrap_app, name="bootstrap")
+
+
+stack_app = typer.Typer(help="Legacy stack orchestration commands.", hidden=True)
+
+
+@stack_app.command("up")
+def stack_up(ctx: typer.Context, service: str | None = typer.Argument(None)) -> None:
+    cli_up(ctx, service)
+
+
+@stack_app.command("down")
+def stack_down(ctx: typer.Context) -> None:
+    cli_down(ctx)
+
+
+@stack_app.command("logs")
+def stack_logs(ctx: typer.Context, service: str = typer.Argument(...)) -> None:
+    cli_logs(ctx, service)
+
+
+app.add_typer(stack_app, name="stack")
+
+
+# Legacy compatibility ------------------------------------------------------
+
 legacy_app = typer.Typer(help="Compatibility shims for legacy CLIs.")
 
 
 @legacy_app.command("ai")
 def legacy_ai(
     ctx: typer.Context,
-    args: Optional[List[str]] = typer.Argument(None, help="Arguments forwarded to scripts.ai_cli.", show_default=False),
+    args: list[str] | None = typer.Argument(None, help="Arguments forwarded to scripts.ai_cli.", show_default=False),
 ) -> None:
     state = _get_state(ctx)
     if state.dry_run:
@@ -361,9 +531,8 @@ def legacy_ai(
 app.add_typer(legacy_app, name="legacy")
 
 
-# ---------------------------------------------------------------------------
-# Plugin commands
-# ---------------------------------------------------------------------------
+# Plug-in commands ----------------------------------------------------------
+
 plugins_app = typer.Typer(help="Commands exposed by installed plug-ins.")
 register_plugin_commands(plugins_app)
 app.add_typer(plugins_app, name="plugins")

--- a/tests/test_tino_cli_services.py
+++ b/tests/test_tino_cli_services.py
@@ -28,7 +28,10 @@ def _enable_telemetry(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict, 
         recorded.append((name, payload, enabled))
         return True
 
-    monkeypatch.setattr("scripts.tino_cli.main.analytics_default", lambda: True)
+    import importlib
+
+    module = importlib.import_module("scripts.tino_cli.main")
+    monkeypatch.setattr(module, "analytics_default", lambda: True)
     monkeypatch.setattr("scripts.tino_cli.clients.base.record_event", _capture)
     return recorded
 
@@ -112,14 +115,29 @@ def test_task_signal_with_confirmation_hits_api(
 
     result = tino_cli_runner.invoke(
         app,
-        ["--confirm", "task", "signal", "abc123", "--signal", "cancel"],
+        [
+            "--confirm",
+            "task",
+            "signal",
+            "abc123",
+            "--signal",
+            "cancel",
+            "--link",
+            "https://example.com",
+            "--note",
+            "Investigate",
+        ],
     )
 
     assert result.exit_code == 0
     assert json.loads(result.output) == {"ok": True}
     call = fake_http_service["calls"][0]
     assert call["url"].endswith("/tasks/abc123/signal")
-    assert call["json_payload"] == {"signal": "cancel"}
+    assert call["json_payload"] == {
+        "signal": "cancel",
+        "link": "https://example.com",
+        "note": "Investigate",
+    }
     assert any(evt[0].endswith("signal") for evt in recorded)
 
 
@@ -131,26 +149,34 @@ def test_docs_publish_uses_configured_endpoint(
     recorded = _enable_telemetry(monkeypatch)
     fake_http_service["stub"]("post", "/docs/publish", {"site": "handbook"})
 
-    result = tino_cli_runner.invoke(app, ["docs", "publish", "handbook", "--version", "v1"])
+    result = tino_cli_runner.invoke(
+        app,
+        ["docs", "publish", "handbook", "--site", "handbook", "--version", "v1"],
+    )
 
     assert result.exit_code == 0
     assert json.loads(result.output) == {"site": "handbook"}
     call = fake_http_service["calls"][0]
-    assert call["json_payload"] == {"site": "handbook", "version": "v1"}
+    assert call["json_payload"] == {
+        "target": "handbook",
+        "doc_id": "handbook",
+        "site": "handbook",
+        "version": "v1",
+    }
     assert recorded
     assert recorded[0][1]["status"] == 200
 
 
-def test_stack_logs_requires_confirmation(
+def test_logs_requires_confirmation(
     tino_cli_runner: "CliRunner",
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    result = tino_cli_runner.invoke(app, ["stack", "logs", "ume"])
+    result = tino_cli_runner.invoke(app, ["logs", "ume"])
     assert result.exit_code == 1
     assert "Use --confirm" in result.output
 
 
-def test_stack_logs_dry_run_skips_subprocess(
+def test_logs_dry_run_skips_subprocess(
     tino_cli_runner: "CliRunner",
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -161,13 +187,13 @@ def test_stack_logs_dry_run_skips_subprocess(
         return 0
 
     monkeypatch.setattr("subprocess.call", _fake_call)
-    result = tino_cli_runner.invoke(app, ["--dry-run", "stack", "logs", "ume"])
+    result = tino_cli_runner.invoke(app, ["--dry-run", "logs", "ume"])
     assert result.exit_code == 0
     assert "[dry-run]" in result.output
     assert called == []
 
 
-def test_stack_logs_confirm_invokes_subprocess(
+def test_logs_confirm_invokes_subprocess(
     tino_cli_runner: "CliRunner",
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -179,7 +205,7 @@ def test_stack_logs_confirm_invokes_subprocess(
 
     monkeypatch.setattr("subprocess.call", _fake_call)
 
-    result = tino_cli_runner.invoke(app, ["--confirm", "stack", "logs", "ume"])
+    result = tino_cli_runner.invoke(app, ["--confirm", "logs", "ume"])
 
     assert result.exit_code == 0
     assert captured


### PR DESCRIPTION
## Summary
- expose canonical tino CLI commands at the top level with shared state helpers and richer options
- update cockpit action handlers to invoke real orchestration logic while preserving audit logging
- extend service clients and tests to support additional task, research, wishlist, and docs payloads

## Testing
- pytest tests/test_tino_cli_services.py

------
https://chatgpt.com/codex/tasks/task_e_68de9174d4348326ab63e72373df5df1