### PR TITLE
Enhance whoami output with identity and service info

### DIFF
--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -19,9 +19,17 @@ from .clients import (
     TaskCascadenceClient,
     UMEClient,
 )
-from .config import load_env_defaults
+from .config import (
+    DOCS,
+    FINANCE,
+    STORM,
+    TASKCASCADENCE,
+    UME,
+    ServiceConfig,
+    load_env_defaults,
+)
 from .plugin_loader import register_plugin_commands
-from .state import CLIState
+from .state import CLIState, snapshot_identity, stable_dict
 
 app = typer.Typer(help="Automation interface for d0tTino tooling.", no_args_is_help=True)
 
@@ -29,16 +37,29 @@ COMPOSE_FILE = Path("docker-compose.yml")
 WISHLIST_PATH = Path("metadata") / "wishlist.json"
 
 
+_SERVICE_CONFIGS: tuple[tuple[str, ServiceConfig], ...] = (
+    ("docs", DOCS),
+    ("finance", FINANCE),
+    ("storm", STORM),
+    ("taskcascadence", TASKCASCADENCE),
+    ("ume", UME),
+)
+
+
 def build_state(*, dry_run: bool, confirm: bool) -> CLIState:
     """Create a :class:`CLIState` populated with environment defaults."""
 
     load_env_defaults()
     log_path = Path(os.environ.get("TINO_CLI_LOG", "tino-cli.log"))
+    identity = snapshot_identity()
+    services = stable_dict({name: config.resolve() for name, config in _SERVICE_CONFIGS})
     return CLIState(
         dry_run=dry_run,
         confirm=confirm,
         telemetry_enabled=analytics_default(),
         log_path=log_path,
+        identity=identity,
+        services=services,
     )
 
 
@@ -94,11 +115,16 @@ def run_doctor(state: CLIState) -> int:
 
 
 def show_whoami(state: CLIState) -> dict[str, object]:
-    return {
+    identity = stable_dict(dict(state.identity))
+    services = stable_dict(dict(state.services))
+    payload = {
         "confirm": state.confirm,
         "telemetry": state.telemetry_enabled,
         "log_path": str(state.log_path),
+        "identity": identity,
+        "services": services,
     }
+    return stable_dict(payload)
 
 
 def start_services(state: CLIState, service: str | None = None) -> int:
@@ -320,7 +346,7 @@ def task_status(ctx: typer.Context, task_id: str = typer.Argument(...)) -> None:
 def task_signal(
     ctx: typer.Context,
     task_id: str = typer.Argument(...),
-    signal: str | None = typer.Option(
+    signal: Optional[str] = typer.Option(
         None,
         "--signal",
         help="Signal name. Defaults to link, note, or link_and_note based on payload.",

--- a/scripts/tino_cli/state.py
+++ b/scripts/tino_cli/state.py
@@ -1,8 +1,42 @@
 """Shared runtime state for the :mod:`scripts.tino_cli` command line."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
+import getpass
+import os
+import platform
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Mapping
+
+
+def stable_dict(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a dictionary with keys sorted for stable JSON output."""
+
+    return {key: data[key] for key in sorted(data)}
+
+
+def snapshot_identity() -> dict[str, str]:
+    """Capture user and host identity information once per CLI session."""
+
+    identity: dict[str, str] = {}
+    for key in ("USER", "USERNAME", "LOGNAME"):
+        value = os.environ.get(key)
+        if value:
+            identity[key] = value
+
+    hostname = os.environ.get("HOSTNAME") or os.environ.get("COMPUTERNAME") or platform.node()
+    if hostname:
+        identity["HOSTNAME"] = hostname
+
+    try:
+        system_user = getpass.getuser()
+    except Exception:  # pragma: no cover - fallback when system lookup fails
+        system_user = None
+    if system_user and system_user not in identity.values():
+        identity["SYSTEM_USER"] = system_user
+
+    return stable_dict(identity)
 
 
 @dataclass(slots=True)
@@ -13,6 +47,8 @@ class CLIState:
     confirm: bool
     telemetry_enabled: bool
     log_path: Path
+    identity: Mapping[str, str] = field(default_factory=dict)
+    services: Mapping[str, str] = field(default_factory=dict)
 
 
-__all__ = ["CLIState"]
+__all__ = ["CLIState", "snapshot_identity", "stable_dict"]

--- a/tests/test_tino_cli.py
+++ b/tests/test_tino_cli.py
@@ -29,6 +29,34 @@ def test_bootstrap_whoami_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     assert "[dry-run]" in result.output
 
 
+def test_whoami_reports_identity_and_services(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+) -> None:
+    monkeypatch.chdir(Path(__file__).resolve().parent.parent)
+    monkeypatch.setenv("TINO_CLI_LOG", str(tmp_path / "cli.log"))
+    monkeypatch.setenv("USER", "cli-tester")
+    monkeypatch.setenv("HOSTNAME", "cli-host")
+    monkeypatch.setenv("TASKCASCADENCE_URL", "http://example.local/tasks")
+    monkeypatch.setenv("STORM_URL", "http://example.local/storm")
+    monkeypatch.setenv("UME_URL", "http://example.local/ume")
+    monkeypatch.setenv("FINANCE_URL", "http://example.local/finance")
+    monkeypatch.setenv("DOCS_URL", "http://example.local/docs")
+
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0
+
+    data = json.loads(result.output)
+    assert data["identity"]["USER"] == "cli-tester"
+    assert data["identity"]["HOSTNAME"] == "cli-host"
+    assert data["services"] == {
+        "docs": "http://example.local/docs",
+        "finance": "http://example.local/finance",
+        "storm": "http://example.local/storm",
+        "taskcascadence": "http://example.local/tasks",
+        "ume": "http://example.local/ume",
+    }
+
+
 def test_wishlist_add_dry_run(monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path) -> None:
     monkeypatch.chdir(Path(__file__).resolve().parent.parent)
     monkeypatch.setenv("TINO_CLI_LOG", str(tmp_path / "log"))


### PR DESCRIPTION
## Summary
- capture system identity and resolved service endpoints when constructing the CLI state
- extend the `tino whoami` output with the cached identity snapshot and deterministic ordering
- add regression coverage to ensure the new whoami payload reports the expected information

## Testing
- pytest tests/test_tino_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68f636ab68f083268488b131044a20d8