### PR TITLE
Add managed Ghostty profile and align setup, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,13 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/shell` → `.zshrc`, `.bashrc`, and `~/.config/starship.toml`
 - `dotfiles/nvim` → `~/.config/nvim/...`
 - `dotfiles/tmux` → `.tmux.conf`
-- `dotfiles/terminal` → terminal config (`~/.config/ghostty/ghostty.toml`)
+- `dotfiles/ghostty/ghostty.toml` → managed Ghostty config copied by `scripts/setup-ghostty.sh`
 - `hosts/desktop` and `hosts/work_laptop` → machine-specific overrides
 
 Example:
 
 ```bash
-stow --target="$HOME" dotfiles/shell dotfiles/nvim dotfiles/tmux dotfiles/terminal
+stow --target="$HOME" dotfiles/shell dotfiles/nvim dotfiles/tmux
 stow --target="$HOME" hosts/desktop   # or hosts/work_laptop
 ```
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -7,7 +7,7 @@ Desktop-specific overrides now live in host overlays under `hosts/desktop`.
 1. Clone the repository.
 2. Apply the shared dotfile packages you need, for example:
    ```bash
-   stow --target="$HOME" dotfiles/shell dotfiles/terminal dotfiles/tmux
+   stow --target="$HOME" dotfiles/shell dotfiles/tmux
    ```
 3. Apply the desktop host overlay:
    ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -350,11 +350,13 @@ On Windows you can call the PowerShell wrapper or use `bootstrap.ps1` with the
 cargo install ghostty
 ```
 
-Configuration lives in `~/.config/ghostty/ghostty.toml`. A minimal example enables ligatures and sets the window title:
+Ghostty is the standard terminal profile in this repository. `scripts/setup-ghostty.sh` copies the managed config from `dotfiles/ghostty/ghostty.toml` into `~/.config/ghostty/ghostty.toml`, including Nerd Font defaults, Blacklight colors, opacity, and cursor polish settings.
 
 ```toml
-use_ligatures = true
-window_title = "Ghostty"
+font-family = "JetBrainsMono Nerd Font"
+font-size = 13
+background-opacity = 0.92
+cursor-style = "block"
 ```
 
 Launch `ghostty` instead of your default terminal to try it out.

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -87,7 +87,7 @@ This repository includes example setups for various tools:
 - `dotfiles/shell` – `.zshrc`, `.bashrc`, and `~/.config/starship.toml`.
 - `dotfiles/nvim` – Neovim package (`~/.config/nvim/...`).
 - `dotfiles/tmux` – `.tmux.conf`.
-- `dotfiles/terminal` – terminal emulator configuration (`~/.config/ghostty/ghostty.toml`).
+- `dotfiles/ghostty/ghostty.toml` – canonical Ghostty configuration managed by `scripts/setup-ghostty.sh`.
 - `hosts/desktop` and `hosts/work_laptop` – host overlays for machine-specific tweaks.
 - `windows-terminal` – minimal starter `settings.json` for Windows Terminal. The
   file is built from `common-profiles.json` using `generate_settings.py`.
@@ -253,7 +253,7 @@ traditional command palette is available with **Ctrl+Shift+P**.
    stow dotfiles/shell
    stow dotfiles/nvim
    stow dotfiles/tmux
