### PR TITLE
Improve cockpit context injection handling

### DIFF
--- a/scripts/tino_cli/actions.py
+++ b/scripts/tino_cli/actions.py
@@ -16,9 +16,9 @@ from .main import (
     build_state,
     compose_command,
     docs_publish_operation,
-    idea_submit_operation,
     research_ingest_operation,
     task_run_operation,
+    task_signal_operation,
     wishlist_add_operation,
 )
 from .models import ActionSpec, CommandResult
@@ -165,21 +165,36 @@ def _error_action(log_path: os.PathLike[str], command: str, message: str) -> tup
 
 
 def _research_action_payload(raw: str) -> tuple[str | None, str]:
-    if "::" in raw:
-        topic, source = raw.split("::", 1)
-        topic = topic.strip() or None
-        source = source.strip()
-        return topic, source
-    return None, raw.strip()
-def _research_action_payload(raw: str) -> tuple[str, str | None]:
-    topic: str | None = None
+    """Return (topic, source) extracted from ``raw``."""
+
     source = raw.strip()
+    topic: str | None = None
     if "::" in raw:
         topic_part, source_part = raw.split("::", 1)
         source = source_part.strip()
         parsed_topic = topic_part.strip()
         topic = parsed_topic or None
-    return source, topic
+    return topic, source
+
+
+def _parse_context_payload(job_id: str | None, payload: str | None) -> tuple[str | None, str]:
+    """Extract ``job_id`` and ``message`` for context injection."""
+
+    message = (payload or "").strip()
+    parsed_job = job_id.strip() if job_id else None
+    if not parsed_job and payload and "::" in payload:
+        raw_job, raw_message = payload.split("::", 1)
+        parsed_job = raw_job.strip() or None
+        message = raw_message.strip()
+    return parsed_job, message
+
+
+def _looks_like_url(value: str) -> bool:
+    if not value:
+        return False
+    if value.startswith("http://") or value.startswith("https://"):
+        return True
+    return False
 
 
 def _run_special_action(
@@ -187,6 +202,8 @@ def _run_special_action(
     payload: str | None,
     confirm: bool,
     log_path: os.PathLike[str],
+    *,
+    job_id: str | None = None,
 ) -> tuple[int, list[str], dict[str, Any]]:
     state = build_state(dry_run=False, confirm=confirm)
     if name == "cockpit-new-task":
@@ -196,19 +213,45 @@ def _run_special_action(
         command = f"task run {shlex.quote(task_name)}"
         return _invoke_callable(log_path, command, lambda: task_run_operation(state, task_name, payload=None))
     if name == "cockpit-inject-context":
-        if not payload:
-            return _error_action(log_path, "idea <missing>", "Context payload required.")
-        context = payload
-        command = f"idea {shlex.quote(context)}"
-        return _invoke_callable(log_path, command, lambda: idea_submit_operation(state, text=context))
+        parsed_job, message = _parse_context_payload(job_id, payload)
+        if not parsed_job:
+            return _error_action(
+                log_path,
+                "task signal context <missing>",
+                "Task identifier required for context injection.",
+            )
+        if not message:
+            return _error_action(
+                log_path,
+                "task signal context <missing>",
+                "Context message required for injection.",
+            )
+
+        is_link = _looks_like_url(message)
+        link = message if is_link else None
+        note = None if is_link else message
+
+        command = f"task signal context {shlex.quote(parsed_job)}"
+        if is_link:
+            command += f" --link {shlex.quote(message)}"
+        else:
+            command += f" --note {shlex.quote(message)}"
+
+        return _invoke_callable(
+            log_path,
+            command,
+            lambda: task_signal_operation(
+                state,
+                parsed_job,
+                signal="context",
+                link=link,
+                note=note,
+            ),
+        )
     if name == "cockpit-research-ingest":
         if not payload:
             return _error_action(log_path, "research ingest <missing>", "Source path or URL required.")
         topic, source = _research_action_payload(payload)
-        command = f"research ingest {shlex.quote(source)}"
-        if topic:
-            command = f"{command} --topic {shlex.quote(topic)}"
-        source, topic = _research_action_payload(payload)
         command = f"research ingest {shlex.quote(source)}"
         if topic:
             command += f" --topic {shlex.quote(topic)}"
@@ -230,7 +273,13 @@ def _run_special_action(
     raise ValueError(f"Unknown action: {name}")
 
 
-def run_action(name: str, *, payload: str | None = None, confirm: bool = False) -> CommandResult:
+def run_action(
+    name: str,
+    *,
+    payload: str | None = None,
+    confirm: bool = False,
+    job_id: str | None = None,
+) -> CommandResult:
     """Execute a cockpit action described by ``name``."""
 
     spec = DEFAULT_ACTIONS.get(name)
@@ -248,7 +297,13 @@ def run_action(name: str, *, payload: str | None = None, confirm: bool = False) 
         steps = _render_steps(spec, payload)
         exit_code, rendered_commands = _execute_steps(steps, log_path)
     else:
-        exit_code, rendered_commands, details_extra = _run_special_action(name, payload, confirm, log_path)
+        exit_code, rendered_commands, details_extra = _run_special_action(
+            name,
+            payload,
+            confirm,
+            log_path,
+            job_id=job_id,
+        )
 
     timestamp = time.time()
     audit_path = cache_dir / "cockpit.log"

--- a/scripts/tino_cli/api.py
+++ b/scripts/tino_cli/api.py
@@ -227,10 +227,16 @@ def dashboard() -> dict[str, Any]:
     return {"dashboard": asdict(summary)}
 
 
-def cockpit_action(name: str, *, payload: str | None = None, confirm: bool = False) -> dict[str, Any]:
+def cockpit_action(
+    name: str,
+    *,
+    payload: str | None = None,
+    confirm: bool = False,
+    job_id: str | None = None,
+) -> dict[str, Any]:
     """Execute a named cockpit action."""
 
-    result = run_action(name, payload=payload, confirm=confirm)
+    result = run_action(name, payload=payload, confirm=confirm, job_id=job_id)
     return {"result": {
         "message": result.message,
         "telemetry": asdict(result.telemetry) if result.telemetry else None,

--- a/scripts/tino_cli/run.py
+++ b/scripts/tino_cli/run.py
@@ -72,7 +72,10 @@ def build_parser() -> argparse.ArgumentParser:
         "cockpit-publish-docs",
     ]:
         action_parser = sub.add_parser(action)
-        if action in {"cockpit-new-task", "cockpit-inject-context", "cockpit-research-ingest", "cockpit-wishlist-add"}:
+        if action == "cockpit-inject-context":
+            action_parser.add_argument("job", nargs="?")
+            action_parser.add_argument("message", nargs=argparse.REMAINDER)
+        elif action in {"cockpit-new-task", "cockpit-research-ingest", "cockpit-wishlist-add"}:
             action_parser.add_argument("payload")
         action_parser.add_argument("--confirm", action="store_true")
 
@@ -111,11 +114,25 @@ def main(argv: list[str] | None = None) -> int:
         return _run_handler(api.cockpit_logs, limit=args.limit)
     if args.command.startswith("cockpit-"):
         payload = getattr(args, "payload", None)
+        job_id = None
+        if args.command == "cockpit-inject-context":
+            job_arg = getattr(args, "job", None)
+            message_parts = getattr(args, "message", None) or []
+            if message_parts:
+                payload = " ".join(message_parts).strip()
+            else:
+                payload = getattr(args, "payload", None)
+            job_id = job_arg
+            if job_arg and "::" in job_arg and not payload:
+                job_part, message_part = job_arg.split("::", 1)
+                job_id = job_part.strip() or None
+                payload = message_part.strip()
         return _run_handler(
             api.cockpit_action,
             args.command,
             payload=payload,
             confirm=args.confirm,
+            job_id=job_id,
         )
 
     parser.error("Unknown command")

--- a/tests/test_tino_cockpit_context.py
+++ b/tests/test_tino_cockpit_context.py
@@ -1,0 +1,107 @@
+"""Tests for cockpit context injection handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from importlib import import_module
+
+from scripts.tino_cli import actions
+from scripts.tino_cli.models import TelemetryStatus
+
+
+main_module = import_module("scripts.tino_cli.main")
+
+
+class _Result:
+    payload = {"ok": True}
+
+
+@pytest.fixture()
+def _patched_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(actions, "ensure_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        actions,
+        "build_state",
+        lambda *, dry_run, confirm: SimpleNamespace(dry_run=dry_run, confirm=confirm),
+    )
+    monkeypatch.setattr(actions, "telemetry_status", lambda: TelemetryStatus(enabled=False))
+
+
+def test_cockpit_inject_context_parses_combined_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _patched_environment
+) -> None:
+    recorded: dict[str, object] = {}
+
+    def _fake_signal(self, state, task_id, *, signal, link=None, note=None):  # noqa: ANN001
+        recorded.update({
+            "task_id": task_id,
+            "signal": signal,
+            "link": link,
+            "note": note,
+        })
+        return _Result()
+
+    monkeypatch.setattr(main_module.TaskCascadenceClient, "signal", _fake_signal, raising=False)
+
+    result = actions.run_action(
+        "cockpit-inject-context",
+        payload="job-42::add more details",
+        confirm=False,
+    )
+
+    assert recorded == {
+        "task_id": "job-42",
+        "signal": "context",
+        "link": None,
+        "note": "add more details",
+    }
+    assert "--note" in result.details["commands"][0]
+
+
+def test_cockpit_inject_context_uses_link_for_urls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _patched_environment
+) -> None:
+    recorded: dict[str, object] = {}
+
+    def _fake_signal(self, state, task_id, *, signal, link=None, note=None):  # noqa: ANN001
+        recorded.update({
+            "task_id": task_id,
+            "signal": signal,
+            "link": link,
+            "note": note,
+        })
+        return _Result()
+
+    monkeypatch.setattr(main_module.TaskCascadenceClient, "signal", _fake_signal, raising=False)
+
+    result = actions.run_action(
+        "cockpit-inject-context",
+        payload="https://example.com/context",
+        confirm=False,
+        job_id="job-42",
+    )
+
+    assert recorded == {
+        "task_id": "job-42",
+        "signal": "context",
+        "link": "https://example.com/context",
+        "note": None,
+    }
+    assert "--link" in result.details["commands"][0]
+
+
+def test_cockpit_inject_context_requires_job(
+    tmp_path: Path, _patched_environment
+) -> None:
+    result = actions.run_action(
+        "cockpit-inject-context",
+        payload="just some context",
+        confirm=False,
+    )
+
+    assert result.details["exit_code"] == 1
+    assert result.details["error"] == "Task identifier required for context injection."


### PR DESCRIPTION
## Summary
- ensure cockpit context injection parses job identifiers, forwards context via task signals, and detects URL payloads
- thread an explicit job_id through the CLI entrypoint and API while maintaining support for legacy job::message strings
- add targeted tests that stub the TaskCascadence client to verify parsing, URL handling, and missing job failures

## Testing
- pytest tests/test_tino_cockpit_context.py

------
https://chatgpt.com/codex/tasks/task_e_68f24388d0bc8326bffbc11a3f55f4f9