### PR TITLE
Validate plugin registry loading and add telemetry logging

### DIFF
--- a/scripts/tino_cli/plugin_loader.py
+++ b/scripts/tino_cli/plugin_loader.py
@@ -11,6 +11,7 @@ from typing import Callable, Iterator, List, Optional
 import typer
 
 from scripts import plugins
+from telemetry import analytics_default, record_event
 
 from .executor import execute_command
 from .state import CLIState
@@ -33,17 +34,57 @@ class PluginCommand:
     package: str | None = None
 
 
-def _load_registry(path: Path = REGISTRY_PATH) -> plugins.PluginRegistryData | None:
+def _load_registry(path: Path | None = None) -> plugins.PluginRegistryData | None:
+    path = path or REGISTRY_PATH
     if not path.exists():
+        typer.echo(f"Plug-in registry not found at {path}.", err=True)
+        record_event(
+            "plugin_registry",
+            {"status": "missing", "path": str(path)},
+            enabled=analytics_default(),
+        )
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as exc:
+        typer.echo(f"Failed to load plug-in registry at {path}: {exc}", err=True)
+        record_event(
+            "plugin_registry",
+            {"status": "invalid", "reason": "read_error", "detail": str(exc)},
+            enabled=analytics_default(),
+        )
+        return None
+    try:
+        plugins.validate_registry_payload(payload)
+    except Exception as exc:
+        detail = getattr(exc, "message", None) or str(exc)
+        location = getattr(exc, "json_path", None) or getattr(exc, "path", None)
+        context = f" at {location}" if location else ""
+        typer.echo(
+            f"Invalid plug-in registry schema{context}: {detail}.",
+            err=True,
+        )
+        record_event(
+            "plugin_registry",
+            {
+                "status": "invalid",
+                "reason": "schema_validation",
+                "detail": detail,
+                "location": str(location) if location else None,
+            },
+            enabled=analytics_default(),
+        )
         return None
     try:
         return plugins.parse_registry_payload(payload)
-    except Exception:
-        return None
+    except Exception as exc:
+        typer.echo(f"Failed to parse plug-in registry: {exc}", err=True)
+        record_event(
+            "plugin_registry",
+            {"status": "invalid", "reason": "parse_error", "detail": str(exc)},
+            enabled=analytics_default(),
+        )
+    return None
 
 
 def _import_callable(qualname: str) -> Callable[[tuple[str, ...]], int] | None:
