### PR TITLE
Add registry-driven plugin command execution

### DIFF
--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 import requests
 
@@ -39,6 +39,32 @@ class PluginCommand:
     exec: str
     tags: tuple[str, ...] = ()
     examples: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PluginCLICommandDescriptor:
+    """Command descriptor declared within a plug-in's ``cli`` section."""
+
+    name: str
+    help: str
+    exec: str | None = None
+    callable: str | None = None
+    tags: tuple[str, ...] = ()
+    examples: tuple[str, ...] = ()
+
+    def has_exec(self) -> bool:
+        return isinstance(self.exec, str) and bool(self.exec)
+
+    def has_callable(self) -> bool:
+        return isinstance(self.callable, str) and bool(self.callable)
+
+
+@dataclass(frozen=True)
+class PluginCLIMetadata:
+    """CLI metadata exposed by a plug-in entry."""
+
+    help: str | None
+    commands: tuple[PluginCLICommandDescriptor, ...]
 
 
 @dataclass(frozen=True)
@@ -71,6 +97,7 @@ class PluginPackage:
     name: str
     package: str
     raw: Mapping[str, Any] = field(default_factory=dict)
+    cli: PluginCLIMetadata | None = None
 
     @property
     def mcp(self) -> Mapping[str, Any] | None:
@@ -163,9 +190,35 @@ def _validate_registry(data: Mapping[str, Any]) -> None:
         _REGISTRY_VALIDATOR.validate(data)
         return
     required = ("name", "version", "commands", "taskTemplates")
