### PR TITLE
Add modular Neovim dotfiles config with lazy.nvim plugins

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -114,6 +114,22 @@ New-Item -ItemType SymbolicLink -Path $Env:USERPROFILE\\AppData\\Local\\Packages
 
 These examples assume the repository is cloned in a convenient location. Adjust the paths to match your setup.
 
+## Neovim first run and startup profiling
+
+The `dotfiles/nvim` package uses `lazy.nvim` for plugin management and bootstraps itself on first launch.
+
+1. Start Neovim normally (`nvim`).
+2. Wait for `lazy.nvim` to clone and install plugins.
+3. Run `:Lazy sync` if you want to force a full sync/update pass.
+
+To inspect startup performance:
+
+```bash
+nvim --startuptime /tmp/nvim-startup.log +qa
+```
+
+Then open the log and review the slowest entries.
+
 ## Terminal Tools: fastfetch, btm & Nushell/Starship
 
 ### fastfetch

--- a/dotfiles/nvim/.config/nvim/init.lua
+++ b/dotfiles/nvim/.config/nvim/init.lua
@@ -1,2 +1,3 @@
-vim.o.number = true
-vim.o.relativenumber = true
+require("config.options")
+require("config.keymaps")
+require("config.lazy")

--- a/dotfiles/nvim/.config/nvim/lua/config/keymaps.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/keymaps.lua
@@ -1,0 +1,21 @@
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
+local map = vim.keymap.set
+local opts = { noremap = true, silent = true }
+
+map("n", "<leader>w", "<cmd>write<cr>", opts)
+map("n", "<leader>q", "<cmd>quit<cr>", opts)
+map("n", "<Esc>", "<cmd>nohlsearch<cr>", opts)
+
+map("n", "<leader>ff", "<cmd>Telescope find_files<cr>", opts)
+map("n", "<leader>fg", "<cmd>Telescope live_grep<cr>", opts)
+map("n", "<leader>fb", "<cmd>Telescope buffers<cr>", opts)
+map("n", "<leader>fh", "<cmd>Telescope help_tags<cr>", opts)
+
+map("n", "[d", vim.diagnostic.goto_prev, opts)
+map("n", "]d", vim.diagnostic.goto_next, opts)
+map("n", "<leader>e", vim.diagnostic.open_float, opts)
+map("n", "<leader>ca", vim.lsp.buf.code_action, opts)
+map("n", "gd", vim.lsp.buf.definition, opts)
+map("n", "gr", vim.lsp.buf.references, opts)

--- a/dotfiles/nvim/.config/nvim/lua/config/lazy.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/lazy.lua
@@ -1,0 +1,29 @@
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+
+if not vim.loop.fs_stat(lazypath) then
+    vim.fn.system({
+        "git",
+        "clone",
+        "--filter=blob:none",
+        "https://github.com/folke/lazy.nvim.git",
+        "--branch=stable",
+        lazypath,
+    })
+end
+
+vim.opt.rtp:prepend(lazypath)
+
+require("lazy").setup({
+    spec = {
+        { import = "plugins" },
+    },
+    defaults = {
+        lazy = true,
+    },
+    install = {
+        colorscheme = { "tokyonight" },
+    },
+    checker = {
+        enabled = false,
+    },
+})

--- a/dotfiles/nvim/.config/nvim/lua/config/options.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/options.lua
@@ -1,0 +1,16 @@
+local opt = vim.opt
+
+opt.termguicolors = true
+opt.number = true
+opt.relativenumber = true
+opt.signcolumn = "yes"
+opt.cursorline = true
+
+opt.mouse = "a"
+opt.updatetime = 250
+opt.timeoutlen = 300
+opt.splitright = true
+opt.splitbelow = true
+opt.ignorecase = true
+opt.smartcase = true
+opt.clipboard = "unnamedplus"

--- a/dotfiles/nvim/.config/nvim/lua/plugins/colorscheme.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/colorscheme.lua
@@ -1,0 +1,14 @@
+return {
+    {
+        "folke/tokyonight.nvim",
+        lazy = false,
+        priority = 1000,
+        opts = {
+            style = "moon",
+        },
+        config = function(_, opts)
+            require("tokyonight").setup(opts)
+            vim.cmd.colorscheme("tokyonight")
+        end,
+    },
+}

