### PR TITLE
Document updated tino task signal behaviour and cockpit context

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ stateful services. The CLI also honours new environment variables introduced
 in the refactor, such as ``TINO_CLI_LOG`` (log destination for command
 transcripts) and ``TINO_DOC_TARGET`` (default documentation publish target).
 
+Signals now infer the type based on the provided payload. Use ``--link`` for
+URL-based updates and ``--note`` for inline messages; the CLI chooses the
+appropriate signal shape automatically. For example:
+
+```shell
+tino task signal my-task-id --link https://status.example.com/incident/123 --confirm
+```
+
+The above emits a ``link`` signal without needing ``--type link``. Swap in
+``--note`` for free-form text updates when sharing progress notes or status
+summaries.
+
 Or use Scoop in a single line:
 
 ```powershell

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -1,0 +1,23 @@
+# Cockpit context injection
+
+Cockpit surfaces a text box for context when raising a task signal from the GUI.
+To give downstream automations the same structured data as the CLI, include the
+job identifier and message on separate lines in the form:
+
+```
+Job: <task or job id>
+Message: <status update or request>
+```
+
+When using the cockpit GUI, paste the ``Job`` line first, followed by the
+``Message`` line. The CLI fall back uses the same structure:
+
+```shell
+# Equivalent CLI update
+printf 'Job: %s\nMessage: %s\n' "my-task-id" "Waiting on vendor confirmation" \
+  | tino task signal my-task-id --note - --confirm
+```
+
+The CLI example streams the formatted note to ``tino task signal`` using STDIN;
+Cockpit mirrors this shape so automated parsers can detect the job id and
+message fields consistently.


### PR DESCRIPTION
## Summary
- document automatic signal type inference in the README and show a link-based example
- add cockpit guidance describing the job and message context format shared by the GUI and CLI

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f2491839148326bd331e0c4fea9343