### PR TITLE
Update doctor command to use diagnostics summary

### DIFF
--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -28,7 +28,6 @@ from .config import (
     ServiceConfig,
     load_env_defaults,
 )
-from .doctor import gather_report
 from .doctor import gather_diagnostics
 from .plugin_loader import register_plugin_commands
 from .state import CLIState, snapshot_identity, stable_dict
@@ -115,17 +114,12 @@ def init_tooling(state: CLIState, *, quick: bool = False) -> int:
 
 
 def run_doctor(state: CLIState) -> int:
-    report = gather_report(skip_checks=state.dry_run)
-    payload = report.to_dict()
+    diagnostics = gather_diagnostics(state)
     if state.dry_run:
-        payload.setdefault("summary", {})["dry_run"] = True
-    typer.echo(json.dumps(payload, indent=2))
-    if state.dry_run:
-        return 0
-    return 0 if report.ok else 1
-    report = gather_diagnostics(state)
-    typer.echo(json.dumps(report, indent=2))
-    return 0 if report.get("summary", {}).get("status") != "error" else 1
+        diagnostics.setdefault("summary", {})["dry_run"] = True
+    typer.echo(json.dumps(diagnostics, indent=2))
+    status = diagnostics.get("summary", {}).get("status")
+    return 0 if status != "error" else 1
 
 
 def _identity_metadata() -> dict[str, str]:

--- a/tests/test_tino_cli_doctor.py
+++ b/tests/test_tino_cli_doctor.py
@@ -1,81 +1,72 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
-import pytest
 import importlib
 
-from typer.testing import CliRunner
+import pytest
 
 from scripts.tino_cli import doctor
