### PR TITLE
Add CLI and plugin loader test coverage

### DIFF
--- a/tests/test_plugin_loader_branches.py
+++ b/tests/test_plugin_loader_branches.py
@@ -1,0 +1,105 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# Load Typer in isolation to satisfy plugin_loader import
+_site_packages = (
+    Path(sys.executable).resolve().parent.parent
+    / "lib"
+    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+_typer_init = _site_packages / "typer" / "__init__.py"
+_typer_spec = importlib.util.spec_from_file_location("typer", _typer_init)
+if _typer_spec and _typer_spec.loader:
+    _typer_module = importlib.util.module_from_spec(_typer_spec)
+    _typer_spec.loader.exec_module(_typer_module)
+    sys.modules["typer"] = _typer_module
+
+import typer  # noqa: E402
+from scripts.tino_cli import plugin_loader  # noqa: E402
+
+
+@pytest.fixture()
+def registry_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.json"
+
+
+def _write_registry(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _base_registry() -> dict[str, Any]:
+    return {
+        "name": "test-registry",
+        "version": "1",
+        "commands": [],
+        "taskTemplates": [],
+        "plugins": {},
+        "recipes": {},
+        "recipe_configs": {},
+    }
+
+
+def test_load_registry_reports_parse_errors(monkeypatch, registry_path: Path, capsys) -> None:
+    registry_path.write_text("{not-json]", encoding="utf-8")
+    events: list[dict[str, object]] = []
+
+    monkeypatch.setattr(plugin_loader, "REGISTRY_PATH", registry_path)
+    monkeypatch.setattr(plugin_loader, "analytics_default", lambda: True)
+    monkeypatch.setattr(
+        plugin_loader,
+        "record_event",
+        lambda _name, payload, *, enabled=False: events.append(payload),
+    )
+
+    assert plugin_loader._load_registry(registry_path) is None
+    captured = capsys.readouterr()
+    assert "Failed to load plug-in registry" in captured.err
+    assert any(item.get("reason") == "read_error" for item in events)
+
+
+def test_iter_plugin_commands_returns_empty_when_missing(monkeypatch, registry_path: Path, capsys) -> None:
+    monkeypatch.setattr(plugin_loader, "REGISTRY_PATH", registry_path)
+    monkeypatch.setattr(plugin_loader, "analytics_default", lambda: False)
+    commands = list(plugin_loader.iter_plugin_commands())
+
+    captured = capsys.readouterr()
+    assert commands == []
+    assert "Plug-in registry not found" in captured.err
+
+
+def test_register_plugin_commands_uses_fallback_for_missing_callable(monkeypatch, registry_path: Path, tino_cli_runner) -> None:
+    payload = _base_registry()
+    payload["plugins"] = {
+        "demo": {
+            "package": "demo-package",
+            "cli": {
+                "commands": [
+                    {
+                        "name": "hello",
+                        "help": "say hello",
+                        "callable": "tests.missing:handler",
+                    }
+                ]
+            },
+        }
+    }
+
+    _write_registry(registry_path, payload)
+    monkeypatch.setattr(plugin_loader, "REGISTRY_PATH", registry_path)
+    monkeypatch.setattr(plugin_loader, "analytics_default", lambda: False)
+    monkeypatch.setattr(plugin_loader, "record_event", lambda *_args, **_kwargs: None)
+
+    app = typer.Typer()
+    plugin_loader.register_plugin_commands(app)
+
+    result = tino_cli_runner.invoke(app, ["demo", "hello"])
+
+    assert result.exit_code == 1
+    assert "The 'demo' plug-in is not installed" in result.stderr

--- a/tests/test_tino_cli_main_state.py
+++ b/tests/test_tino_cli_main_state.py
@@ -1,0 +1,204 @@
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# Ensure Typer is importable in isolation
+_site_packages = (
+    Path(sys.executable).resolve().parent.parent
+    / "lib"
+    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+_typer_init = _site_packages / "typer" / "__init__.py"
+_typer_spec = importlib.util.spec_from_file_location("typer", _typer_init)
+if _typer_spec and _typer_spec.loader:
+    _typer_module = importlib.util.module_from_spec(_typer_spec)
+    _typer_spec.loader.exec_module(_typer_module)
+    sys.modules["typer"] = _typer_module
+
+import typer  # noqa: E402
+from scripts.tino_cli.main import (  # noqa: E402
+    API_URL_ENV,
+    CLIState,
+    app,
+    build_state,
+    compose_command,
+    run_shell_command,
+    show_whoami,
+)
+
+main_module = importlib.import_module("scripts.tino_cli.main")
+
+
+@pytest.fixture()
+def _test_state(tmp_path: Path) -> CLIState:
+    return CLIState(
+        dry_run=False,
+        confirm=False,
+        telemetry_enabled=False,
+        log_path=tmp_path / "log.txt",
+        identity={},
+        services={},
+    )
+
+
+def test_build_state_populates_identity_and_services(monkeypatch, tmp_path: Path) -> None:
+    called: dict[str, Any] = {}
+    monkeypatch.setenv("TINO_CLI_LOG", str(tmp_path / "custom.log"))
+
+    monkeypatch.setattr(main_module, "load_env_defaults", lambda: called.setdefault("load_env", True))
+    monkeypatch.setattr(main_module, "snapshot_identity", lambda: {"USER": "alice"})
+    monkeypatch.setattr(main_module, "analytics_default", lambda: True)
+
+    class _Service:
+        def __init__(self, value: str) -> None:
+            self._value = value
+
+        def resolve(self) -> str:
+            return self._value
+
+    monkeypatch.setattr(
+        main_module,
+        "_SERVICE_CONFIGS",
+        (("svc", _Service("http://service")),),
+    )
+
+    state = build_state(dry_run=True, confirm=True)
+
+    assert state.dry_run is True
+    assert state.confirm is True
+    assert state.telemetry_enabled is True
+    assert state.identity == {"USER": "alice"}
+    assert state.services == {"svc": "http://service"}
+    assert state.log_path == tmp_path / "custom.log"
+    assert called["load_env"] is True
+
+
+def test_show_whoami_merges_identity_and_endpoints(monkeypatch, _test_state: CLIState) -> None:
+    monkeypatch.setenv("USER", "env-user")
+    monkeypatch.setenv("GROUP", "devs")
+    monkeypatch.setenv("EMAIL", "me@example.com")
+    monkeypatch.setenv(API_URL_ENV, "https://api.example.com")
+    monkeypatch.setenv("EVENTS_URL", "https://events.example.com")
+
+    monkeypatch.setattr(main_module, "load_env_defaults", lambda: None)
+
+    state = _test_state
+    state.telemetry_enabled = True
+    state.confirm = True
+    state.identity = {"SYSTEM_USER": "system"}
+    state.services = {"svc": "https://svc"}
+
+    whoami = show_whoami(state)
+
+    assert whoami["confirm"] is True
+    assert whoami["telemetry"] == {
+        "enabled": True,
+        "endpoint": "https://events.example.com",
+    }
+    assert whoami["log_path"].endswith("log.txt")
+    assert whoami["endpoints"]["api"] == "https://api.example.com"
+    assert whoami["identity"] == {
+        "email": "me@example.com",
+        "group": "devs",
+        "SYSTEM_USER": "system",
+        "user": "env-user",
+    }
+    assert whoami["services"] == {"svc": "https://svc"}
+
+
+def test_run_shell_command_respects_dry_run(monkeypatch, capsys, _test_state: CLIState) -> None:
+    state = _test_state
+    state.dry_run = True
+
+    result = run_shell_command(state, ["echo", "hello"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "[dry-run] echo hello" in captured.out
+
+
+def test_run_shell_command_requires_confirmation(monkeypatch, capsys, _test_state: CLIState) -> None:
+    state = _test_state
+    confirm_message = "need --confirm"
+
+    result = run_shell_command(state, ["echo", "hi"], require_confirm=True, confirm_message=confirm_message)
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert confirm_message in captured.err
+
+
+def test_run_shell_command_invokes_subprocess(monkeypatch, _test_state: CLIState) -> None:
+    state = _test_state
+    state.confirm = True
+    calls: list[list[str]] = []
+    monkeypatch.setattr(main_module.subprocess, "call", lambda cmd: calls.append(cmd) or 3)
+
+    assert run_shell_command(state, ["doit"]) == 3
+    assert calls == [["doit"]]
+
+
+def test_compose_command_generates_tuple() -> None:
+    assert compose_command("up", "-d") == (
+        "docker",
+        "compose",
+        "-f",
+        "docker-compose.yml",
+        "up",
+        "-d",
+    )
+
+
+def test_schedule_list_uses_shared_state(monkeypatch, _test_state: CLIState) -> None:
+    responses: list[Any] = []
+    monkeypatch.setattr(main_module, "_render_response", lambda payload: responses.append(payload))
+    monkeypatch.setattr(main_module, "get_schedule", lambda state: {"state": state.confirm})
+
+    ctx = types.SimpleNamespace(obj=_test_state)
+    main_module.task_schedule_list(ctx)
+
+    assert responses == [{"state": False}]
+
+
+def test_schedule_update_enforces_confirm(monkeypatch, _test_state: CLIState) -> None:
+    called: list[dict[str, Any]] = []
+    monkeypatch.setattr(main_module, "update_schedule", lambda state, schedule: called.append({"state": state, "schedule": schedule}))
+
+    ctx = types.SimpleNamespace(obj=_test_state)
+    with pytest.raises(typer.Exit) as excinfo:
+        main_module.task_schedule_update(ctx, schedule="{}")
+
+    assert excinfo.value.exit_code == 1
+    assert called == []
+
+
+def test_schedule_update_dry_run_previews_payload(monkeypatch, capsys, _test_state: CLIState) -> None:
+    _test_state.dry_run = True
+
+    calls: list[dict[str, Any]] = []
+
+    def _update(state, schedule):
+        calls.append({"state": state.confirm, "schedule": schedule})
+        return {"ok": True, "schedule": schedule}
+
+    monkeypatch.setattr(main_module, "update_schedule", _update)
+
+    ctx = types.SimpleNamespace(obj=_test_state)
+    main_module.task_schedule_update(ctx, schedule="{\"foo\": 1}")
+
+    captured = capsys.readouterr()
+    assert calls == [{"state": False, "schedule": {"foo": 1}}]
+    assert "[dry-run] Preview schedule update payload:" in captured.out
+    rendered = captured.out.split("[dry-run] Preview schedule update payload:\n", 1)[1]
+    decoder = json.JSONDecoder()
+    payload, offset = decoder.raw_decode(rendered)
+    response, _ = decoder.raw_decode(rendered[offset:].lstrip())
+    assert payload == {"foo": 1}
+    assert response == {"ok": True, "schedule": {"foo": 1}}


### PR DESCRIPTION
## Summary
- add tests covering CLI state construction, whoami output, command execution flags, compose helper, and schedule operations
- add plugin loader tests for registry parse failures, missing registries, and fallback messaging

## Testing
- pytest tests/test_tino_cli_main_state.py tests/test_plugin_loader_branches.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694420e9320c8326beb782e41525ac9a)