-    for field in required:
-        if field not in data:
-            raise ValueError(f"registry missing required field: {field}")
+    for key in required:
+        if key not in data:
+            raise ValueError(f"registry missing required field: {key}")
+
+
+def validate_registry_payload(data: Mapping[str, Any]) -> None:
+    """Public wrapper for schema validation used by CLI loaders and tests."""
+
+    _validate_registry(data)
+
+
+def _valid_registry(data: Mapping[str, Any]) -> bool:
+    """Return ``True`` when ``data`` passes lightweight structural validation."""
+
+    try:
+        validate_registry_payload(data)
+    except Exception:
+        return False
+    plugins_section = data.get("plugins")
+    if isinstance(plugins_section, Mapping):
+        for value in plugins_section.values():
+            if not isinstance(value, Mapping):
+                continue
+            mcp_meta = value.get("mcp")
+            if isinstance(mcp_meta, Mapping):
+                descriptor = mcp_meta.get("descriptor")
+                if descriptor is not None and not isinstance(descriptor, Mapping):
+                    return False
+    return True
 
 
 def _merge_sequence(
@@ -271,6 +324,47 @@ def _parse_commands(data: Iterable[Mapping[str, Any]]) -> tuple[PluginCommand, .
     return tuple(commands)
 
 
+def _parse_plugin_cli_commands(data: Iterable[Mapping[str, Any]]) -> tuple[PluginCLICommandDescriptor, ...]:
+    commands: list[PluginCLICommandDescriptor] = []
+    for entry in data:
+        name = entry.get("name")
+        help_text = entry.get("help")
+        exec_cmd = entry.get("exec")
+        callable_name = entry.get("callable")
+        if not (isinstance(name, str) and name and isinstance(help_text, str) and help_text):
+            continue
+        exec_value = exec_cmd if isinstance(exec_cmd, str) and exec_cmd else None
+        callable_value = callable_name if isinstance(callable_name, str) and callable_name else None
+        if exec_value is None and callable_value is None:
+            continue
+        tags = tuple(tag for tag in entry.get("tags", []) if isinstance(tag, str))
+        examples = tuple(
+            example for example in entry.get("examples", []) if isinstance(example, str)
+        )
+        commands.append(
+            PluginCLICommandDescriptor(
+                name=name,
+                help=help_text,
+                exec=exec_value,
+                callable=callable_value,
+                tags=tags,
+                examples=examples,
+            )
+        )
+    return tuple(commands)
+
+
+def _parse_plugin_cli(data: Mapping[str, Any]) -> PluginCLIMetadata | None:
+    if not data:
+        return None
+    help_text = data.get("help") if isinstance(data.get("help"), str) else None
+    commands_raw = data.get("commands") if isinstance(data.get("commands"), list) else []
+    commands = _parse_plugin_cli_commands(commands_raw)
+    if not help_text and not commands:
+        return None
+    return PluginCLIMetadata(help=help_text, commands=commands)
+
+
 def _parse_variables(data: Iterable[Mapping[str, Any]]) -> tuple[TaskTemplateVariable, ...]:
     variables: list[TaskTemplateVariable] = []
     for entry in data:
@@ -326,7 +420,17 @@ def _parse_plugins(data: Mapping[str, Any]) -> Dict[str, PluginPackage]:
         elif isinstance(value, Mapping):
             package_name = value.get("package")
             if isinstance(package_name, str):
-                parsed[name] = PluginPackage(name=name, package=package_name, raw=deepcopy(dict(value)))
+                cli_meta = (
+                    _parse_plugin_cli(value.get("cli"))
+                    if isinstance(value.get("cli"), Mapping)
+                    else None
+                )
+                parsed[name] = PluginPackage(
+                    name=name,
+                    package=package_name,
+                    raw=deepcopy(dict(value)),
+                    cli=cli_meta,
+                )
     return parsed
 
 
@@ -362,6 +466,13 @@ def _parse_registry(data: Mapping[str, Any]) -> PluginRegistryData:
     )
 
 
+def parse_registry_payload(data: Mapping[str, Any]) -> PluginRegistryData:
+    """Parse a registry payload after validating it against the schema."""
+
+    validate_registry_payload(data)
+    return _parse_registry(data)
+
+
 def load_registry(update: bool = False, ttl: int = DEFAULT_CACHE_TTL) -> PluginRegistryData:
     """Return the parsed plug-in registry data."""
 
@@ -385,13 +496,11 @@ def load_registry(update: bool = False, ttl: int = DEFAULT_CACHE_TTL) -> PluginR
 
     if registry_payload is None:
         registry_payload = base_data
-    else:
-        try:
-            _validate_registry(registry_payload)
-        except Exception:
-            registry_payload = base_data
 
-    return _parse_registry(registry_payload)
+    try:
+        return parse_registry_payload(registry_payload)
+    except Exception:
+        return parse_registry_payload(base_data)
 
 
 def _is_installed(package: str) -> bool:

--- a/scripts/tino_cli/executor.py
+++ b/scripts/tino_cli/executor.py
@@ -1,0 +1,38 @@
+"""Shared command execution helpers for :mod:`scripts.tino_cli`."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+import shlex
+import subprocess
+
+import typer
+
+from .state import CLIState
+
+
+def _normalise_command(command: Iterable[str] | str) -> list[str]:
+    if isinstance(command, str):
+        return shlex.split(command)
+    return list(command)
+
+
+def execute_command(
+    command: Iterable[str] | str,
+    *,
+    state: CLIState | None = None,
+    require_confirm: bool = False,
+) -> int:
+    """Execute ``command`` honouring the active CLI ``state`` semantics."""
+
+    command_list = _normalise_command(command)
+    printable = " ".join(shlex.quote(arg) for arg in command_list)
+    if state is not None and state.dry_run:
+        typer.echo(f"[dry-run] {printable}")
+        return 0
+    if require_confirm and (state is None or not state.confirm):
+        typer.echo("Use --confirm to execute this command.", err=True)
+        return 1
+    return subprocess.call(command_list)
+
+
+__all__ = ["execute_command"]

--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -6,7 +6,7 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import typer
 
@@ -14,6 +14,7 @@ from telemetry import analytics_default
 
 from .clients import DocsClient, FinanceClient, StormClient, TaskCascadenceClient, UMEClient
 from .config import load_env_defaults
+from .executor import execute_command
 from .plugin_loader import register_plugin_commands
 from .state import CLIState
 
@@ -57,18 +58,6 @@ def main(
 bootstrap_app = typer.Typer(help="Bootstrap local tooling and environments.")
 
 
-def _run_command(state: CLIState, command: Iterable[str], *, require_confirm: bool = False) -> int:
-    command_list = list(command)
-    printable = " ".join(shlex.quote(arg) for arg in command_list)
-    if state.dry_run:
-        typer.echo(f"[dry-run] {printable}")
-        return 0
-    if require_confirm and not state.confirm:
-        typer.echo("Use --confirm to execute this command.", err=True)
-        return 1
-    return subprocess.call(command_list)
-
-
 @bootstrap_app.command("init")
 def bootstrap_init(ctx: typer.Context, quick: bool = typer.Option(False, "--quick", help="Skip optional setup.")) -> None:
     """Initialise local tooling by delegating to ``install.sh``."""
@@ -78,7 +67,7 @@ def bootstrap_init(ctx: typer.Context, quick: bool = typer.Option(False, "--quic
     command = ["bash", str(script)]
     if quick:
         command.append("--quick")
-    code = _run_command(state, command, require_confirm=True)
+    code = execute_command(command, state=state, require_confirm=True)
     raise typer.Exit(code)
 
 
@@ -88,7 +77,7 @@ def bootstrap_doctor(ctx: typer.Context) -> None:
 
     state = _get_state(ctx)
     script = Path("scripts") / "check-hooks.sh"
-    code = _run_command(state, ["bash", str(script)])
+    code = execute_command(["bash", str(script)], state=state)
     raise typer.Exit(code)
 
 
@@ -129,7 +118,7 @@ def stack_up(ctx: typer.Context, service: Optional[str] = typer.Argument(None)) 
     command = list(_compose_command("up", "-d"))
     if service:
         command.append(service)
-    code = _run_command(state, command, require_confirm=True)
+    code = execute_command(command, state=state, require_confirm=True)
     raise typer.Exit(code)
 
 
@@ -139,7 +128,7 @@ def stack_down(ctx: typer.Context) -> None:
 
     state = _get_state(ctx)
     command = _compose_command("down")
-    code = _run_command(state, command, require_confirm=True)
+    code = execute_command(command, state=state, require_confirm=True)
     raise typer.Exit(code)
 
 

--- a/scripts/tino_cli/plugin_loader.py
+++ b/scripts/tino_cli/plugin_loader.py
@@ -3,14 +3,21 @@ from __future__ import annotations
 
 import importlib
 import json
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterator, List, Optional
 
 import typer
 
+from scripts import plugins
+
+from .executor import execute_command
+from .state import CLIState
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REGISTRY_PATH = REPO_ROOT / "plugin-registry.json"
+
 
 @dataclass(slots=True)
 class PluginCommand:
@@ -19,16 +26,24 @@ class PluginCommand:
     plugin: str
     name: str
     help: str
-    handler: Callable[[tuple[str, ...]], int]
+    tags: tuple[str, ...] = ()
+    examples: tuple[str, ...] = ()
+    exec: str | None = None
+    callable: str | None = None
+    package: str | None = None
 
 
-def _load_registry(path: Path = REGISTRY_PATH) -> dict[str, object]:
+def _load_registry(path: Path = REGISTRY_PATH) -> plugins.PluginRegistryData | None:
     if not path.exists():
-        return {}
+        return None
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {}
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    try:
+        return plugins.parse_registry_payload(payload)
+    except Exception:
+        return None
 
 
 def _import_callable(qualname: str) -> Callable[[tuple[str, ...]], int] | None:
@@ -45,88 +60,187 @@ def _import_callable(qualname: str) -> Callable[[tuple[str, ...]], int] | None:
     return None
 
 
-def iter_plugin_commands() -> Iterator[PluginCommand]:
-    """Yield :class:`PluginCommand` objects from ``plugin-registry.json``."""
-
-    registry = _load_registry()
-    plugins = registry.get("plugins")
-    if not isinstance(plugins, dict):
-        return
-    for name, raw_meta in plugins.items():
-        if isinstance(raw_meta, str):
-            help_text = f"Commands for the {name} plug-in (install {raw_meta})."
-            handler = _fallback_handler(name, raw_meta)
-            yield PluginCommand(name=name, help=help_text, plugin=name, handler=handler)
-            continue
-        if not isinstance(raw_meta, dict):
-            continue
-        cli_meta = raw_meta.get("cli", {})
-        help_text = cli_meta.get("help") if isinstance(cli_meta, dict) else None
-        if not help_text:
-            package = raw_meta.get("package", "unknown package")
-            help_text = f"Commands for the {name} plug-in (install {package})."
-        commands = []
-        if isinstance(cli_meta, dict):
-            commands = cli_meta.get("commands", [])
-        if not commands:
-            handler = _fallback_handler(name, raw_meta.get("package", "<unknown>"))
-            yield PluginCommand(name=name, help=help_text, plugin=name, handler=handler)
-            continue
-        for command_meta in commands:
-            if not isinstance(command_meta, dict):
-                continue
-            cmd_name = command_meta.get("name") or name
-            cmd_help = command_meta.get("help") or help_text
-            qualname = command_meta.get("callable")
-            handler = _import_callable(qualname) if isinstance(qualname, str) else None
-            if handler is None:
-                package = raw_meta.get("package", "<unknown>")
-                handler = _fallback_handler(name, package)
-            yield PluginCommand(plugin=name, name=cmd_name, help=cmd_help, handler=handler)
-    return
+def _normalise_args(args: Optional[List[str]], *, command_name: str | None = None) -> List[str]:
+    values = list(args or [])
+    if command_name and values and values[0] == command_name:
+        values = values[1:]
+    if values and values[0] == "--":
+        values = values[1:]
+    return values
 
 
-def _fallback_handler(plugin: str, package: str) -> Callable[[tuple[str, ...]], int]:
-    def _handler(args: tuple[str, ...]) -> int:  # noqa: ARG001 - forwarded command
-        typer.echo(
-            f"The '{plugin}' plug-in is not installed. Install '{package}' to use this command.",
-            err=True,
-        )
-        return 1
-
-    return _handler
+def _resolve_state(ctx: typer.Context) -> CLIState | None:
+    state = getattr(ctx, "obj", None)
+    if isinstance(state, CLIState):
+        return state
+    return None
 
 
-def register_plugin_commands(app: typer.Typer) -> None:
-    """Attach plug-in commands to ``app`` under their plug-in names."""
-
-    grouped: dict[str, list[PluginCommand]] = {}
-    for command in iter_plugin_commands():
-        grouped.setdefault(command.plugin, []).append(command)
-    for plugin, commands in sorted(grouped.items()):
-        help_text = commands[0].help if commands else f"Commands for plug-in {plugin}."
-        plugin_app = typer.Typer(help=help_text)
-
-        for command in commands:
-            plugin_app.command(command.name, help=command.help)(_wrap_handler(command.handler))
-
-        app.add_typer(plugin_app, name=plugin)
+def _format_help(help_text: str, tags: tuple[str, ...], examples: tuple[str, ...]) -> str:
+    sections: list[str] = []
+    if tags:
+        sections.append("Tags: " + ", ".join(tags))
+    if examples:
+        formatted = "\n".join(f"  {example}" for example in examples)
+        sections.append(f"Examples:\n{formatted}")
+    if sections:
+        return f"{help_text}\n\n" + "\n\n".join(sections)
+    return help_text
 
 
-def _wrap_handler(handler: Callable[[tuple[str, ...]], int]) -> Callable[[List[str]], None]:
+def _fallback_message(plugin: str, package: str | None) -> str:
+    package_hint = package or "the corresponding package"
+    return f"The '{plugin}' plug-in is not installed. Install '{package_hint}' to use this command."
+
+
+def _wrap_callable(
+    handler: Callable[[tuple[str, ...]], int], *, command_name: str | None = None
+) -> Callable[[typer.Context, Optional[List[str]]], None]:
     def _command(
+        ctx: typer.Context,
         args: Optional[List[str]] = typer.Argument(
             None,
             metavar="ARGS...",
             help="Arguments forwarded to the plug-in handler.",
             show_default=False,
-        )
+        ),
     ) -> None:
-        forwarded = tuple(args or [])
+        forwarded = tuple(_normalise_args(args, command_name=command_name))
         code = handler(forwarded)
         raise typer.Exit(code)
 
     return _command
+
+
+def _wrap_exec(
+    exec_command: str,
+    *,
+    require_confirm: bool = False,
+    command_name: str | None = None,
+) -> Callable[[typer.Context, Optional[List[str]]], None]:
+    def _command(
+        ctx: typer.Context,
+        args: Optional[List[str]] = typer.Argument(
+            None,
+            metavar="ARGS...",
+            help="Arguments forwarded to the plug-in command.",
+            show_default=False,
+        ),
+    ) -> None:
+        forwarded = _normalise_args(args, command_name=command_name)
+        command = shlex.split(exec_command)
+        command.extend(forwarded)
+        state = _resolve_state(ctx)
+        code = execute_command(command, state=state, require_confirm=require_confirm)
+        raise typer.Exit(code)
+
+    return _command
+
+
+def _wrap_fallback(
+    plugin: str,
+    package: str | None,
+    *,
+    command_name: str | None = None,
+) -> Callable[[typer.Context, Optional[List[str]]], None]:
+    message = _fallback_message(plugin, package)
+
+    def _command(
+        ctx: typer.Context,
+        args: Optional[List[str]] = typer.Argument(
+            None,
+            metavar="ARGS...",
+            help="Arguments forwarded to the plug-in handler.",
+            show_default=False,
+        ),
+    ) -> None:  # noqa: ARG001 - forwarded command
+        _normalise_args(args, command_name=command_name)
+        typer.echo(message, err=True)
+        raise typer.Exit(1)
+
+    return _command
+
+
+def _plugin_help(plugin: str, package: plugins.PluginPackage) -> str:
+    cli_meta = package.cli
+    if cli_meta and cli_meta.help:
+        return cli_meta.help
+    return f"Commands for the {plugin} plug-in (install {package.package})."
+
+
+def iter_plugin_commands() -> Iterator[PluginCommand]:
+    """Yield :class:`PluginCommand` objects from ``plugin-registry.json``."""
+
+    registry = _load_registry()
+    if registry is None:
+        return
+    for name, package in registry.plugin_packages.items():
+        cli_meta = package.cli
+        if cli_meta is None or not cli_meta.commands:
+            yield PluginCommand(
+                plugin=name,
+                name="install",
+                help=_plugin_help(name, package),
+                package=package.package,
+            )
+            continue
+        for descriptor in cli_meta.commands:
+            yield PluginCommand(
+                plugin=name,
+                name=descriptor.name,
+                help=descriptor.help,
+                tags=descriptor.tags,
+                examples=descriptor.examples,
+                exec=descriptor.exec,
+                callable=descriptor.callable,
+                package=package.package,
+            )
+
+
+def _register_registry_commands(app: typer.Typer, registry: plugins.PluginRegistryData) -> None:
+    for descriptor in registry.commands:
+        help_text = _format_help(descriptor.help, descriptor.tags, descriptor.examples)
+        app.command(descriptor.name, help=help_text)(
+            _wrap_exec(descriptor.exec, command_name=descriptor.name)
+        )
+
+
+def register_plugin_commands(app: typer.Typer) -> None:
+    """Attach plug-in commands to ``app`` under their plug-in names."""
+
+    registry = _load_registry()
+    if registry is None:
+        return
+
+    _register_registry_commands(app, registry)
+
+    for plugin, package in sorted(registry.plugin_packages.items()):
+        plugin_app = typer.Typer(help=_plugin_help(plugin, package))
+        cli_meta = package.cli
+        commands = list(cli_meta.commands) if cli_meta else []
+        if not commands:
+            plugin_app.command("install", help=_fallback_message(plugin, package.package))(
+                _wrap_fallback(plugin, package.package, command_name="install")
+            )
+            app.add_typer(plugin_app, name=plugin)
+            continue
+        for descriptor in commands:
+            help_text = _format_help(descriptor.help, descriptor.tags, descriptor.examples)
+            if descriptor.exec:
+                plugin_app.command(descriptor.name, help=help_text)(
+                    _wrap_exec(descriptor.exec, command_name=descriptor.name)
+                )
+                continue
+            handler = _import_callable(descriptor.callable) if descriptor.callable else None
+            if handler is None:
+                plugin_app.command(descriptor.name, help=help_text)(
+                    _wrap_fallback(plugin, package.package, command_name=descriptor.name)
+                )
+                continue
+            plugin_app.command(descriptor.name, help=help_text)(
+                _wrap_callable(handler, command_name=descriptor.name)
+            )
+        app.add_typer(plugin_app, name=plugin)
 
 
 __all__ = ["register_plugin_commands", "iter_plugin_commands", "PluginCommand"]

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,5 +1,4 @@
 import json
-import importlib
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -16,6 +15,20 @@ if TYPE_CHECKING:
 
 
 pytest.importorskip("requests")
+
+
+def _registry_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "name": "test-registry",
+        "version": "1",
+        "commands": [],
+        "taskTemplates": [],
+        "plugins": {},
+        "recipes": {},
+        "recipe_configs": {},
+    }
+    payload.update(overrides)
+    return payload
 
 
 def test_load_registry_returns_commands_and_templates() -> None:
@@ -112,7 +125,7 @@ def test_load_registry_invalid_cache_falls_back(monkeypatch, tmp_path: Path) -> 
         "lmql": "d0ttino-lmql-plugin",
     }
     for name, pkg in expected.items():
-        assert registry[name] == pkg
+        assert registry.plugin_package_map[name] == pkg
 
 
 def test_valid_registry_rejects_bad_descriptor():
@@ -133,8 +146,8 @@ def test_register_plugin_commands_executes_handler(
     monkeypatch: pytest.MonkeyPatch,
 ):
     registry_path = tmp_path / "registry.json"
-    registry = {
-        "plugins": {
+    registry = _registry_payload(
+        plugins={
             "demo": {
                 "package": "demo-pkg",
                 "cli": {
@@ -149,14 +162,11 @@ def test_register_plugin_commands_executes_handler(
                 },
             }
         }
-    }
+    )
     registry_path.write_text(json.dumps(registry), encoding="utf-8")
     monkeypatch.setattr(plugin_loader, "REGISTRY_PATH", registry_path)
-    monkeypatch.setattr(
-        plugin_loader,
-        "_load_registry",
-        lambda path=registry_path: json.loads(registry_path.read_text(encoding="utf-8")),
-    )
+    registry_data = plugins.parse_registry_payload(registry)
+    monkeypatch.setattr(plugin_loader, "_load_registry", lambda path=registry_path: registry_data)
     # Ensure stale call history from other tests does not leak in.
     stubs.plugin_command.calls = []  # type: ignore[attr-defined]
 
@@ -174,8 +184,8 @@ def test_register_plugin_command_falls_back_on_missing_callable(
     monkeypatch: pytest.MonkeyPatch,
 ):
     registry_path = tmp_path / "registry.json"
-    registry = {
-        "plugins": {
+    registry = _registry_payload(
+        plugins={
             "demo": {
                 "package": "demo-pkg",
                 "cli": {
@@ -185,14 +195,11 @@ def test_register_plugin_command_falls_back_on_missing_callable(
                 },
             }
         }
-    }
+    )
     registry_path.write_text(json.dumps(registry), encoding="utf-8")
     monkeypatch.setattr(plugin_loader, "REGISTRY_PATH", registry_path)
-    monkeypatch.setattr(
-        plugin_loader,
-        "_load_registry",
-        lambda path=registry_path: json.loads(registry_path.read_text(encoding="utf-8")),
-    )
+    registry_data = plugins.parse_registry_payload(registry)
+    monkeypatch.setattr(plugin_loader, "_load_registry", lambda path=registry_path: registry_data)
 
     app = typer.Typer()
     plugin_loader.register_plugin_commands(app)
@@ -200,4 +207,43 @@ def test_register_plugin_command_falls_back_on_missing_callable(
     result = tino_cli_runner.invoke(app, ["demo", "hello"])
     assert result.exit_code == 1
     assert "demo-pkg" in result.stderr or "demo-pkg" in result.output
+
+
+def test_plugins_cli_runs_exec_command(
+    tino_cli_runner: "CliRunner",
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _registry_payload(
+        commands=[
+            {
+                "name": "demo:exec",
+                "help": "Demo exec",
+                "exec": "echo demo",
+                "tags": ["demo"],
+                "examples": ["tino plugins demo:exec -- --flag value"],
+            }
+        ],
+        plugins={},
+    )
+    registry_data = plugins.parse_registry_payload(registry)
+    monkeypatch.setattr(plugin_loader, "_load_registry", lambda *_: registry_data)
+
+    calls: dict[str, object] = {}
+
+    def fake_execute(command, *, state=None, require_confirm=False):
+        calls["command"] = list(command)
+        calls["state"] = state
+        calls["confirm"] = require_confirm
+        return 0
+
+    monkeypatch.setattr(plugin_loader, "execute_command", fake_execute)
+
+    app = typer.Typer()
+    plugin_loader.register_plugin_commands(app)
+
+    result = tino_cli_runner.invoke(app, ["demo:exec", "--", "--flag", "value"])
+    assert result.exit_code == 0
+    assert calls["command"] == ["echo", "demo", "--flag", "value"]
+    assert calls["state"] is None
+    assert calls["confirm"] is False
 


### PR DESCRIPTION
## Summary
- expose shared registry parsing and CLI metadata dataclasses for plug-in consumers
- register registry-level exec commands and plug-in callables through the new executor helper
- extend plug-in registry tests to cover command execution, fallbacks, and schema validation

## Testing
- pytest tests/test_plugin_registry.py
- ruff check scripts/plugins.py scripts/tino_cli/plugin_loader.py tests/test_plugin_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68de956b7e60832694eb1cf2cb5a8395