### PR TITLE
Update docs to highlight tino task run JSON payload usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ refactored surface:
 | ``tino whoami`` | Print the current CLI state, including ``--dry-run`` and telemetry settings. |
 | ``tino up`` / ``tino down`` | Manage the docker-compose stack, optionally targeting a single service. Both respect ``--confirm`` before mutating services. |
 | ``tino logs`` | Stream docker-compose logs; use ``--confirm`` to acknowledge the interactive stream. |
-| ``tino task …`` | Manage TaskCascadence tasks (``run``, ``status``, ``signal``). ``signal`` always requires ``--confirm``. |
+| ``tino task run <task_name> [--json payload]`` | Execute TaskCascadence tasks; ``status`` and ``signal`` remain available (``signal`` always requires ``--confirm``). |
 | ``tino research …`` | Access tino-storm research helpers (``ingest``, ``draft``). |
 | ``tino idea`` | Submit a quick idea/event to UME memory without opening the group commands. |
 | ``tino mem …`` | Query UME memories with structured filters. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,11 +28,11 @@ status. ``TINO_CLI_LOG`` controls where transcripts are written when
 
 ## Task lifecycle with confirmations
 
-TaskCascadence helpers live under ``tino task``. Run a task and monitor its
-status:
+TaskCascadence helpers live under ``tino task``. Run a task with an optional
+JSON payload and monitor its status:
 
 ```bash
-tino task run weekly-report --payload '{"period": "last-week"}'
+tino task run weekly-report --json '{"period": "last-week"}'
 tino task status 01HRZ73CJT37P9QZD7XQ3E5A4V
 ```
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -33,7 +33,7 @@ The cockpit buttons are thin wrappers over canonical ``tino`` commands:
 | **Recipes ▸ Run** | ``python -m scripts.tino_cli run-recipe <name> <goal>`` | Mirrors the Typer recipe helpers and records telemetry if enabled.
 | **Cockpit ▸ Up** | ``tino --confirm up`` | Requires confirmation inside the GUI before issuing ``docker compose up -d``. Windows hosts use ``cmd /C`` while Bash shells use ``/bin/sh -c``; the bridge handles both.
 | **Cockpit ▸ Down** | ``tino --confirm down`` | Stops the compose stack and is gated behind the confirmation toggle.
-| **New Task** | ``tino task run <payload>`` | The dialog payload becomes the ``task`` argument.
+| **New Task** | ``tino task run <task_name> [--json payload]`` | Enter a task name and optional JSON body; the dialog maps it to ``--json``.
 | **Inject Context** | ``tino idea <payload>`` | Stores quick notes via the UME bridge.
 | **Research Ingest** | ``tino research ingest <topic> <source>`` | The GUI accepts ``topic::source`` or a raw URL and forwards the parsed values to the CLI.
 | **Wishlist Add** | ``tino wishlist add <url>`` | Adds entries to ``metadata/wishlist.json`` just like the CLI.


### PR DESCRIPTION
## Summary
- document the `tino task run <task_name> [--json payload]` syntax in the README quickstart table
- refresh CLI and GUI quickstart examples to show the optional `--json` payload flag

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68ee65aa345083268b91b0c134c27bbd