### PR TITLE
Derive task signal defaults from payload options

### DIFF
--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -320,7 +320,11 @@ def task_status(ctx: typer.Context, task_id: str = typer.Argument(...)) -> None:
 def task_signal(
     ctx: typer.Context,
     task_id: str = typer.Argument(...),
-    signal: str = typer.Option(..., "--signal", help="Signal name."),
+    signal: str | None = typer.Option(
+        None,
+        "--signal",
+        help="Signal name. Defaults to link, note, or link_and_note based on payload.",
+    ),
     link: str = typer.Option(None, "--link", help="Optional link payload."),
     note: str = typer.Option(None, "--note", help="Optional note payload."),
 ) -> None:
@@ -328,7 +332,26 @@ def task_signal(
     if not state.confirm:
         typer.echo("Use --confirm to send signals to remote tasks.", err=True)
         raise typer.Exit(1)
-    result = task_signal_operation(state, task_id, signal=signal, link=link or None, note=note or None)
+    resolved_link = link or None
+    resolved_note = note or None
+    resolved_signal = signal or None
+    if resolved_signal is None:
+        payload_hints: list[str] = []
+        if resolved_link:
+            payload_hints.append("link")
+        if resolved_note:
+            payload_hints.append("note")
+        if not payload_hints:
+            typer.echo("Provide --signal or include --link/--note payload.", err=True)
+            raise typer.Exit(1)
+        resolved_signal = "_and_".join(payload_hints)
+    result = task_signal_operation(
+        state,
+        task_id,
+        signal=resolved_signal,
+        link=resolved_link,
+        note=resolved_note,
+    )
     _render_response(result)
 
 

--- a/tests/test_tino_cli_services.py
+++ b/tests/test_tino_cli_services.py
@@ -179,6 +179,58 @@ def test_task_signal_with_confirmation_hits_api(
     assert any(evt[0].endswith("signal") for evt in recorded)
 
 
+@pytest.mark.parametrize(
+    "options, expected",
+    (
+        pytest.param(["--link", "https://example.com"], "link", id="link-only"),
+        pytest.param(["--note", "Investigate"], "note", id="note-only"),
+        pytest.param(
+            ["--link", "https://example.com", "--note", "Investigate"],
+            "link_and_note",
+            id="link-and-note",
+        ),
+    ),
+)
+def test_task_signal_derives_signal_from_payload(
+    tino_cli_runner: "CliRunner",
+    fake_http_service: dict,
+    monkeypatch: pytest.MonkeyPatch,
+    options: list[str],
+    expected: str,
+) -> None:
+    _enable_telemetry(monkeypatch)
+    fake_http_service["stub"]("post", "/tasks/abc123/signal", {"ok": True})
+
+    result = tino_cli_runner.invoke(
+        app,
+        [
+            "--confirm",
+            "task",
+            "signal",
+            "abc123",
+            *options,
+        ],
+    )
+
+    assert result.exit_code == 0
+    call = fake_http_service["calls"][0]
+    assert call["json_payload"]["signal"] == expected
+
+
+def test_task_signal_requires_payload_when_signal_missing(
+    tino_cli_runner: "CliRunner",
+    fake_http_service: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_telemetry(monkeypatch)
+
+    result = tino_cli_runner.invoke(app, ["--confirm", "task", "signal", "abc123"])
+
+    assert result.exit_code == 1
+    assert "Provide --signal" in result.output
+    assert fake_http_service["calls"] == []
+
+
 def test_docs_publish_uses_configured_endpoint(
     tino_cli_runner: "CliRunner",
     fake_http_service: dict,


### PR DESCRIPTION
## Summary
- allow `tino task signal` to infer its signal name when only payload flags are supplied
- document the default signal derivation in the CLI help text
- add regression coverage for payload-derived signals and missing payload validation

## Testing
- pytest tests/test_tino_cli_services.py

------
https://chatgpt.com/codex/tasks/task_e_68f2438821088326a6529e961124cb4a