### PR TITLE
Normalize terminal font family to CaskaydiaCove Nerd Font

### DIFF
--- a/dotfiles/ghostty/ghostty.toml
+++ b/dotfiles/ghostty/ghostty.toml
@@ -1,5 +1,5 @@
 # Managed Ghostty profile (Blacklight palette shared across Starship/tmux)
-font-family = "JetBrainsMono Nerd Font"
+font-family = "CaskaydiaCove Nerd Font"
 font-size = 13
 
 # Window + background polish

--- a/dotfiles/terminal/.config/ghostty/ghostty.toml
+++ b/dotfiles/terminal/.config/ghostty/ghostty.toml
@@ -1,3 +1,4 @@
 # Example configuration for Ghostty terminal
 use_ligatures = true
 window_title = "Ghostty"
+font-family = "CaskaydiaCove Nerd Font"

--- a/tablet-config/windows-terminal/settings.base.json
+++ b/tablet-config/windows-terminal/settings.base.json
@@ -29,7 +29,7 @@
   "profiles": {
     "defaults": {
       "font": {
-        "face": "CascaydiaCove Nerd Font",
+        "face": "CaskaydiaCove Nerd Font",
         "weight": "normal"
       },
       "opacity": 20

--- a/tablet-config/windows-terminal/settings.json
+++ b/tablet-config/windows-terminal/settings.json
@@ -33,7 +33,7 @@
       "useAcrylic": true,
       "textAntialiasing": "grayscale",
       "font": {
-        "face": "CascaydiaCove Nerd Font",
+        "face": "CaskaydiaCove Nerd Font",
         "weight": "normal"
       },
       "opacity": 20


### PR DESCRIPTION
### Motivation
- Ensure a single canonical terminal font family is used across Ghostty and Windows Terminal configs so runtime rendering doesn't fall back to substitute glyphs.
- Align font installer scripts with configuration to guarantee the installed font metadata matches the config values.
- Used `skill-installer` guidance to keep installer/config alignment consistent.

### Description
- Updated `dotfiles/ghostty/ghostty.toml` to use `CaskaydiaCove Nerd Font` instead of `JetBrainsMono Nerd Font`.
- Added `font-family = "CaskaydiaCove Nerd Font"` to `dotfiles/terminal/.config/ghostty/ghostty.toml` so both Ghostty configs match.
- Fixed tablet Windows Terminal config entries in `tablet-config/windows-terminal/settings.json` and `tablet-config/windows-terminal/settings.base.json` by changing `"CascaydiaCove Nerd Font"` to `"CaskaydiaCove Nerd Font"`.
- Verified desktop Windows Terminal files and both installer scripts already target `CaskaydiaCove`, so installer metadata and runtime config now align end-to-end.

### Testing
- Attempted to run `pytest -q tests/test_install_fonts.py tests/test_setup_ghostty.py tests/test_install_windows_terminal.py tests/test_generate_settings.py` but the test bootstrap could not complete in this environment because it expects a specific pyenv site-packages layout for `typer`; I installed `requests` and `typer` via `pip` while attempting to satisfy dependencies.
- Validated all modified Windows Terminal JSON files with `python -c 'json.loads(...)'` which succeeded.
- Linted the installer script with `bash -n scripts/helpers/install_fonts.sh` which returned OK.
- Tried to parse the PowerShell installer with `pwsh -NoProfile -Command ...` but `pwsh` is not available in this environment so that check could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d90e337883269cd61235922b0e3a)