### PR TITLE
Add idempotent shallow cloning for zsh plugins in WSL setup

### DIFF
--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -52,6 +52,39 @@ install_terminal() {
 
 install_terminal
 
+ensure_shallow_plugin_repo() {
+    local repo_url="$1"
+    local repo_name="$2"
+    local plugin_dir="$HOME/.local/share/zsh/plugins/$repo_name"
+
+    mkdir -p "$HOME/.local/share/zsh/plugins"
+
+    if [ -d "$plugin_dir/.git" ]; then
+        git -C "$plugin_dir" remote set-url origin "$repo_url"
+        git -C "$plugin_dir" fetch --depth 1 origin
+
+        local origin_head=""
+        origin_head="$(git -C "$plugin_dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+        if [ -z "$origin_head" ]; then
+            git -C "$plugin_dir" remote set-head origin --auto >/dev/null 2>&1 || true
+            origin_head="$(git -C "$plugin_dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+        fi
+
+        if [ -n "$origin_head" ]; then
+            git -C "$plugin_dir" checkout --quiet "${origin_head#origin/}" 2>/dev/null || true
+            git -C "$plugin_dir" reset --hard "$origin_head"
+        fi
+    elif [ -d "$plugin_dir" ]; then
+        echo "Error: $plugin_dir exists but is not a git repository." >&2
+        exit 1
+    else
+        git clone --depth 1 "$repo_url" "$plugin_dir"
+    fi
+}
+
+ensure_shallow_plugin_repo "https://github.com/zsh-users/zsh-autosuggestions" "zsh-autosuggestions"
+ensure_shallow_plugin_repo "https://github.com/zsh-users/zsh-syntax-highlighting" "zsh-syntax-highlighting"
+
 # Verify that curl is available; exit with a helpful message if not.
 if ! command -v curl >/dev/null; then
     echo "Error: curl is required but could not be installed." >&2


### PR DESCRIPTION
### Motivation

- Ensure the zsh plugin directory is provisioned during WSL setup so runtime `~/.zshrc` plugin paths resolve.
- Install requested zsh plugins quickly using shallow clones to reduce download size and time.
- Make plugin provisioning idempotent so re-running the bootstrap updates existing checkouts instead of duplicating work.

### Description

- Added an `ensure_shallow_plugin_repo` helper to `scripts/setup-wsl.sh` that creates `~/.local/share/zsh/plugins` and either shallow-clones a repo with `--depth 1` or updates an existing git checkout in-place by fetching and resetting to `origin/HEAD`.
- The helper errors if the target plugin directory exists but is not a git repository to avoid corrupt state.
- Wired the bootstrap to provision `https://github.com/zsh-users/zsh-autosuggestions` and `https://github.com/zsh-users/zsh-syntax-highlighting` into `~/.local/share/zsh/plugins` while keeping `dotfiles/shell/.zshrc` paths unchanged.

### Testing

- Ran `bash -n scripts/setup-wsl.sh` to verify shell syntax; the check succeeded.
- Attempted to run `shellcheck scripts/setup-wsl.sh` but `shellcheck` is not available in the environment so linting could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69868eb4cdc48326b06cce0622486ad9)