### PR TITLE
Add host-specific terminal overlays, source them at shell startup, and document install order

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,15 +182,27 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/shell` → `.zshrc`, `.bashrc`, and `~/.config/starship.toml`
 - `dotfiles/nvim` → `~/.config/nvim/...`
 - `dotfiles/tmux` → `.tmux.conf`
+- `dotfiles/terminal` → shared terminal defaults in `~/.config/tino/terminal-defaults.sh`
 - `dotfiles/ghostty/ghostty.toml` → **canonical** Ghostty config; `scripts/setup-ghostty.sh` deploys it to `~/.config/ghostty/ghostty.toml`
 - `hosts/desktop` and `hosts/work_laptop` → machine-specific overrides
 
 Example:
 
 ```bash
-stow --target="$HOME" dotfiles/shell dotfiles/nvim dotfiles/tmux
-stow --target="$HOME" hosts/desktop   # or hosts/work_laptop
+# Core defaults first (includes terminal defaults)
+stow --target="$HOME" --dir=dotfiles shell nvim tmux terminal
+
+# Host overlay second (desktop OR work_laptop)
+stow --target="$HOME" --dir=hosts desktop
+# stow --target="$HOME" --dir=hosts work_laptop
 ```
+
+Expected behavior:
+
+- `dotfiles/terminal` provides shared defaults in `~/.config/tino/terminal-defaults.sh`.
+- Host overlay packages only contain diffs in `~/.config/tino/host-overrides.sh`.
+- On shell startup, `.zshrc` loads defaults first and then host overrides, so host values win when both define the same variable.
+- `scripts/install_dotfiles.sh --host <name>` follows the same order: core packages, then host overlay.
 
 ## Changelog (auto‑updated)
 

--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -10,6 +10,15 @@ if [[ -r "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]
     source "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 fi
 
+
+if [[ -r "$HOME/.config/tino/terminal-defaults.sh" ]]; then
+    source "$HOME/.config/tino/terminal-defaults.sh"
+fi
+
+if [[ -r "$HOME/.config/tino/host-overrides.sh" ]]; then
+    source "$HOME/.config/tino/host-overrides.sh"
+fi
+
 eval "$(starship init zsh)"
 
 if command -v zoxide >/dev/null; then

--- a/dotfiles/terminal/.config/tino/terminal-defaults.sh
+++ b/dotfiles/terminal/.config/tino/terminal-defaults.sh
@@ -1,0 +1,5 @@
+# Shared terminal defaults for all hosts.
+# Host overlays can override these values from ~/.config/tino/host-overrides.sh.
+export TINO_TERMINAL_OPACITY="0.92"
+export TINO_TERMINAL_FPS="120"
+export TINO_TERMINAL_EFFECTS="on"

--- a/hosts/desktop/.config/tino/host-overrides.sh
+++ b/hosts/desktop/.config/tino/host-overrides.sh
@@ -1,2 +1,4 @@
-# Desktop-specific environment overrides
-export DESKTOP_VAR=1
+# Desktop-specific terminal overrides.
+export TINO_TERMINAL_OPACITY="0.95"
+export TINO_TERMINAL_FPS="165"
+export TINO_TERMINAL_EFFECTS="high"

--- a/hosts/work_laptop/.config/tino/host-overrides.sh
+++ b/hosts/work_laptop/.config/tino/host-overrides.sh
@@ -1,2 +1,4 @@
-# Work laptop-specific environment overrides
-export LAPTOP_VAR=1
+# Work laptop-specific terminal overrides.
+export TINO_TERMINAL_OPACITY="0.88"
+export TINO_TERMINAL_FPS="60"
+export TINO_TERMINAL_EFFECTS="balanced"

--- a/tests/test_install_dotfiles.py
+++ b/tests/test_install_dotfiles.py
@@ -120,3 +120,46 @@ def test_install_dotfiles_selective_packages_and_host_order(tmp_path: Path) -> N
     calls = stow_log.read_text().strip().splitlines()
     package_calls = [line.rsplit(" ", 1)[-1] for line in calls if line]
     assert package_calls == ["tmux", "tmux", "shell", "shell", "desktop", "desktop"]
+
+
+def test_install_dotfiles_core_then_host_overlay_order(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path)
+    stow_log = tmp_path / "stow.log"
+
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub_stow(stub_dir / "stow")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_dir}:{env['PATH']}"
+    env["STOW_LOG"] = str(stow_log)
+
+    subprocess.run(
+        [
+            "/bin/bash",
+            "scripts/install_dotfiles.sh",
+            "--dry-run",
+            "--host",
+            "desktop",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    calls = stow_log.read_text().strip().splitlines()
+    package_calls = [line.rsplit(" ", 1)[-1] for line in calls if line]
+    assert package_calls == [
+        "shell",
+        "shell",
+        "nvim",
+        "nvim",
+        "tmux",
+        "tmux",
+        "terminal",
+        "terminal",
+        "desktop",
+        "desktop",
+    ]


### PR DESCRIPTION
### Motivation
- Provide meaningful per-host terminal configuration (opacity/fps/effects) while keeping shared defaults in a central `dotfiles/terminal` package.
- Ensure the shell startup sequence loads shared defaults first and then host-specific diffs so host values take precedence.
- Make the expected `stow` usage and overlay ordering explicit in the README and validate the behavior with an automated test.

### Description
- Added shared defaults at `dotfiles/terminal/.config/tino/terminal-defaults.sh` containing `TINO_TERMINAL_*` variables.
- Replaced placeholder host scripts with per-host terminal diffs in `hosts/desktop/.config/tino/host-overrides.sh` and `hosts/work_laptop/.config/tino/host-overrides.sh`.
- Updated `dotfiles/shell/.zshrc` to source `~/.config/tino/terminal-defaults.sh` first and then `~/.config/tino/host-overrides.sh` if present, so host overrides win.
- Expanded the README `Dotfiles layout` section with exact `stow` commands (core packages first, host overlay second) and documented expected behavior.
- Added `test_install_dotfiles_core_then_host_overlay_order` to `tests/test_install_dotfiles.py` to assert that `scripts/install_dotfiles.sh --host <name>` runs core packages before the host overlay.

### Testing
- Installed missing test deps with `python -m pip install requests typer pytest` and re-ran tests; `pytest tests/test_install_dotfiles.py` passed (4 passed).
- Ran the linter with `ruff check tests/test_install_dotfiles.py` and it returned `All checks passed!`.
- Attempted `shellcheck` on shell files but it is not available in the environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989db055ce08326ab13c8241c615a48)