### PR TITLE
Add stack shutdown CLI tests and refine docs publish

### DIFF
--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -187,8 +187,11 @@ def start_services(state: CLIState, service: str | None = None) -> int:
     return run_shell_command(state, command, require_confirm=True)
 
 
-def stop_services(state: CLIState) -> int:
-    command = compose_command("down")
+def stop_services(state: CLIState, service: str | None = None) -> int:
+    if service:
+        command = compose_command("rm", "-s", "-f", service)
+    else:
+        command = compose_command("down")
     return run_shell_command(state, command, require_confirm=True)
 
 
@@ -371,9 +374,12 @@ def cli_up(ctx: typer.Context, service: str = typer.Argument(None, help="Optiona
 
 
 @app.command("down")
-def cli_down(ctx: typer.Context) -> None:
+def cli_down(
+    ctx: typer.Context,
+    service: str = typer.Argument(None, help="Optional service name."),
+) -> None:
     state = _get_state(ctx)
-    code = stop_services(state)
+    code = stop_services(state, service or None)
     raise typer.Exit(code)
 
 
@@ -579,7 +585,6 @@ def docs_publish(
         None,
         help="Document path or identifier. Defaults to $TINO_DOC_TARGET when omitted.",
     ),
-    target: str | None = typer.Argument(None, help="Document path or identifier."),
     site: str = typer.Option(None, "--site", help="Documentation site."),
     version: str = typer.Option(None, "--version", help="Version label."),
 ) -> None:
@@ -593,13 +598,6 @@ def docs_publish(
         )
     except ValueError as exc:
         raise typer.BadParameter(str(exc), param_hint="target") from exc
-    resolved_target = target or os.environ.get("TINO_DOC_TARGET") or "latest"
-    result = docs_publish_operation(
-        state,
-        target=resolved_target,
-        site=site or None,
-        version=version or None,
-    )
     _render_response(result)
 
 
@@ -642,8 +640,8 @@ def stack_up(ctx: typer.Context, service: str = typer.Argument(None)) -> None:
 
 
 @stack_app.command("down")
-def stack_down(ctx: typer.Context) -> None:
-    cli_down(ctx)
+def stack_down(ctx: typer.Context, service: str = typer.Argument(None)) -> None:
+    cli_down(ctx, service or None)
 
 
 @stack_app.command("logs")

--- a/tests/test_tino_cli_stack.py
+++ b/tests/test_tino_cli_stack.py
@@ -1,0 +1,80 @@
+"""Tests for legacy ``tino stack`` compatibility commands."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+_doctor_stub = types.ModuleType("scripts.tino_cli.doctor")
+_doctor_stub.gather_report = lambda *args, **kwargs: None  # type: ignore[assignment]
+_doctor_stub.gather_diagnostics = lambda *args, **kwargs: None  # type: ignore[assignment]
+sys.modules.setdefault("scripts.tino_cli.doctor", _doctor_stub)
+
+from scripts.tino_cli.main import app
+
+
+@pytest.fixture()
+def _capture_shell(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Capture ``run_shell_command`` invocations for assertions."""
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_run_shell(
+        state,
+        command,
+        *,
+        require_confirm: bool = False,
+        confirm_message: str = "Use --confirm to execute this command.",
+    ) -> int:
+        calls.append(
+            {
+                "command": tuple(command),
+                "require_confirm": require_confirm,
+                "confirm_message": confirm_message,
+            }
+        )
+        return 0
+
+    main_module = sys.modules["scripts.tino_cli.main"]
+    monkeypatch.setattr(main_module, "run_shell_command", _fake_run_shell)
+    return calls
+
+
+def test_stack_down_full_invokes_compose_down(tino_cli_runner, _capture_shell) -> None:
+    result = tino_cli_runner.invoke(app, ["--confirm", "stack", "down"])
+
+    assert result.exit_code == 0
+    assert _capture_shell == [
+        {
+            "command": ("docker", "compose", "-f", "docker-compose.yml", "down"),
+            "require_confirm": True,
+            "confirm_message": "Use --confirm to execute this command.",
+        }
+    ]
+
+
+def test_stack_down_service_removes_compose_service(
+    tino_cli_runner,
+    _capture_shell,
+) -> None:
+    result = tino_cli_runner.invoke(app, ["--confirm", "stack", "down", "ume"])
+
+    assert result.exit_code == 0
+    assert _capture_shell == [
+        {
+            "command": (
+                "docker",
+                "compose",
+                "-f",
+                "docker-compose.yml",
+                "rm",
+                "-s",
+                "-f",
+                "ume",
+            ),
+            "require_confirm": True,
+            "confirm_message": "Use --confirm to execute this command.",
+        }
+    ]


### PR DESCRIPTION
## Summary
- add tests covering the legacy `tino stack down` command for full and per-service shutdowns
- allow the CLI to accept an optional service when stopping containers and target that service with `docker compose rm`
- simplify the docs publish command wrapper to avoid redundant invocation

## Testing
- pytest tests/test_tino_cli_stack.py

------
https://chatgpt.com/codex/tasks/task_e_68f8da48b378832690e44a167eb92669