-   stow dotfiles/terminal
+   ./scripts/setup-ghostty.sh
    ```
 
    Stow cleanly manages symlinks, letting you enable or disable packages with `stow -D <name>`.

--- a/dotfiles/ghostty/ghostty.toml
+++ b/dotfiles/ghostty/ghostty.toml
@@ -1,0 +1,42 @@
+# Managed Ghostty profile (Blacklight palette shared across Starship/tmux)
+font-family = "JetBrainsMono Nerd Font"
+font-size = 13
+
+# Window + background polish
+background = "#000000"
+background-opacity = 0.92
+window-padding-x = 10
+window-padding-y = 8
+window-theme = "dark"
+
+# Cursor + rendering behavior
+cursor-color = "#FC17DA"
+cursor-style = "block"
+cursor-style-blink = true
+shell-integration-features = "cursor,sudo,title"
+copy-on-select = true
+confirm-close-surface = false
+
+# Core UX preferences
+window-title = "Ghostty"
+window-save-state = "always"
+macos-titlebar-style = "tabs"
+mouse-hide-while-typing = true
+
+# Blacklight terminal colors (aligned with tmux + starship)
+palette = "0=#000000"
+palette = "1=#ff66c4"
+palette = "2=#b2ff59"
+palette = "3=#ffff66"
+palette = "4=#66b2ff"
+palette = "5=#845CFF"
+palette = "6=#66fff2"
+palette = "7=#f2f2f2"
+palette = "8=#666666"
+palette = "9=#ff66c4"
+palette = "10=#b2ff59"
+palette = "11=#ffff66"
+palette = "12=#66b2ff"
+palette = "13=#FC17DA"
+palette = "14=#66fff2"
+palette = "15=#ffffff"

--- a/scripts/setup-ghostty.sh
+++ b/scripts/setup-ghostty.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install Ghostty via cargo if not already installed
+# Install Ghostty via cargo if not already installed.
+# This script also provisions the repository-managed rich profile
+# (font, Blacklight colors, opacity, and UI polish settings).
 if ! command -v cargo >/dev/null 2>&1; then
     echo "Error: cargo is required to install Ghostty" >&2
     exit 1
@@ -19,7 +21,7 @@ mkdir -p "$config_dir"
 if [[ -e "$config_file" ]]; then
     echo "Configuration already exists at $config_file"
 else
-    cp "$repo_root/dotfiles/terminal/.config/ghostty/ghostty.toml" "$config_file"
+    cp "$repo_root/dotfiles/ghostty/ghostty.toml" "$config_file"
     echo "Configuration copied to $config_file"
 fi
 

--- a/tests/test_setup_ghostty.py
+++ b/tests/test_setup_ghostty.py
@@ -66,3 +66,21 @@ def test_setup_ghostty_installs_and_copies(tmp_path: Path) -> None:
     assert cargo_log.read_text().strip() == "install --locked ghostty"
     config_file = Path(env["XDG_CONFIG_HOME"]) / "ghostty/ghostty.toml"
     assert config_file.exists()
+
+
+def test_managed_ghostty_config_has_required_keys() -> None:
+    config_path = REPO_ROOT / "dotfiles" / "ghostty" / "ghostty.toml"
+    contents = config_path.read_text()
+
+    required = [
+        "font-family = ",
+        "font-size = ",
+        "background-opacity = ",
+        "cursor-style = ",
+        "window-title = ",
+    ]
+    for key in required:
+        assert key in contents
+
+    palette_entries = [line for line in contents.splitlines() if line.startswith("palette = ")]
+    assert len(palette_entries) >= 16


### PR DESCRIPTION
### Motivation
- Provide a single, richer, repository‑managed Ghostty profile so the terminal experience is cohesive with Starship/Neovim/tmux and includes sensible defaults (font, size, colors, opacity, cursor polish). 
- Remove stale references to older/alternate terminal config locations and make Ghostty the canonical, supported terminal profile the helper script provisions.

### Description
- Add `dotfiles/ghostty/ghostty.toml` with Nerd Font defaults, font size, background color and opacity, cursor settings, window/UI polish, and a 16‑entry Blacklight color palette aligned with `starship`/`tmux` themes. 
- Update `scripts/setup-ghostty.sh` comments to document the richer managed profile and change the path it copies from to `dotfiles/ghostty/ghostty.toml`.
- Update documentation entries in `README.md`, `docs/terminal.md`, `docs/installation.md`, and `docs/desktop.md` to declare Ghostty as the standard managed profile and remove stale `dotfiles/terminal` references from setup guidance.
- Add validation coverage in `tests/test_setup_ghostty.py` to assert presence of required keys (`font-family`, `font-size`, `background-opacity`, `cursor-style`, `window-title`) and that at least 16 `palette` entries exist.

### Testing
- Installed dev dependencies with `python -m pip install -q -r requirements-dev.txt` (completed).
- Ran `pytest -q tests/test_setup_ghostty.py tests/test_install_dotfiles.py` and received all tests passing (`6 passed, 1 warning`).
- Ran `ruff check tests/test_setup_ghostty.py` and checks passed for the modified Python test file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864d7ce67c83268824d54ff63e385d)