### PR TITLE
Add schedule helpers for TaskCascadence client

### DIFF
--- a/scripts/tino_cli/clients/taskcascadence.py
+++ b/scripts/tino_cli/clients/taskcascadence.py
@@ -45,5 +45,35 @@ class TaskCascadenceClient(BaseClient):
             telemetry_action="signal",
         )
 
+    def get_schedule(self, state: CLIState) -> RequestResult | None:
+        """Return the current automation schedule."""
 
-__all__ = ["TaskCascadenceClient"]
+        return self.request(state, "get", "/schedule", telemetry_action="get_schedule")
+
+    def update_schedule(self, state: CLIState, *, schedule: Mapping[str, Any]) -> RequestResult | None:
+        """Update the automation schedule with ``schedule`` values."""
+
+        return self.request(
+            state,
+            "patch",
+            "/schedule",
+            json_payload=schedule,
+            telemetry_action="update_schedule",
+        )
+
+
+def get_schedule(state: CLIState) -> RequestResult | None:
+    """Return the TaskCascadence schedule using a convenience client."""
+
+    client = TaskCascadenceClient()
+    return client.get_schedule(state)
+
+
+def update_schedule(state: CLIState, *, schedule: Mapping[str, Any]) -> RequestResult | None:
+    """Update the TaskCascadence schedule using a convenience client."""
+
+    client = TaskCascadenceClient()
+    return client.update_schedule(state, schedule=schedule)
+
+
+__all__ = ["TaskCascadenceClient", "get_schedule", "update_schedule"]

--- a/tests/test_taskcascadence_schedule.py
+++ b/tests/test_taskcascadence_schedule.py
@@ -1,0 +1,85 @@
+"""Unit tests for TaskCascadence schedule helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import sys
+import types
+
+import pytest
+
+_stub_run = types.ModuleType("scripts.tino_cli.run")
+_stub_run.main = lambda *args, **kwargs: None  # type: ignore[assignment]
+sys.modules.setdefault("scripts.tino_cli.run", _stub_run)
+
+from scripts.tino_cli.clients.taskcascadence import TaskCascadenceClient  # noqa: E402
+from scripts.tino_cli.state import CLIState  # noqa: E402
+
+
+def _build_state(tmp_path: Path, *, dry_run: bool, telemetry_enabled: bool) -> CLIState:
+    return CLIState(
+        dry_run=dry_run,
+        confirm=True,
+        telemetry_enabled=telemetry_enabled,
+        log_path=tmp_path / "cli.log",
+    )
+
+
+def _capture_events(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any], bool]]:
+    events: list[tuple[str, dict[str, Any], bool]] = []
+
+    def _record(name: str, payload: dict[str, Any], *, enabled: bool = False) -> bool:  # noqa: FBT002
+        events.append((name, payload, enabled))
+        return True
+
+    monkeypatch.setattr("scripts.tino_cli.clients.base.record_event", _record)
+    return events
+
+
+def test_get_schedule_success(fake_http_service: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fake_http_service["stub"]("get", "/schedule", {"items": []})
+    events = _capture_events(monkeypatch)
+
+    state = _build_state(tmp_path, dry_run=False, telemetry_enabled=True)
+    client = TaskCascadenceClient()
+
+    result = client.get_schedule(state)
+
+    assert result is not None
+    assert result.payload == {"items": []}
+    assert fake_http_service["calls"][0]["method"] == "get"
+    assert fake_http_service["calls"][0]["url"].endswith("/schedule")
+
+    assert len(events) == 1
+    name, payload, enabled = events[0]
+    assert name == "tino_cli.taskcascadence.get_schedule"
+    assert enabled is True
+    assert payload["action"] == "get_schedule"
+    assert payload["url"].endswith("/schedule")
+    assert payload["status"] == 200
+    assert "duration_ms" in payload
+
+
+def test_update_schedule_dry_run(fake_http_service: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    events = _capture_events(monkeypatch)
+
+    state = _build_state(tmp_path, dry_run=True, telemetry_enabled=True)
+    client = TaskCascadenceClient()
+
+    result = client.update_schedule(state, schedule={"timezone": "UTC"})
+
+    assert result is None
+    assert fake_http_service["calls"] == []
+
+    captured = capsys.readouterr()
+    assert "[dry-run] PATCH http://127.0.0.1:6001/schedule" in captured.out
+
+    assert len(events) == 1
+    name, payload, enabled = events[0]
+    assert name == "tino_cli.taskcascadence.update_schedule"
+    assert enabled is True
+    assert payload["action"] == "update_schedule"
+    assert payload["url"].endswith("/schedule")
+    assert payload["dry_run"] is True
+    assert payload["status"] is None


### PR DESCRIPTION
## Summary
- add get_schedule and update_schedule helpers to TaskCascadence client and module exports
- provide module-level convenience wrappers for the new schedule helpers
- add focused tests covering schedule success and dry-run telemetry behaviour

## Testing
- ruff check scripts/tino_cli/clients/taskcascadence.py tests/test_taskcascadence_schedule.py
- pytest tests/test_taskcascadence_schedule.py

------
https://chatgpt.com/codex/tasks/task_e_690a0f1a64388326a9d16ecc7e91ab4d