--- a/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -1,0 +1,18 @@
+return {
+    {
+        "neovim/nvim-lspconfig",
+        event = { "BufReadPre", "BufNewFile" },
+        ft = { "lua", "python", "javascript", "typescript", "sh" },
+        cmd = { "LspInfo", "LspStart" },
+        config = function()
+            local lspconfig = require("lspconfig")
+
+            local servers = { "lua_ls", "pyright", "ts_ls", "bashls" }
+            for _, server in ipairs(servers) do
+                if lspconfig[server] then
+                    lspconfig[server].setup({})
+                end
+            end
+        end,
+    },
+}

--- a/dotfiles/nvim/.config/nvim/lua/plugins/lualine.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/lualine.lua
@@ -1,0 +1,15 @@
+return {
+    {
+        "nvim-lualine/lualine.nvim",
+        event = "VeryLazy",
+        dependencies = {
+            "nvim-tree/nvim-web-devicons",
+        },
+        opts = {
+            options = {
+                theme = "tokyonight",
+                globalstatus = true,
+            },
+        },
+    },
+}

--- a/dotfiles/nvim/.config/nvim/lua/plugins/telescope.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/telescope.lua
@@ -1,0 +1,15 @@
+return {
+    {
+        "nvim-telescope/telescope.nvim",
+        cmd = "Telescope",
+        dependencies = {
+            "nvim-lua/plenary.nvim",
+        },
+        opts = {
+            defaults = {
+                layout_strategy = "horizontal",
+                sorting_strategy = "ascending",
+            },
+        },
+    },
+}

--- a/dotfiles/nvim/.config/nvim/lua/plugins/treesitter.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/treesitter.lua
@@ -1,0 +1,15 @@
+return {
+    {
+        "nvim-treesitter/nvim-treesitter",
+        event = { "BufReadPost", "BufNewFile" },
+        build = ":TSUpdate",
+        opts = {
+            ensure_installed = { "bash", "lua", "python", "javascript", "typescript", "json", "markdown" },
+            highlight = { enable = true },
+            indent = { enable = true },
+        },
+        config = function(_, opts)
+            require("nvim-treesitter.configs").setup(opts)
+        end,
+    },
+}


### PR DESCRIPTION
### Motivation

- Provide a self-contained, modular Neovim package under `dotfiles/nvim` so the repository ships a ready-to-use `~/.config/nvim` that follows modern Lua config practices. 
- Keep startup fast by using `lazy.nvim` and defining plugin specs with lazy-load triggers (`event`, `ft`, `cmd`).

### Description

- Add `dotfiles/nvim/.config/nvim/init.lua` that imports modular config via `require("config.options")`, `require("config.keymaps")`, and `require("config.lazy")`.
- Add `lua/config` modules: `options.lua` to set UI/options (e.g. `termguicolors`, numbers, `signcolumn`, `cursorline`), `keymaps.lua` for leader keys and common mappings, and `lazy.lua` to bootstrap `lazy.nvim` and call `require("lazy").setup({ spec = { import = "plugins" } })`.
- Add `lua/plugins/*.lua` plugin specs for a maintained colorscheme and common plugins: `folke/tokyonight.nvim` (colorscheme, loaded immediately), `neovim/nvim-lspconfig` (lazy by `event`, `ft`, `cmd`), `nvim-treesitter/nvim-treesitter` (lazy by buffer events, with `:TSUpdate` build), `nvim-telescope/telescope.nvim` (lazy by `cmd = "Telescope"`), and `nvim-lualine/lualine.nvim` (lazy via `VeryLazy` event), each wired to appropriate options/dependencies.
- Document first-run plugin sync and startup profiling in `docs/terminal.md` with the `:Lazy sync` note and `nvim --startuptime /tmp/nvim-startup.log +qa` example.

### Testing

- Ran unit tests with `pytest -q tests/test_dotfiles.py tests/test_install_dotfiles.py`, which completed successfully (`4 passed`).
- Ran JavaScript linter with `npm run lint` (invokes `npx eslint`) which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698649d037c083268632e32bb3c27ac2)