### PR TITLE
Add schedule helpers for TaskCascadence client

### DIFF
--- a/scripts/tino_cli/clients/__init__.py
+++ b/scripts/tino_cli/clients/__init__.py
@@ -5,7 +5,7 @@ from .base import BaseClient, RequestResult
 from .docs import DocsClient
 from .finance import FinanceClient
 from .storm import StormClient
-from .taskcascadence import TaskCascadenceClient
+from .taskcascadence import TaskCascadenceClient, get_schedule, update_schedule
 from .ume import UMEClient
 
 __all__ = [
@@ -15,5 +15,7 @@ __all__ = [
     "FinanceClient",
     "StormClient",
     "TaskCascadenceClient",
+    "get_schedule",
+    "update_schedule",
     "UMEClient",
 ]

--- a/scripts/tino_cli/clients/taskcascadence.py
+++ b/scripts/tino_cli/clients/taskcascadence.py
@@ -7,6 +7,8 @@ from .base import BaseClient, RequestResult
 from ..config import TASKCASCADENCE
 from ..state import CLIState
 
+_SCHEDULE_PATH = "/schedule"
+
 
 class TaskCascadenceClient(BaseClient):
     """Typed convenience wrapper around the TaskCascadence API."""
@@ -48,7 +50,7 @@ class TaskCascadenceClient(BaseClient):
     def get_schedule(self, state: CLIState) -> RequestResult | None:
         """Return the current automation schedule."""
 
-        return self.request(state, "get", "/schedule", telemetry_action="get_schedule")
+        return self.request(state, "get", _SCHEDULE_PATH, telemetry_action="get_schedule")
 
     def update_schedule(self, state: CLIState, *, schedule: Mapping[str, Any]) -> RequestResult | None:
         """Update the automation schedule with ``schedule`` values."""
@@ -56,7 +58,7 @@ class TaskCascadenceClient(BaseClient):
         return self.request(
             state,
             "patch",
-            "/schedule",
+            _SCHEDULE_PATH,
             json_payload=schedule,
             telemetry_action="update_schedule",
         )

--- a/tests/test_taskcascadence_schedule.py
+++ b/tests/test_taskcascadence_schedule.py
@@ -61,6 +61,32 @@ def test_get_schedule_success(fake_http_service: dict, monkeypatch: pytest.Monke
     assert "duration_ms" in payload
 
 
+def test_update_schedule_success(fake_http_service: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fake_http_service["stub"]("patch", "/schedule", {"ok": True})
+    events = _capture_events(monkeypatch)
+
+    state = _build_state(tmp_path, dry_run=False, telemetry_enabled=True)
+    client = TaskCascadenceClient()
+
+    result = client.update_schedule(state, schedule={"timezone": "UTC"})
+
+    assert result is not None
+    assert result.payload == {"ok": True}
+
+    assert fake_http_service["calls"][0]["method"] == "patch"
+    assert fake_http_service["calls"][0]["url"].endswith("/schedule")
+    assert fake_http_service["calls"][0]["json_payload"] == {"timezone": "UTC"}
+
+    assert len(events) == 1
+    name, payload, enabled = events[0]
+    assert name == "tino_cli.taskcascadence.update_schedule"
+    assert enabled is True
+    assert payload["action"] == "update_schedule"
+    assert payload["url"].endswith("/schedule")
+    assert payload["status"] == 200
+    assert "duration_ms" in payload
+
+
 def test_update_schedule_dry_run(fake_http_service: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     events = _capture_events(monkeypatch)
 


### PR DESCRIPTION
## Summary
- add a shared schedule path helper to the TaskCascadence client and expose the schedule helpers through the clients package
- expand schedule tests to cover successful and dry-run telemetry flows

## Testing
- pytest tests/test_taskcascadence_schedule.py
- ruff check scripts/tino_cli/clients/taskcascadence.py tests/test_taskcascadence_schedule.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163ddc3bfc8326b45d63eb769d088a)