### PR TITLE
Add zsh-focused shell dotfiles and update WSL setup to prefer zsh

### DIFF
--- a/dotfiles/common/.bashrc
+++ b/dotfiles/common/.bashrc
@@ -1,21 +1,13 @@
-# Basic shell settings that should work everywhere
+# Bash compatibility shim.
+# d0tTino uses zsh as the primary interactive shell configuration.
 
-# Only continue if running interactively
 case $- in
-    *i*) ;;
-      *) return ;;
+    *i*)
+        if [ -n "${BASH_VERSION:-}" ]; then
+            printf 'This environment is configured for zsh. Run `zsh` or set it as your login shell.\n' >&2
+        fi
+        ;;
+    *)
+        return
+        ;;
 esac
-
-# History settings
-export HISTSIZE=1000
-export HISTFILESIZE=2000
-export HISTCONTROL=ignoredups:erasedups
-shopt -s histappend
-
-# Useful aliases
-alias ll='ls -alF'
-alias la='ls -A'
-alias l='ls -CF'
-
-# Simple prompt
-PS1='\u@\h:\w\$ '

--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -1,0 +1,17 @@
+autoload -Uz compinit && compinit -d "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump"
+
+ZSH_PLUGIN_DIR="${ZSH_PLUGIN_DIR:-$HOME/.local/share/zsh/plugins}"
+
+if [[ -r "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
+    source "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
+fi
+
+if [[ -r "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
+    source "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+fi
+
+eval "$(starship init zsh)"
+
+if command -v zoxide >/dev/null; then
+    eval "$(zoxide init zsh)"
+fi

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -30,7 +30,8 @@ sudo apt-get install -y \
     build-essential \
     starship \
     zoxide \
-    curl
+    curl \
+    zsh
 
 # Verify that curl is available; exit with a helpful message if not.
 if ! command -v curl >/dev/null; then
@@ -64,6 +65,12 @@ if ! command -v zoxide >/dev/null; then
     fi
 fi
 
+# Ensure zsh is available.
+if ! command -v zsh >/dev/null; then
+    echo "Error: zsh installation failed." >&2
+    exit 1
+fi
+
 # Provide helpful symlinks for batcat and fdfind if they exist
 if command -v batcat >/dev/null && ! command -v bat >/dev/null; then
     sudo ln -sf "$(command -v batcat)" /usr/local/bin/bat
@@ -72,22 +79,15 @@ if command -v fdfind >/dev/null && ! command -v fd >/dev/null; then
     sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 fi
 
-# Add starship and zoxide initialization to ~/.bashrc if missing
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-bashrc="$HOME/.bashrc"
-if [ ! -f "$bashrc" ]; then
-    touch "$bashrc"
-fi
-if ! grep -Fq 'starship init bash' "$bashrc" 2>/dev/null; then
-    starship_config_path="$repo_root/starship.toml"
-    {
-        printf 'starship_config="%s"\n' "$starship_config_path"
-        printf 'if command -v starship >/dev/null; then\n'
-        printf '    eval "$(starship init bash --config \"$starship_config\")"\n'
-        printf 'fi\n'
-        printf 'if command -v zoxide >/dev/null; then\n'
-        printf '    eval "$(zoxide init bash)"\n'
-        printf 'fi\n'
-    } >>"$bashrc"
+# Set zsh as the default shell only when it is not already the login shell.
+zsh_path="$(command -v zsh)"
+if command -v chsh >/dev/null; then
+    current_shell="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7 || true)"
+    if [ -z "$current_shell" ]; then
+        current_shell="${SHELL:-}"
+    fi
 
+    if [ "$current_shell" != "$zsh_path" ]; then
+        chsh -s "$zsh_path"
+    fi
 fi

--- a/tests/test_setup_wsl.py
+++ b/tests/test_setup_wsl.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+
 def create_exe(path, contents="#!/usr/bin/env bash\n"):
     path.write_text(contents)
     path.chmod(0o755)
@@ -18,16 +19,22 @@ def test_setup_wsl_symlinks(tmp_path):
 
     # Stub commands
     apt_log = fake_root / "apt_history"
-    apt_stub = f"#!/usr/bin/env bash\n" \
-               f"echo \"$@\" >> \"{apt_log}\"\n" \
-               "if [[ $1 == install ]]; then\n" \
-               f"  touch {bin_dir}/starship {bin_dir}/zoxide\n" \
-               f"  chmod 755 {bin_dir}/starship {bin_dir}/zoxide\n" \
-               "fi\n"
+    apt_stub = (
+        "#!/usr/bin/env bash\n"
+        f"echo \"$@\" >> \"{apt_log}\"\n"
+        "if [[ $1 == install ]]; then\n"
+        f"  touch {bin_dir}/starship {bin_dir}/zoxide {bin_dir}/zsh\n"
+        f"  chmod 755 {bin_dir}/starship {bin_dir}/zoxide {bin_dir}/zsh\n"
+        "fi\n"
+    )
     create_exe(bin_dir / "apt-get", apt_stub)
     create_exe(bin_dir / "sudo", "#!/bin/sh\n\"$@\"\n")
     create_exe(bin_dir / "batcat")
     create_exe(bin_dir / "fdfind")
+    create_exe(bin_dir / "getent", "#!/usr/bin/env bash\necho \"$2:x:1000:1000::/home/$2:/bin/bash\"\n")
+    chsh_log = fake_root / "chsh_history"
+    create_exe(bin_dir / "chsh", f"#!/usr/bin/env bash\necho \"$@\" >> \"{chsh_log}\"\n")
+
     # ln wrapper that redirects /usr/local/bin to FAKE_ROOT
     ln_script = """#!/usr/bin/env bash
 last=${@: -1}
@@ -43,7 +50,7 @@ fi
 
     env = os.environ.copy()
     env.update({
-        "PATH": f"{bin_dir}:{env['PATH']}",
+        "PATH": f"{bin_dir}:/bin",
         "FAKE_ROOT": str(fake_root),
         "HOME": str(fake_root),
     })
@@ -75,14 +82,47 @@ fi
         "build-essential",
         "starship",
         "zoxide",
+        "zsh",
     ]
     for pkg in required:
         assert pkg in install_args
 
-    bashrc = fake_root / ".bashrc"
-    bash_text = bashrc.read_text()
-    assert "starship init bash" in bash_text
-    assert "zoxide init bash" in bash_text
+    assert chsh_log.read_text().strip() == f"-s {bin_dir / 'zsh'}"
+    assert not (fake_root / ".bashrc").exists()
+
+
+def test_setup_wsl_skips_chsh_when_zsh_is_already_default(tmp_path):
+    fake_root = tmp_path
+    bin_dir = fake_root / "bin"
+    bin_dir.mkdir(parents=True)
+
+    create_exe(bin_dir / "apt-get", "#!/usr/bin/env bash\nexit 0\n")
+    create_exe(bin_dir / "sudo", "#!/bin/sh\n\"$@\"\n")
+    create_exe(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "starship", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zoxide", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zsh", "#!/bin/sh\nexit 0\n")
+    create_exe(
+        bin_dir / "getent",
+        f"#!/usr/bin/env bash\necho \"$2:x:1000:1000::/home/$2:{bin_dir / 'zsh'}\"\n",
+    )
+    chsh_log = fake_root / "chsh_history"
+    create_exe(bin_dir / "chsh", f"#!/usr/bin/env bash\necho \"$@\" >> \"{chsh_log}\"\n")
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:/bin",
+        "HOME": str(fake_root),
+    })
+
+    subprocess.run(
+        ["/bin/bash", str(REPO_ROOT / "scripts" / "setup-wsl.sh")],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert not chsh_log.exists()
 
 
 def test_setup_wsl_requires_sudo(tmp_path):
@@ -95,6 +135,7 @@ def test_setup_wsl_requires_sudo(tmp_path):
     create_exe(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "starship", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "zoxide", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zsh", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "id", "#!/bin/sh\necho 1000\n")
 
     (bin_dir / "grep").symlink_to("/usr/bin/grep")
@@ -126,6 +167,7 @@ def test_setup_wsl_root_without_sudo(tmp_path):
     create_exe(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "starship", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "zoxide", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zsh", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "id", "#!/bin/sh\necho 0\n")
 
     (bin_dir / "grep").symlink_to("/usr/bin/grep")
@@ -152,6 +194,7 @@ def test_setup_wsl_requires_apt_get(tmp_path):
     create_exe(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "starship", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "zoxide", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zsh", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "id", "#!/bin/sh\necho 0\n")
 
     (bin_dir / "grep").symlink_to("/usr/bin/grep")
@@ -186,6 +229,7 @@ def test_setup_wsl_starship_install_failure(tmp_path):
     create_exe(bin_dir / "apt-get", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "sudo", "#!/bin/sh\n\"$@\"\n")
     create_exe(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zsh", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "id", "#!/bin/sh\necho 0\n")
 
     (bin_dir / "grep").symlink_to("/usr/bin/grep")
@@ -222,6 +266,7 @@ def test_setup_wsl_zoxide_install_failure(tmp_path):
     create_exe(bin_dir / "sudo", "#!/bin/sh\n\"$@\"\n")
     create_exe(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "starship", "#!/bin/sh\nexit 0\n")
+    create_exe(bin_dir / "zsh", "#!/bin/sh\nexit 0\n")
     create_exe(bin_dir / "id", "#!/bin/sh\necho 0\n")
 
     (bin_dir / "grep").symlink_to("/usr/bin/grep")
@@ -247,4 +292,3 @@ def test_setup_wsl_zoxide_install_failure(tmp_path):
 
     assert result.returncode != 0
     assert "zoxide installation failed" in result.stderr
-   


### PR DESCRIPTION
### Motivation
- Provide a first-class zsh package for interactive environments and avoid conflicting bash prompt logic when users are encouraged to use zsh. 
- Make WSL setup install and prefer zsh while keeping the operation idempotent so repeated runs don't duplicate configuration or forcibly reset the login shell.

### Description
- Added `dotfiles/shell/.zshrc` that initializes `compinit` with a cache path, sources lightweight local plugins (`zsh-autosuggestions` and `zsh-syntax-highlighting` from `~/.local/share/zsh/plugins`), enables Starship with `eval "$(starship init zsh)"`, and conditionally runs `zoxide init zsh` if `zoxide` is present. 
- Replaced `dotfiles/common/.bashrc` with a minimal interactive shim that prints a short message directing interactive bash users to `zsh` and returns early for non-interactive shells to avoid conflicting prompt logic. 
- Updated `scripts/setup-wsl.sh` to install `zsh`, validate its presence, and set the default shell with `chsh -s` only when the current login shell differs (idempotent); removed the previous logic that appended bash-specific `starship`/`zoxide` snippets into `~/.bashrc`. 
- Extended and adjusted `tests/test_setup_wsl.py` to stub `zsh`/`getent`/`chsh` behavior, assert package install expectations now include `zsh`, verify `chsh` calls are idempotent (skipped when zsh is already the login shell), and assert no unwanted `~/.bashrc` snippets are created. 

### Testing
- Ran `pytest tests/test_setup_wsl.py tests/test_dotfiles.py` and all tests passed (`8 passed`).
- Ran `ruff check tests/test_setup_wsl.py` with no issues reported.
- Performed shell syntax checks with `bash -n scripts/setup-wsl.sh && bash -n dotfiles/common/.bashrc`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864082bc8083269d12a2aa6d54a708)