-from scripts.tino_cli.doctor import DoctorCheck, DoctorReport
-from scripts.tino_cli.main import app
+from scripts.tino_cli.main import run_doctor
+from scripts.tino_cli.state import CLIState
 
 
-@pytest.fixture()
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-def _stub_check(name: str, ok: bool, details: dict[str, object] | None = None) -> DoctorCheck:
-    message = "ok" if ok else "error"
-    return DoctorCheck(name=name, ok=ok, message=message, details=details)
-
-
-def test_doctor_report_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    docker_check = _stub_check("docker", True, {"server_version": "25.0"})
-    ports_check = _stub_check("ports", True, {"occupied": []})
-    hooks_check = _stub_check("git-hooks", True, {"path": ".githooks"})
-
-    monkeypatch.setattr(doctor, "_check_docker_engine", lambda: docker_check)
-    monkeypatch.setattr(doctor, "_check_required_ports", lambda: ports_check)
-    monkeypatch.setattr(doctor, "_check_git_hooks", lambda: hooks_check)
-
-    report = doctor.gather_report()
-    assert report.ok is True
-
-    payload = report.to_dict()
-    assert payload["summary"] == {"ok": True, "total": 3, "passed": 3, "failed": 0}
-
-    docker_payload = next(item for item in payload["checks"] if item["name"] == "docker")
-    assert docker_payload["details"]["server_version"] == "25.0"
-
-
-def test_doctor_report_with_port_conflicts(monkeypatch: pytest.MonkeyPatch) -> None:
-    docker_check = _stub_check("docker", True, {"server_version": "25.0"})
-    ports_check = _stub_check("ports", False, {"occupied": [4222, 8080]})
-    hooks_check = _stub_check("git-hooks", True, {"path": ".githooks"})
-
-    monkeypatch.setattr(doctor, "_check_docker_engine", lambda: docker_check)
-    monkeypatch.setattr(doctor, "_check_required_ports", lambda: ports_check)
-    monkeypatch.setattr(doctor, "_check_git_hooks", lambda: hooks_check)
-
-    report = doctor.gather_report()
-    assert report.ok is False
-
-    payload = report.to_dict()
-    assert payload["summary"]["failed"] == 1
-
-    port_payload = next(item for item in payload["checks"] if item["name"] == "ports")
-    assert port_payload["details"]["occupied"] == [4222, 8080]
-
-
-def test_cli_doctor_outputs_report(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> None:
-    report = DoctorReport(
-        [
-            _stub_check("docker", True, {"server_version": "25.0"}),
-            _stub_check("ports", False, {"occupied": [4222]}),
-            _stub_check("git-hooks", True, {"path": ".githooks"}),
-        ]
+def _make_state(*, dry_run: bool = False) -> CLIState:
+    return CLIState(
+        dry_run=dry_run,
+        confirm=not dry_run,
+        telemetry_enabled=False,
+        log_path=Path("cli.log"),
+        identity={},
+        services={"docs": "http://example.invalid"},
     )
 
-    monkeypatch.setattr(doctor, "gather_report", lambda skip_checks=False: report)
+
+def test_gather_diagnostics_reports_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    docker_payload = {"status": "ok", "message": "docker ok"}
+    services_payload = {"status": "warning", "items": [{"name": "docs"}]}
+    tokens_payload = {"status": "error", "missing": ["TOKEN"]}
+    hooks_payload = {"status": "ok", "message": "hooks"}
+
+    monkeypatch.setattr(doctor, "_docker_check", lambda: docker_payload)
+    monkeypatch.setattr(
+        doctor,
+        "_service_endpoints",
+        lambda services, dry_run: services_payload,
+    )
+    monkeypatch.setattr(doctor, "_env_tokens_check", lambda: tokens_payload)
+    monkeypatch.setattr(doctor, "_git_hooks_check", lambda: hooks_payload)
+
+    report = doctor.gather_diagnostics(_make_state())
+
+    assert report["summary"] == {"status": "error", "errors": 1, "warnings": 1}
+    assert report["checks"] == {
+        "docker": docker_payload,
+        "services": services_payload,
+        "env_tokens": tokens_payload,
+        "git_hooks": hooks_payload,
+    }
+
+
+def test_run_doctor_dry_run_reports_flag(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    diagnostics = {
+        "dry_run": True,
+        "confirm": False,
+        "summary": {"status": "ok", "errors": 0, "warnings": 0},
+        "checks": {"docker": {"status": "ok"}},
+    }
+
+    monkeypatch.setattr(doctor, "gather_diagnostics", lambda state: dict(diagnostics))
     main_module = importlib.import_module("scripts.tino_cli.main")
-    monkeypatch.setattr(main_module, "gather_report", lambda skip_checks=False: report)
+    monkeypatch.setattr(main_module, "gather_diagnostics", lambda state: dict(diagnostics))
 
-    result = runner.invoke(app, ["doctor"])
-    assert result.exit_code == 1
+    code = run_doctor(_make_state(dry_run=True))
 
-    payload = json.loads(result.stdout)
-    assert payload["summary"]["failed"] == 1
-    assert any(item["name"] == "ports" for item in payload["checks"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["summary"]["dry_run"] is True
+    assert payload["checks"]["docker"] == {"status": "ok"}

--- a/tests/test_tino_docs_publish.py
+++ b/tests/test_tino_docs_publish.py
@@ -4,8 +4,12 @@ import json
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from typer.testing import CliRunner
 
 if "scripts.tino_cli.doctor" not in sys.modules:
     _doctor_stub = ModuleType("scripts.tino_cli.doctor")
@@ -15,7 +19,7 @@ if "scripts.tino_cli.doctor" not in sys.modules:
             return {}
 
     _doctor_stub.gather_report = lambda skip_checks=False: _Report()
-    _doctor_stub.gather_diagnostics = lambda: []
+    _doctor_stub.gather_diagnostics = lambda *args, **kwargs: []
     sys.modules["scripts.tino_cli.doctor"] = _doctor_stub
 
 from scripts.tino_cli.clients.docs import DocsClient


### PR DESCRIPTION
## Summary
- switch the `tino doctor` command to call `gather_diagnostics`, preserve the dry-run annotation, and derive the exit code from the new summary status
- rework `tests/test_tino_cli_doctor.py` to assert the new diagnostics payload shape and cover the dry-run output path
- keep the docs publish fixture in sync with the doctor stub so other tests still import the expected symbols

## Testing
- pytest tests/test_tino_cli_doctor.py
- ruff check scripts/tino_cli/main.py tests/test_tino_cli_doctor.py tests/test_tino_docs_publish.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd67d58a08326a3fe45414fbfe1df)