### PR TITLE
Add --json alias for task run payload option

### DIFF
--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -301,7 +301,7 @@ task_app = typer.Typer(help="Interact with TaskCascadence services.")
 def task_run(
     ctx: typer.Context,
     task: str = typer.Argument(..., help="Task identifier"),
-    payload: str = typer.Option(None, "--payload", help="JSON payload."),
+    payload: str = typer.Option(None, "--payload", "--json", help="JSON payload."),
 ) -> None:
     state = _get_state(ctx)
     body = json.loads(payload) if payload else None

--- a/tests/test_tino_cli_services.py
+++ b/tests/test_tino_cli_services.py
@@ -97,6 +97,38 @@ def test_task_run_invokes_remote_service(
     assert enabled is True
 
 
+def test_task_run_accepts_json_alias(
+    tino_cli_runner: "CliRunner",
+    fake_http_service: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded = _enable_telemetry(monkeypatch)
+    fake_http_service["stub"](
+        "post",
+        "/tasks/run",
+        {"status": "queued", "task": "demo"},
+    )
+
+    result = tino_cli_runner.invoke(
+        app,
+        ["task", "run", "demo", "--json", json.dumps({"foo": 42})],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"status": "queued", "task": "demo"}
+
+    call = fake_http_service["calls"][0]
+    assert call["method"] == "post"
+    assert call["url"].endswith("/tasks/run")
+    assert call["json_payload"] == {"task": "demo", "payload": {"foo": 42}}
+
+    assert recorded
+    _, payload, enabled = recorded[0]
+    assert payload["status"] == 200
+    assert payload["url"].endswith("/tasks/run")
+    assert enabled is True
+
+
 def test_task_signal_requires_confirmation(
     tino_cli_runner: "CliRunner",
     fake_http_service: dict,


### PR DESCRIPTION
## Summary
- add a `--json` alias to the `task run` payload option so both flags share the JSON help text
- ensure CLI parsing handles the alias by extending the service tests

## Testing
- pytest tests/test_tino_cli_services.py -k task_run

------
https://chatgpt.com/codex/tasks/task_e_68ee65a97e008326947b227e0de151cd