### PR TITLE
Ensure `tino down` delegates to stop services

### DIFF
--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -379,7 +379,7 @@ def cli_down(
     service: str = typer.Argument(None, help="Optional service name."),
 ) -> None:
     state = _get_state(ctx)
-    code = stop_services(state, service or None)
+    code = stop_services(state, service)
     raise typer.Exit(code)
 
 

--- a/tests/test_tino_cli_stack.py
+++ b/tests/test_tino_cli_stack.py
@@ -99,3 +99,21 @@ def test_down_command_delegates_to_stop_services(
     result = tino_cli_runner.invoke(app, ["down", "ume"])
     assert result.exit_code == 0
     assert calls == [None, "ume"]
+
+
+def test_down_command_uses_stop_services_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tino_cli_runner
+) -> None:
+    calls: list[str | None] = []
+
+    def _fake_stop(state, service: str | None = None) -> int:  # pragma: no cover - trivial
+        calls.append(service)
+        return 7
+
+    main_module = sys.modules["scripts.tino_cli.main"]
+    monkeypatch.setattr(main_module, "stop_services", _fake_stop)
+
+    result = tino_cli_runner.invoke(app, ["down"])
+
+    assert result.exit_code == 7
+    assert calls == [None]


### PR DESCRIPTION
## Summary
- update the `tino down` command to delegate directly to `stop_services`
- add a regression test ensuring the exit code from `tino down` comes from `stop_services`

## Testing
- pytest tests/test_tino_cli_stack.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163ddbf81c83268af1f7ad3b88abf5)