### PR TITLE
Add task schedule CLI commands

### DIFF
--- a/scripts/tino_cli/main.py
+++ b/scripts/tino_cli/main.py
@@ -18,6 +18,8 @@ from .clients import (
     StormClient,
     TaskCascadenceClient,
     UMEClient,
+    get_schedule,
+    update_schedule,
 )
 from .config import (
     DOCS,
@@ -387,6 +389,53 @@ def cli_logs(ctx: typer.Context, service: str = typer.Argument(..., help="Servic
 task_app = typer.Typer(help="Interact with TaskCascadence services.")
 
 
+schedule_app = typer.Typer(help="Inspect and manage task automation schedules.")
+
+
+@schedule_app.command("list")
+def task_schedule_list(ctx: typer.Context) -> None:
+    """Fetch the configured automation schedule."""
+
+    state = _get_state(ctx)
+    result = get_schedule(state)
+    _render_response(result)
+
+
+def _parse_schedule_payload(value: str) -> Mapping[str, object]:
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as exc:  # noqa: PERF203 - typer error construction is cheap
+        raise typer.BadParameter("Schedule payload must be valid JSON.") from exc
+    if not isinstance(payload, Mapping):
+        raise typer.BadParameter("Schedule payload must be a JSON object.")
+    return payload
+
+
+@schedule_app.command("update")
+def task_schedule_update(
+    ctx: typer.Context,
+    schedule: str = typer.Option(..., "--schedule", "--json", help="JSON schedule payload."),
+) -> None:
+    """Update the automation schedule via the TaskCascadence API."""
+
+    state = _get_state(ctx)
+    payload = _parse_schedule_payload(schedule)
+
+    if state.dry_run:
+        typer.echo("[dry-run] Preview schedule update payload:")
+        typer.echo(json.dumps(payload, indent=2))
+        result = update_schedule(state, schedule=payload)
+        _render_response(result)
+        return
+
+    if not state.confirm:
+        typer.echo("Use --confirm to update the automation schedule.", err=True)
+        raise typer.Exit(1)
+
+    result = update_schedule(state, schedule=payload)
+    _render_response(result)
+
+
 @task_app.command("run")
 def task_run(
     ctx: typer.Context,
@@ -444,6 +493,8 @@ def task_signal(
     )
     _render_response(result)
 
+
+task_app.add_typer(schedule_app, name="schedule")
 
 app.add_typer(task_app, name="task")
 

--- a/tests/test_tino_cli_schedule.py
+++ b/tests/test_tino_cli_schedule.py
@@ -1,0 +1,121 @@
+"""CLI coverage for ``tino task schedule`` commands."""
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+tino_cli_main = importlib.import_module("scripts.tino_cli.main")
+app = tino_cli_main.app
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _setup_cli_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parent.parent
+    monkeypatch.chdir(project_root)
+    monkeypatch.setenv("TINO_CLI_LOG", str(tmp_path / "tino-cli.log"))
+
+
+def test_task_schedule_list_uses_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, runner: CliRunner) -> None:
+    _setup_cli_env(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_get_schedule(state):  # type: ignore[no-untyped-def]
+        captured["state"] = state
+        return {"items": ["alpha"]}
+
+    monkeypatch.setattr(tino_cli_main, "get_schedule", fake_get_schedule)
+
+    result = runner.invoke(app, ["task", "schedule", "list"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"items": ["alpha"]}
+    assert "state" in captured
+
+
+def test_task_schedule_update_requires_confirm(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    runner: CliRunner,
+) -> None:
+    _setup_cli_env(monkeypatch, tmp_path)
+
+    called: dict[str, object] = {}
+
+    def fake_update_schedule(state, *, schedule):  # type: ignore[no-untyped-def]
+        called["schedule"] = schedule
+        return {"ok": True}
+
+    monkeypatch.setattr(tino_cli_main, "update_schedule", fake_update_schedule)
+
+    result = runner.invoke(
+        app,
+        ["task", "schedule", "update", "--schedule", json.dumps({"timezone": "UTC"})],
+    )
+
+    assert result.exit_code == 1
+    assert "Use --confirm" in result.output
+    assert called == {}
+
+
+def test_task_schedule_update_dry_run_preview(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    runner: CliRunner,
+) -> None:
+    _setup_cli_env(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_update_schedule(state, *, schedule):  # type: ignore[no-untyped-def]
+        captured["dry_run"] = state.dry_run
+        captured["schedule"] = schedule
+        return None
+
+    monkeypatch.setattr(tino_cli_main, "update_schedule", fake_update_schedule)
+
+    payload = {"timezone": "UTC", "windows": ["nightly"]}
+    result = runner.invoke(
+        app,
+        ["--dry-run", "task", "schedule", "update", "--schedule", json.dumps(payload)],
+    )
+
+    assert result.exit_code == 0
+    assert "[dry-run] Preview schedule update payload" in result.output
+    assert json.dumps(payload, indent=2) in result.output
+    assert captured == {"dry_run": True, "schedule": payload}
+
+
+def test_task_schedule_update_executes_with_confirm(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    runner: CliRunner,
+) -> None:
+    _setup_cli_env(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_update_schedule(state, *, schedule):  # type: ignore[no-untyped-def]
+        captured["confirm"] = state.confirm
+        captured["schedule"] = schedule
+        return {"ok": True}
+
+    monkeypatch.setattr(tino_cli_main, "update_schedule", fake_update_schedule)
+
+    payload = {"timezone": "UTC"}
+    result = runner.invoke(
+        app,
+        ["--confirm", "task", "schedule", "update", "--schedule", json.dumps(payload)],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"ok": True}
+    assert captured == {"confirm": True, "schedule": payload}


### PR DESCRIPTION
## Summary
- add a nested `task schedule` Typer sub-application for listing and updating TaskCascadence schedules
- validate JSON payloads, require confirmation for updates, and surface dry-run previews before calling the client helper
- cover the new CLI surface with tests that exercise list, dry-run, and confirmation behaviours

## Testing
- pytest tests/test_tino_cli_schedule.py
- ruff check scripts/tino_cli/main.py tests/test_tino_cli_schedule.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddf9c1594832682812cbc050730f3)