### PR TITLE
Fix tino down command delegation

### DIFF
--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -190,7 +190,6 @@ def start_services(state: CLIState, service: str | None = None) -> int:
 def stop_services(state: CLIState, service: str | None = None) -> int:
     if service:
         command = compose_command("rm", "-s", "-f", service)
-        command = compose_command("rm", "--stop", "--force", service)
     else:
         command = compose_command("down")
     return run_shell_command(state, command, require_confirm=True)
@@ -379,7 +378,6 @@ def cli_down(
     ctx: typer.Context,
     service: str = typer.Argument(None, help="Optional service name."),
 ) -> None:
-def cli_down(ctx: typer.Context, service: str = typer.Argument(None, help="Optional service name.")) -> None:
     state = _get_state(ctx)
     code = stop_services(state, service or None)
     raise typer.Exit(code)
@@ -583,7 +581,7 @@ docs_app = typer.Typer(help="Publish documentation updates.")
 @docs_app.command("publish")
 def docs_publish(
     ctx: typer.Context,
-    target: str | None = typer.Argument(
+    target: str = typer.Argument(
         None,
         help="Document path or identifier. Defaults to $TINO_DOC_TARGET when omitted.",
     ),
@@ -591,10 +589,11 @@ def docs_publish(
     version: str = typer.Option(None, "--version", help="Version label."),
 ) -> None:
     state = _get_state(ctx)
+    resolved_target = target or None
     try:
         result = docs_publish_operation(
             state,
-            target=target,
+            target=resolved_target,
             site=site or None,
             version=version or None,
         )

--- a/tests/test_tino_cli_stack.py
+++ b/tests/test_tino_cli_stack.py
@@ -78,3 +78,24 @@ def test_stack_down_service_removes_compose_service(
             "confirm_message": "Use --confirm to execute this command.",
         }
     ]
+
+
+def test_down_command_delegates_to_stop_services(
+    monkeypatch: pytest.MonkeyPatch, tino_cli_runner
+) -> None:
+    calls: list[str | None] = []
+
+    def _fake_stop(state, service: str | None = None) -> int:  # pragma: no cover - trivial
+        calls.append(service)
+        return 0
+
+    main_module = sys.modules["scripts.tino_cli.main"]
+    monkeypatch.setattr(main_module, "stop_services", _fake_stop)
+
+    result = tino_cli_runner.invoke(app, ["down"])
+    assert result.exit_code == 0
+    assert calls == [None]
+
+    result = tino_cli_runner.invoke(app, ["down", "ume"])
+    assert result.exit_code == 0
+    assert calls == [None, "ume"]


### PR DESCRIPTION
## Summary
- collapse the duplicated `tino down` Typer handler into a single command that delegates to `stop_services`
- adjust the docs publish command signature to avoid unsupported union annotations during CLI loading
- add a regression test to ensure `tino down` invokes `stop_services`

## Testing
- pytest tests/test_tino_cli_stack.py

------
https://chatgpt.com/codex/tasks/task_e_690a0f19b4c083268498ec66a39c2cde