### PR TITLE
Refactor install_dotfiles to support curated package sets and host overlays

### DIFF
--- a/scripts/install_dotfiles.sh
+++ b/scripts/install_dotfiles.sh
@@ -8,19 +8,24 @@ if ! command -v stow >/dev/null 2>&1; then
 fi
 
 usage() {
-    cat <<'USAGE'
-Usage: $(basename "$0") [--dry-run] [--target DIR]
+    cat <<USAGE
+Usage: $(basename "$0") [--dry-run] [--target DIR] [--packages LIST] [--host NAME]
 
 Link dotfile packages into the target directory using GNU Stow.
 
   -n, --dry-run      Show what would be done without modifying files
   -t, --target DIR   Target directory (defaults to $HOME)
+  -p, --packages     Comma-separated package list (defaults to: shell,nvim,tmux,terminal)
+      --host NAME    Apply host overlay from hosts/NAME after core packages
   -h, --help         Show this help message
 USAGE
 }
 
 dry_run=0
 target="$HOME"
+packages_csv=""
+host_name=""
+core_packages=(shell nvim tmux terminal)
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -40,6 +45,22 @@ while [[ $# -gt 0 ]]; do
             usage
             exit 0
             ;;
+        -p|--packages)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --packages requires a comma-separated list" >&2
+                exit 1
+            fi
+            packages_csv="$2"
+            shift 2
+            ;;
+        --host)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --host requires a hostname" >&2
+                exit 1
+            fi
+            host_name="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown option: $1" >&2
             usage
@@ -48,7 +69,32 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-stow_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../dotfiles" && pwd)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dotfiles_dir="$repo_root/dotfiles"
+hosts_dir="$repo_root/hosts"
+
+declare -a selected_packages=()
+if [[ -n "$packages_csv" ]]; then
+    IFS=',' read -r -a selected_packages <<< "$packages_csv"
+else
+    selected_packages=("${core_packages[@]}")
+fi
+
+for pkg in "${selected_packages[@]}"; do
+    if [[ -z "$pkg" ]]; then
+        echo "Error: empty package name in --packages list" >&2
+        exit 1
+    fi
+    if [[ ! -d "$dotfiles_dir/$pkg" ]]; then
+        echo "Error: dotfiles package '$pkg' does not exist" >&2
+        exit 1
+    fi
+done
+
+if [[ -n "$host_name" && ! -d "$hosts_dir/$host_name" ]]; then
+    echo "Error: host overlay '$host_name' does not exist" >&2
+    exit 1
+fi
 
 if [[ ! -d "$target" ]]; then
     if [[ $dry_run -eq 1 ]]; then
@@ -59,10 +105,11 @@ if [[ ! -d "$target" ]]; then
 fi
 
 link_package() {
-    local pkg="$1"
+    local base_dir="$1"
+    local pkg="$2"
     echo "Processing $pkg" >&2
     local output
-    output=$(stow -d "$stow_dir" -t "$target" -nv "$pkg" 2>&1 || true)
+    output=$(stow -d "$base_dir" -t "$target" -nv "$pkg" 2>&1 || true)
     if echo "$output" | grep -q "existing target"; then
         echo "$output"
         if [[ $dry_run -eq 1 ]]; then
@@ -79,13 +126,16 @@ link_package() {
         done
     fi
     if [[ $dry_run -eq 1 ]]; then
-        stow -d "$stow_dir" -t "$target" -nv "$pkg"
+        stow -d "$base_dir" -t "$target" -nv "$pkg"
     else
-        stow -d "$stow_dir" -t "$target" -v "$pkg"
+        stow -d "$base_dir" -t "$target" -v "$pkg"
     fi
 }
 
-for pkg_path in "$stow_dir"/*; do
-    [[ -d "$pkg_path" ]] || continue
-    link_package "$(basename "$pkg_path")"
+for pkg in "${selected_packages[@]}"; do
+    link_package "$dotfiles_dir" "$pkg"
 done
+
+if [[ -n "$host_name" ]]; then
+    link_package "$hosts_dir" "$host_name"
+fi

--- a/tests/test_install_dotfiles.py
+++ b/tests/test_install_dotfiles.py
@@ -1,8 +1,35 @@
+import os
 import shutil
 import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_stub_stow(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "${STOW_LOG}"
+"""
+    )
+    path.chmod(0o755)
+
+
+def _setup_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(REPO_ROOT / "scripts" / "install_dotfiles.sh", scripts_dir / "install_dotfiles.sh")
+
+    for pkg in ("shell", "nvim", "tmux", "terminal", "btm"):
+        (repo / "dotfiles" / pkg).mkdir(parents=True)
+
+    (repo / "hosts" / "desktop").mkdir(parents=True)
+    return repo
+
 
 def test_install_dotfiles_requires_stow(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
@@ -24,3 +51,72 @@ def test_install_dotfiles_requires_stow(tmp_path: Path) -> None:
 
     assert result.returncode != 0
     assert "GNU Stow is required" in result.stderr
+
+
+def test_install_dotfiles_defaults_to_core_packages(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    stow_log = tmp_path / "stow.log"
+
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub_stow(stub_dir / "stow")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_dir}:{env['PATH']}"
+    env["STOW_LOG"] = str(stow_log)
+
+    subprocess.run(
+        ["/bin/bash", "scripts/install_dotfiles.sh", "--dry-run"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    calls = stow_log.read_text().strip().splitlines()
+    package_calls = [line.rsplit(" ", 1)[-1] for line in calls if line]
+    assert package_calls == [
+        "shell",
+        "shell",
+        "nvim",
+        "nvim",
+        "tmux",
+        "tmux",
+        "terminal",
+        "terminal",
+    ]
+
+
+def test_install_dotfiles_selective_packages_and_host_order(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    stow_log = tmp_path / "stow.log"
+
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub_stow(stub_dir / "stow")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_dir}:{env['PATH']}"
+    env["STOW_LOG"] = str(stow_log)
+
+    subprocess.run(
+        [
+            "/bin/bash",
+            "scripts/install_dotfiles.sh",
+            "--dry-run",
+            "--packages",
+            "tmux,shell",
+            "--host",
+            "desktop",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    calls = stow_log.read_text().strip().splitlines()
+    package_calls = [line.rsplit(" ", 1)[-1] for line in calls if line]
+    assert package_calls == ["tmux", "tmux", "shell", "shell", "desktop", "desktop"]


### PR DESCRIPTION
### Motivation
- Provide a way to install a curated subset of dotfile packages instead of auto-stowing every directory under `dotfiles/`.
- Allow applying host-specific overlays via a `--host` option applied after core packages.
- Preserve existing dry-run and conflict prompt behavior while enabling selective installs.

### Description
- Add CLI flags `--packages` (comma-separated list) and `--host` to `scripts/install_dotfiles.sh`, and update the usage text accordingly.
- Default to a curated core package set `shell,nvim,tmux,terminal` when `--packages` is not provided and validate that requested packages and hosts exist under `dotfiles/` and `hosts/` respectively.
- Refactor stow invocation to accept a base directory and package via `link_package(base_dir, pkg)`, preserving `--dry-run`, conflict prompts, and removal flow, and apply `hosts/<host>` after the selected package list.
- Add tests in `tests/test_install_dotfiles.py` that stub `stow` and verify default core selection and that `--packages` plus `--host` respect the specified ordering.

### Testing
- Ran a syntax check with `bash -n scripts/install_dotfiles.sh` which passed.
- Executed `pytest -q tests/test_install_dotfiles.py` and the tests passed (`3 passed`, `1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698647939bcc8326b6b6a3ea97c12bf2)