@@ -203,6 +244,11 @@ def _register_registry_commands(app: typer.Typer, registry: plugins.PluginRegist
         app.command(descriptor.name, help=help_text)(
             _wrap_exec(descriptor.exec, command_name=descriptor.name)
         )
+        record_event(
+            "plugin_command_registration",
+            {"plugin": "registry", "command": descriptor.name, "status": "registered"},
+            enabled=analytics_default(),
+        )
 
 
 def register_plugin_commands(app: typer.Typer) -> None:
@@ -222,6 +268,16 @@ def register_plugin_commands(app: typer.Typer) -> None:
             plugin_app.command("install", help=_fallback_message(plugin, package.package))(
                 _wrap_fallback(plugin, package.package, command_name="install")
             )
+            record_event(
+                "plugin_command_registration",
+                {
+                    "plugin": plugin,
+                    "command": "install",
+                    "status": "fallback",
+                    "reason": "no_cli_commands",
+                },
+                enabled=analytics_default(),
+            )
             app.add_typer(plugin_app, name=plugin)
             continue
         for descriptor in commands:
@@ -230,15 +286,45 @@ def register_plugin_commands(app: typer.Typer) -> None:
                 plugin_app.command(descriptor.name, help=help_text)(
                     _wrap_exec(descriptor.exec, command_name=descriptor.name)
                 )
+                record_event(
+                    "plugin_command_registration",
+                    {
+                        "plugin": plugin,
+                        "command": descriptor.name,
+                        "status": "registered",
+                        "source": "exec",
+                    },
+                    enabled=analytics_default(),
+                )
                 continue
             handler = _import_callable(descriptor.callable) if descriptor.callable else None
             if handler is None:
                 plugin_app.command(descriptor.name, help=help_text)(
                     _wrap_fallback(plugin, package.package, command_name=descriptor.name)
                 )
+                record_event(
+                    "plugin_command_registration",
+                    {
+                        "plugin": plugin,
+                        "command": descriptor.name,
+                        "status": "skipped",
+                        "reason": "missing_callable",
+                    },
+                    enabled=analytics_default(),
+                )
                 continue
             plugin_app.command(descriptor.name, help=help_text)(
                 _wrap_callable(handler, command_name=descriptor.name)
+            )
+            record_event(
+                "plugin_command_registration",
+                {
+                    "plugin": plugin,
+                    "command": descriptor.name,
+                    "status": "registered",
+                    "source": "callable",
+                },
+                enabled=analytics_default(),
             )
         app.add_typer(plugin_app, name=plugin)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,26 @@ from urllib.parse import urlparse
 
 import pytest
 import requests
-from typer.testing import CliRunner
+
+_site_packages = (
+    Path(sys.executable).resolve().parent.parent
+    / "lib"
+    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+_typer_init = _site_packages / "typer" / "__init__.py"
+_typer_spec = importlib.util.spec_from_file_location("typer", _typer_init)
+if _typer_spec and _typer_spec.loader:
+    sys.modules.pop("typer", None)
+    for _name in list(sys.modules):
+        if _name.startswith("typer."):
+            sys.modules.pop(_name, None)
+    _typer_module = importlib.util.module_from_spec(_typer_spec)
+    _typer_module.__path__ = [str(_typer_init.parent)]
+    sys.modules["typer"] = _typer_module
+    _typer_spec.loader.exec_module(_typer_module)
+
+from typer.testing import CliRunner  # noqa: E402
 
 if importlib.util.find_spec("llm") is None:
     # Ensure the repository root is on sys.path when running tests directly

--- a/tests/test_plugin_loader_validation.py
+++ b/tests/test_plugin_loader_validation.py
@@ -1,0 +1,116 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_site_packages = (
+    Path(sys.executable).resolve().parent.parent
+    / "lib"
+    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+_typer_init = _site_packages / "typer" / "__init__.py"
+_typer_spec = importlib.util.spec_from_file_location("typer", _typer_init)
+if _typer_spec and _typer_spec.loader:
+    _typer_module = importlib.util.module_from_spec(_typer_spec)
+    _typer_spec.loader.exec_module(_typer_module)
+    sys.modules["typer"] = _typer_module
+
+import typer  # noqa: E402
+from scripts.tino_cli import plugin_loader  # noqa: E402
+from tests import stubs  # noqa: E402
+
+
+def _registry_payload() -> dict[str, object]:
+    return {
+        "name": "test-registry",
+        "version": "1",
+        "commands": [
+            {"name": "demo:exec", "help": "Demo exec", "exec": "echo demo"},
+        ],
+        "taskTemplates": [],
+        "plugins": {
+            "demo": {
+                "package": "demo-pkg",
+                "cli": {
+                    "help": "Demo plug-in",
+                    "commands": [
+                        {
+                            "name": "hello",
+                            "help": "Say hello",
+                            "callable": "tests.stubs:plugin_command",
+                        }
+                    ],
+                },
+            }
+        },
+        "recipes": {},
+        "recipe_configs": {},
+    }
+
+
+def test_register_plugin_commands_logs_events(monkeypatch, tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    payload = _registry_payload()
+    registry_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(plugin_loader, "REGISTRY_PATH", registry_path)
+    monkeypatch.setattr(plugin_loader, "analytics_default", lambda: True)
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def _record(name: str, payload: dict[str, object], *, enabled: bool = False) -> bool:
+        events.append((name, payload))
+        return enabled
+
+    monkeypatch.setattr(plugin_loader, "record_event", _record)
+    stubs.plugin_command.calls = []  # type: ignore[attr-defined]
+
+    app = typer.Typer()
+    plugin_loader.register_plugin_commands(app)
+
+    commands = {(payload["plugin"], payload["command"]): payload for _, payload in events}
+    assert ("registry", "demo:exec") in commands
+    assert commands[("registry", "demo:exec")]["status"] == "registered"
+    assert commands[("demo", "hello")]["status"] == "registered"
+
+
+def test_load_registry_reports_schema_errors(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(plugin_loader, "REGISTRY_PATH", registry_path)
+    monkeypatch.setattr(plugin_loader, "analytics_default", lambda: True)
+
+    events: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        plugin_loader,
+        "record_event",
+        lambda _name, payload, *, enabled=False: events.append(payload),
+    )
+
+    assert plugin_loader._load_registry(registry_path) is None
+    captured = capsys.readouterr()
+    assert "Invalid plug-in registry schema" in captured.err
+    assert any(event.get("status") == "invalid" for event in events)
+
+
+def test_load_registry_handles_missing_file(monkeypatch, tmp_path: Path, capsys) -> None:
+    registry_path = tmp_path / "missing.json"
+
+    monkeypatch.setattr(plugin_loader, "REGISTRY_PATH", registry_path)
+    monkeypatch.setattr(plugin_loader, "analytics_default", lambda: True)
+
+    events: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        plugin_loader,
+        "record_event",
+        lambda _name, payload, *, enabled=False: events.append(payload),
+    )
+
+    assert plugin_loader._load_registry(registry_path) is None
+    captured = capsys.readouterr()
+    assert "Plug-in registry not found" in captured.err
+    assert any(event.get("status") == "missing" for event in events)


### PR DESCRIPTION
## Summary
- validate the CLI plugin registry against the schema before loading and emit actionable errors when problems are found
- record telemetry-friendly events whenever plugin commands are registered, skipped, or fall back to installers
- add unit coverage for valid, invalid, and missing registry files while ensuring tests use the real Typer implementation

## Testing
- python -m ruff check scripts/tino_cli/plugin_loader.py tests/test_plugin_loader_validation.py tests/conftest.py
- python -m pytest tests/test_plugin_loader_validation.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938298f29208326854fe37e5b23d4c4)