### PR TITLE
Unify Ghostty config on canonical dotfiles/ghostty/ghostty.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/shell` → `.zshrc`, `.bashrc`, and `~/.config/starship.toml`
 - `dotfiles/nvim` → `~/.config/nvim/...`
 - `dotfiles/tmux` → `.tmux.conf`
-- `dotfiles/ghostty/ghostty.toml` → managed Ghostty config copied by `scripts/setup-ghostty.sh`
+- `dotfiles/ghostty/ghostty.toml` → **canonical** Ghostty config; `scripts/setup-ghostty.sh` deploys it to `~/.config/ghostty/ghostty.toml`
 - `hosts/desktop` and `hosts/work_laptop` → machine-specific overrides
 
 Example:

--- a/dotfiles/terminal/.config/ghostty/ghostty.toml
+++ b/dotfiles/terminal/.config/ghostty/ghostty.toml
@@ -1,4 +1,0 @@
-# Example configuration for Ghostty terminal
-use_ligatures = true
-window_title = "Ghostty"
-font-family = "CaskaydiaCove Nerd Font"

--- a/scripts/setup-ghostty.sh
+++ b/scripts/setup-ghostty.sh
@@ -15,15 +15,20 @@ fi
 
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ghostty"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+canonical_source="$repo_root/dotfiles/ghostty/ghostty.toml"
 config_file="$config_dir/ghostty.toml"
 mkdir -p "$config_dir"
+
+if [[ ! -f "$canonical_source" ]]; then
+    echo "Error: managed Ghostty config is missing at $canonical_source" >&2
+    exit 1
+fi
 
 if [[ -e "$config_file" ]]; then
     echo "Configuration already exists at $config_file"
 else
-    cp "$repo_root/dotfiles/ghostty/ghostty.toml" "$config_file"
+    cp "$canonical_source" "$config_file"
     echo "Configuration copied to $config_file"
 fi
 
 echo "Ghostty installed."
-

--- a/tests/test_setup_ghostty.py
+++ b/tests/test_setup_ghostty.py
@@ -70,7 +70,10 @@ def test_setup_ghostty_installs_and_copies(tmp_path: Path) -> None:
 
 def test_managed_ghostty_config_has_required_keys() -> None:
     config_path = REPO_ROOT / "dotfiles" / "ghostty" / "ghostty.toml"
+    legacy_config_path = REPO_ROOT / "dotfiles" / "terminal" / ".config" / "ghostty" / "ghostty.toml"
     contents = config_path.read_text()
+
+    assert not legacy_config_path.exists()
 
     required = [
         "font-family = ",
@@ -84,3 +87,11 @@ def test_managed_ghostty_config_has_required_keys() -> None:
 
     palette_entries = [line for line in contents.splitlines() if line.startswith("palette = ")]
     assert len(palette_entries) >= 16
+
+
+def test_setup_script_uses_canonical_config_path() -> None:
+    script_path = REPO_ROOT / "scripts" / "setup-ghostty.sh"
+    script_contents = script_path.read_text()
+
+    assert 'canonical_source="$repo_root/dotfiles/ghostty/ghostty.toml"' in script_contents
+    assert "dotfiles/terminal/.config/ghostty/ghostty.toml" not in script_contents


### PR DESCRIPTION
### Motivation
- Consolidate Ghostty configuration so a single repository-managed file is authoritative to avoid divergence between duplicates. 
- Ensure the setup script deploys the managed config deterministically and fails early if the managed config is missing. 
- Remove the legacy duplicate location to simplify dotfiles layout and stow-style deployment. 

### Description
- Updated `scripts/setup-ghostty.sh` to introduce `canonical_source` pointing to `dotfiles/ghostty/ghostty.toml`, to copy from that path, and to fail fast if the canonical file is absent. 
- Removed the legacy duplicate file at `dotfiles/terminal/.config/ghostty/ghostty.toml`. 
- Updated `README.md` dotfiles layout to indicate `dotfiles/ghostty/ghostty.toml` is the canonical managed Ghostty config and that `scripts/setup-ghostty.sh` deploys it to `~/.config/ghostty/ghostty.toml`. 
- Extended `tests/test_setup_ghostty.py` to assert the setup script references the canonical path and to assert the legacy path does not exist while preserving existing checks for required keys and palette entries. 

### Testing
- Ran `pytest -q tests/test_setup_ghostty.py`, which passed (`4 passed`). 
- Ran `ruff check tests/test_setup_ghostty.py`, which passed. 
- Ran a syntax check on the setup script with `bash -n scripts/setup-ghostty.sh`, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989da3977348326aa1ab5ea292a4b73)