### PR TITLE
Allow tino down to target specific services

### DIFF
--- a/scripts/tino_cli/doctor.py
+++ b/scripts/tino_cli/doctor.py
@@ -1,8 +1,5 @@
-"""Environment validation helpers for the ``tino doctor`` command."""
-
-from __future__ import annotations
-
 """Diagnostic helpers for the ``tino doctor`` command."""
+
 from __future__ import annotations
 
 import os

--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -187,8 +187,11 @@ def start_services(state: CLIState, service: str | None = None) -> int:
     return run_shell_command(state, command, require_confirm=True)
 
 
-def stop_services(state: CLIState) -> int:
-    command = compose_command("down")
+def stop_services(state: CLIState, service: str | None = None) -> int:
+    if service:
+        command = compose_command("rm", "--stop", "--force", service)
+    else:
+        command = compose_command("down")
     return run_shell_command(state, command, require_confirm=True)
 
 
@@ -371,9 +374,9 @@ def cli_up(ctx: typer.Context, service: str = typer.Argument(None, help="Optiona
 
 
 @app.command("down")
-def cli_down(ctx: typer.Context) -> None:
+def cli_down(ctx: typer.Context, service: str = typer.Argument(None, help="Optional service name.")) -> None:
     state = _get_state(ctx)
-    code = stop_services(state)
+    code = stop_services(state, service or None)
     raise typer.Exit(code)
 
 
@@ -579,7 +582,6 @@ def docs_publish(
         None,
         help="Document path or identifier. Defaults to $TINO_DOC_TARGET when omitted.",
     ),
-    target: str | None = typer.Argument(None, help="Document path or identifier."),
     site: str = typer.Option(None, "--site", help="Documentation site."),
     version: str = typer.Option(None, "--version", help="Version label."),
 ) -> None:
@@ -587,19 +589,12 @@ def docs_publish(
     try:
         result = docs_publish_operation(
             state,
-            target=target or None,
+            target=target,
             site=site or None,
             version=version or None,
         )
     except ValueError as exc:
         raise typer.BadParameter(str(exc), param_hint="target") from exc
-    resolved_target = target or os.environ.get("TINO_DOC_TARGET") or "latest"
-    result = docs_publish_operation(
-        state,
-        target=resolved_target,
-        site=site or None,
-        version=version or None,
-    )
     _render_response(result)
 
 


### PR DESCRIPTION
## Summary
- allow the CLI stop helper to accept an optional service argument
- use `docker compose rm --stop --force` when targeting a single service
- update `tino down` so it mirrors the flexibility of `tino up`
- fix the duplicated `target` argument in the `docs publish` Typer command so the module imports cleanly again

## Testing
- `pytest` *(fails: missing optional dependency `requests` required by tests)*
- `ruff check .` *(fails: pre-existing lint violations in unrelated modules)*
- `python -m scripts.tino_cli.main --dry-run --confirm down ume` *(fails under the bundled Typer stub where `Typer` instances are not callable)*
- `python - <<'PY'\nfrom scripts.tino_cli.main import build_state, stop_services\nstate = build_state(dry_run=True, confirm=True)\nstop_services(state, \"ume\")\nstop_services(state)\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68f8da47b0d08326a9924cac290fe858