### PR TITLE
Support optional topics in cockpit research ingest

### DIFF
--- a/scripts/tino_cli/actions.py
+++ b/scripts/tino_cli/actions.py
@@ -164,13 +164,15 @@ def _error_action(log_path: os.PathLike[str], command: str, message: str) -> tup
     return 1, commands, {"error": message}
 
 
-def _research_action_payload(raw: str) -> tuple[str, str]:
+def _research_action_payload(raw: str) -> tuple[str, str | None]:
+    topic: str | None = None
+    source = raw.strip()
     if "::" in raw:
-        topic, source = raw.split("::", 1)
-        topic = topic.strip() or "adhoc"
-        source = source.strip()
-        return topic, source
-    return "adhoc", raw.strip()
+        topic_part, source_part = raw.split("::", 1)
+        source = source_part.strip()
+        parsed_topic = topic_part.strip()
+        topic = parsed_topic or None
+    return source, topic
 
 
 def _run_special_action(
@@ -195,8 +197,10 @@ def _run_special_action(
     if name == "cockpit-research-ingest":
         if not payload:
             return _error_action(log_path, "research ingest <missing>", "Source path or URL required.")
-        topic, source = _research_action_payload(payload)
-        command = f"research ingest {shlex.quote(topic)} {shlex.quote(source)}"
+        source, topic = _research_action_payload(payload)
+        command = f"research ingest {shlex.quote(source)}"
+        if topic:
+            command += f" --topic {shlex.quote(topic)}"
         return _invoke_callable(
             log_path,
             command,

--- a/scripts/tino_cli/clients/storm.py
+++ b/scripts/tino_cli/clients/storm.py
@@ -14,21 +14,31 @@ class StormClient(BaseClient):
     def __init__(self) -> None:
         super().__init__(name="storm", config=STORM)
 
-    def ingest(self, state: CLIState, *, topic: str, source: str) -> RequestResult | None:
-        payload = {"topic": topic, "source": source}
+    def ingest(
+        self,
+        state: CLIState,
+        *,
+        topic: str | None,
+        source: str,
+    ) -> RequestResult | None:
+        payload: dict[str, object] = {"source": source}
+        if topic is not None:
+            payload["topic"] = topic
         return self.request(state, "post", "/research/ingest", json_payload=payload, telemetry_action="ingest")
 
     def draft(
         self,
         state: CLIState,
         *,
-        topic: str,
+        topic: str | None,
         hints: Mapping[str, object] | None = None,
         doc: str | None = None,
         anchor: str | None = None,
         prompt: str | None = None,
     ) -> RequestResult | None:
-        payload: dict[str, object] = {"topic": topic}
+        payload: dict[str, object] = {}
+        if topic is not None:
+            payload["topic"] = topic
         if hints:
             payload["hints"] = hints
         if doc:

--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -150,7 +150,7 @@ def task_signal_operation(
     return client.signal(state, task_id, signal=signal, link=link, note=note)
 
 
-def research_ingest_operation(state: CLIState, *, topic: str, source: str):
+def research_ingest_operation(state: CLIState, *, topic: str | None, source: str):
     client = StormClient()
     return client.ingest(state, topic=topic, source=source)
 
@@ -158,7 +158,7 @@ def research_ingest_operation(state: CLIState, *, topic: str, source: str):
 def research_draft_operation(
     state: CLIState,
     *,
-    topic: str,
+    topic: str | None,
     hints: Mapping[str, object] | None = None,
     doc: str | None = None,
     anchor: str | None = None,

--- a/tests/test_tino_cli_services.py
+++ b/tests/test_tino_cli_services.py
@@ -2,12 +2,18 @@
 from __future__ import annotations
 
 import json
+import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING
+from types import SimpleNamespace
 
 import pytest
 
+from scripts.tino_cli import actions
+from scripts.tino_cli.clients.storm import StormClient
 from scripts.tino_cli.main import app
+from scripts.tino_cli.models import TelemetryStatus
+from scripts.tino_cli.state import CLIState
 
 if TYPE_CHECKING:
     from typer.testing import CliRunner
@@ -211,5 +217,79 @@ def test_logs_confirm_invokes_subprocess(
     assert captured
     assert captured[0][:4] == ["docker", "compose", "-f", "docker-compose.yml"]
     assert captured[0][-1] == "ume"
+
+
+def test_cockpit_research_ingest_without_topic(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(actions, "ensure_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(actions, "build_state", lambda *, dry_run, confirm: SimpleNamespace(dry_run=dry_run, confirm=confirm))
+    monkeypatch.setattr(actions, "telemetry_status", lambda: TelemetryStatus(enabled=False))
+
+    class _Result:
+        payload = {"ok": True}
+
+    def _fake_ingest(state, *, topic, source):  # noqa: ANN001 - dynamic signature for test
+        recorded["topic"] = topic
+        recorded["source"] = source
+        return _Result()
+
+    monkeypatch.setattr(actions, "research_ingest_operation", _fake_ingest)
+
+    result = actions.run_action("cockpit-research-ingest", payload="https://example.com", confirm=False)
+
+    expected_command = f"research ingest {shlex.quote('https://example.com')}"
+    assert result.details["commands"] == [expected_command]
+    assert recorded == {"topic": None, "source": "https://example.com"}
+
+    log_path = Path(result.details["log_path"])
+    assert log_path.exists()
+    assert "--topic" not in log_path.read_text(encoding="utf-8")
+
+
+def test_cockpit_research_ingest_with_topic(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(actions, "ensure_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(actions, "build_state", lambda *, dry_run, confirm: SimpleNamespace(dry_run=dry_run, confirm=confirm))
+    monkeypatch.setattr(actions, "telemetry_status", lambda: TelemetryStatus(enabled=False))
+
+    class _Result:
+        payload = {"ok": True}
+
+    def _fake_ingest(state, *, topic, source):  # noqa: ANN001 - dynamic signature for test
+        recorded["topic"] = topic
+        recorded["source"] = source
+        return _Result()
+
+    monkeypatch.setattr(actions, "research_ingest_operation", _fake_ingest)
+
+    result = actions.run_action(
+        "cockpit-research-ingest",
+        payload="growth::https://example.com/plan.pdf",
+        confirm=False,
+    )
+
+    expected_command = (
+        f"research ingest {shlex.quote('https://example.com/plan.pdf')} --topic {shlex.quote('growth')}"
+    )
+    assert result.details["commands"] == [expected_command]
+    assert recorded == {"topic": "growth", "source": "https://example.com/plan.pdf"}
+
+    log_contents = Path(result.details["log_path"]).read_text(encoding="utf-8")
+    assert "--topic" in log_contents
+
+
+def test_storm_client_ingest_topic_handling(fake_http_service: dict, tmp_path: Path) -> None:
+    fake_http_service["stub"]("post", "/research/ingest", {"ok": True})
+    state = CLIState(dry_run=False, confirm=True, telemetry_enabled=False, log_path=tmp_path / "cli.log")
+    client = StormClient()
+
+    client.ingest(state, topic=None, source="https://example.com/notes")
+    client.ingest(state, topic="growth", source="https://example.com/notes")
+
+    first, second = fake_http_service["calls"][:2]
+    assert first["json_payload"] == {"source": "https://example.com/notes"}
+    assert second["json_payload"] == {"source": "https://example.com/notes", "topic": "growth"}
 
 


### PR DESCRIPTION
## Summary
- allow the storm client ingest and draft helpers to accept optional topics and only send them when present
- adjust cockpit research ingest actions to parse `topic::source`, emit the new command shape, and keep log output aligned
- extend cockpit service tests to cover the optional topic flow and ensure the client payloads match expectations

## Testing
- pytest tests/test_tino_cli_services.py -k cockpit_research
- ruff check scripts/tino_cli/clients/storm.py scripts/tino_cli/actions.py scripts/tino_cli/main.py tests/test_tino_cli_services.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d979a83083269fbf5903a9256c3b