### PR TITLE
Add month option to finance snapshot CLI

### DIFF
--- a/scripts/tino_cli/clients/finance.py
+++ b/scripts/tino_cli/clients/finance.py
@@ -14,11 +14,17 @@ class FinanceClient(BaseClient):
     def __init__(self) -> None:
         super().__init__(name="finance", config=FINANCE)
 
-    def summarize(self, state: CLIState, *, period: str) -> RequestResult | None:
-        return self.snapshot(state, period=period)
+    def summarize(
+        self, state: CLIState, *, period: str, month: str | None = None
+    ) -> RequestResult | None:
+        return self.snapshot(state, period=period, month=month)
 
-    def snapshot(self, state: CLIState, *, period: str) -> RequestResult | None:
+    def snapshot(
+        self, state: CLIState, *, period: str, month: str | None = None
+    ) -> RequestResult | None:
         payload = {"period": period}
+        if month:
+            payload["month"] = month
         return self.request(state, "post", "/finance/report", json_payload=payload, telemetry_action="report")
 
     def sync(self, state: CLIState, *, provider: str) -> RequestResult | None:

--- a/scripts/tino_cli/clients/storm.py
+++ b/scripts/tino_cli/clients/storm.py
@@ -14,7 +14,6 @@ class StormClient(BaseClient):
     def __init__(self) -> None:
         super().__init__(name="storm", config=STORM)
 
-    def ingest(self, state: CLIState, *, topic: str | None, source: str) -> RequestResult | None:
     def ingest(
         self,
         state: CLIState,

--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -6,7 +6,7 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Mapping, Optional, Sequence
 
 import typer
 
@@ -150,8 +150,12 @@ def task_signal_operation(
     return client.signal(state, task_id, signal=signal, link=link, note=note)
 
 
-def research_ingest_operation(state: CLIState, *, source: str, topic: str | None = None):
-def research_ingest_operation(state: CLIState, *, topic: str | None, source: str):
+def research_ingest_operation(
+    state: CLIState,
+    *,
+    topic: str | None = None,
+    source: str,
+):
     client = StormClient()
     return client.ingest(state, topic=topic, source=source)
 
@@ -160,7 +164,6 @@ def research_draft_operation(
     state: CLIState,
     *,
     topic: str | None = None,
-    topic: str | None,
     hints: Mapping[str, object] | None = None,
     doc: str | None = None,
     anchor: str | None = None,
@@ -185,9 +188,11 @@ def mem_query_operation(
     return client.query(state, query=query, filters=filters)
 
 
-def finance_snapshot_operation(state: CLIState, *, period: str):
+def finance_snapshot_operation(
+    state: CLIState, *, period: str, month: Optional[str] = None
+):
     client = FinanceClient()
-    return client.snapshot(state, period=period)
+    return client.snapshot(state, period=period, month=month)
 
 
 def finance_sync_operation(state: CLIState, *, provider: str):
@@ -401,9 +406,10 @@ finance_app = typer.Typer(help="Finance reporting utilities.")
 def finance_snapshot(
     ctx: typer.Context,
     period: str = typer.Option("monthly", "--period", help="Reporting period."),
+    month: Optional[str] = typer.Option(None, "--month", help="Specific month (YYYY-MM)."),
 ) -> None:
     state = _get_state(ctx)
-    result = finance_snapshot_operation(state, period=period)
+    result = finance_snapshot_operation(state, period=period, month=month or None)
     _render_response(result)
 
 

--- a/tests/test_tino_cli_finance.py
+++ b/tests/test_tino_cli_finance.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from scripts.tino_cli.clients import finance as finance_module
+from scripts.tino_cli.main import app
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _setup_cli_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parent.parent
+    monkeypatch.chdir(project_root)
+    monkeypatch.setenv("TINO_CLI_LOG", str(tmp_path / "tino-cli.log"))
+
+
+def test_finance_snapshot_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, runner: CliRunner
+) -> None:
+    _setup_cli_env(monkeypatch, tmp_path)
+
+    captured: dict[str, str | None] = {}
+
+    def fake_snapshot(self, state, *, period: str, month: str | None = None):  # type: ignore[no-untyped-def]
+        captured["period"] = period
+        captured["month"] = month
+        return {"period": period, "month": month}
+
+    monkeypatch.setattr(finance_module.FinanceClient, "snapshot", fake_snapshot, raising=False)
+
+    result = runner.invoke(app, ["--dry-run", "finance", "snapshot"])
+
+    assert result.exit_code == 0
+    assert captured == {"period": "monthly", "month": None}
+
+
+def test_finance_snapshot_with_month(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, runner: CliRunner
+) -> None:
+    _setup_cli_env(monkeypatch, tmp_path)
+
+    captured: dict[str, str | None] = {}
+
+    def fake_snapshot(self, state, *, period: str, month: str | None = None):  # type: ignore[no-untyped-def]
+        captured["period"] = period
+        captured["month"] = month
+        return {"period": period, "month": month}
+
+    monkeypatch.setattr(finance_module.FinanceClient, "snapshot", fake_snapshot, raising=False)
+
+    result = runner.invoke(
+        app,
+        ["--dry-run", "finance", "snapshot", "--month", "2024-01"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {"period": "monthly", "month": "2024-01"}


### PR DESCRIPTION
## Summary
- add an optional `--month` flag to the finance snapshot command and forward it through the finance client
- correct duplicated research CLI definitions so the module imports cleanly
- exercise the finance snapshot command in new CLI tests, covering the default and explicit month flows

## Testing
- pytest tests/test_tino_cli_finance.py

------
https://chatgpt.com/codex/tasks/task_e_68e91ab86c1083268829508841fee62b