### PR TITLE
Add baseline tmux configuration with TPM plugins and docs

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -132,6 +132,27 @@ Then open the log and review the slowest entries.
 
 ## Terminal Tools: fastfetch, btm & Nushell/Starship
 
+## tmux baseline config and TPM plugins
+
+The repository includes a baseline tmux configuration at [`dotfiles/tmux/.tmux.conf`](../dotfiles/tmux/.tmux.conf) with:
+
+- Mouse mode enabled and larger scrollback history.
+- Truecolor-capable terminal settings (`tmux-256color` + RGB terminal features).
+- A status line styled to match the Blacklight palette.
+- Ergonomic pane/window navigation and a `prefix + r` config reload binding.
+
+TPM is bootstrapped automatically (cloned on first startup if missing) with:
+
+- `tmux-plugins/tpm`
+- `tmux-plugins/tmux-resurrect`
+- `tmux-plugins/tmux-continuum`
+
+Useful TPM shortcuts after launching tmux:
+
+- `prefix + I` – install plugins.
+- `prefix + U` – update plugins.
+- `prefix + Alt + u` – remove plugins not currently listed.
+
 ### fastfetch
 Display system information each time a shell starts.
 

--- a/dotfiles/tmux/.tmux.conf
+++ b/dotfiles/tmux/.tmux.conf
@@ -1,2 +1,39 @@
+# Core behavior
 set -g mouse on
-set -g history-limit 10000
+set -g history-limit 100000
+set -g default-terminal "tmux-256color"
+set -as terminal-features ",*:RGB"
+
+# Theme (aligned with Blacklight palette)
+set -g status-style "bg=#000000,fg=#f2f2f2"
+set -g status-left-length 40
+set -g status-right-length 80
+set -g status-left "#[fg=#000000,bg=#845CFF,bold] #S #[default]"
+set -g status-right "#[fg=#66fff2] %Y-%m-%d #[fg=#b2ff59]%H:%M #[default]"
+set -g pane-border-style "fg=#666666"
+set -g pane-active-border-style "fg=#66b2ff"
+set -g message-style "bg=#845CFF,fg=#000000"
+
+# Ergonomic navigation and quality-of-life keybindings
+unbind '"'
+unbind %
+bind - split-window -v -c "#{pane_current_path}"
+bind | split-window -h -c "#{pane_current_path}"
+bind -r h select-pane -L
+bind -r j select-pane -D
+bind -r k select-pane -U
+bind -r l select-pane -R
+bind -r H swap-pane -L
+bind -r L swap-pane -R
+bind -r C-h previous-window
+bind -r C-l next-window
+bind r source-file ~/.tmux.conf \; display-message "tmux config reloaded"
+
+# TPM bootstrap + plugins
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @continuum-restore 'on'
+if-shell "test ! -d ~/.tmux/plugins/tpm" \
+  "run-shell 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm'"
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
### Motivation

- Provide a usable, theme-aligned baseline tmux configuration for dotfiles that enables mouse support, increased scrollback, truecolor, and ergonomic navigation out of the box.
- Enable plugin management via TPM and include common session-resume plugins to improve developer workflow across machines.
- Document the new tmux package and common TPM install/update keys in the terminal docs so users can bootstrap plugins easily.

### Description

- Added `dotfiles/tmux/.tmux.conf` which enables `set -g mouse on`, raises `history-limit`, sets `default-terminal` to `tmux-256color` and adds RGB support via `set -as terminal-features ",*:RGB"`.
- Styled the status/pane/message colors to align with the Blacklight palette and added ergonomic keybindings for pane/window navigation plus a `prefix + r` config reload binding using current tmux syntax.
- Bootstrapped TPM with plugin declarations for `tmux-plugins/tpm`, `tmux-plugins/tmux-resurrect`, and `tmux-plugins/tmux-continuum`, including first-run clone logic and `run '~/.tmux/plugins/tpm/tpm'` to activate TPM.
- Updated `docs/terminal.md` to document the baseline config and useful TPM shortcuts (`prefix + I`, `prefix + U`, `prefix + Alt + u`).

### Testing

- Ran `pytest -q tests/test_dotfiles.py tests/test_install_dotfiles.py`, which passed (`4 passed`).
- Ran `ruff check .`, which reported pre-existing lint issues elsewhere in the repository (9 errors found, 8 fixable) but these issues are unrelated to the tmux changes in this PR.
- Verified the new `dotfiles/tmux/.tmux.conf` and `docs/terminal.md` contents locally to ensure TPM bootstrap lines and keybindings are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864b624e4483268e5c9111979fc590)