### PR TITLE
Revise dotfile tests to validate host overlays and README layout paths

### DIFF
--- a/tests/test_dotfiles.py
+++ b/tests/test_dotfiles.py
@@ -1,12 +1,10 @@
-import glob
-import os
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def has_non_comment_line(path: str) -> bool:
-    with open(path, "r", encoding="utf-8") as f:
+def has_non_comment_line(path: Path) -> bool:
+    with path.open("r", encoding="utf-8") as f:
         for line in f:
             stripped = line.strip()
             if stripped and not stripped.startswith("#"):
@@ -14,15 +12,43 @@ def has_non_comment_line(path: str) -> bool:
     return False
 
 
-def test_dotfiles_have_non_comment_lines():
-    for folder in (
-        REPO_ROOT / "dotfiles" / "desktop",
-        REPO_ROOT / "dotfiles" / "work_laptop",
+def iter_package_files(package_dir: Path) -> list[Path]:
+    return [path for path in package_dir.rglob("*") if path.is_file()]
+
+
+def test_active_dotfile_packages_have_non_comment_lines():
+    packages = (
+        REPO_ROOT / "dotfiles" / "shell",
+        REPO_ROOT / "dotfiles" / "nvim",
+        REPO_ROOT / "dotfiles" / "tmux",
+        REPO_ROOT / "dotfiles" / "terminal",
         REPO_ROOT / "dotfiles" / "fastfetch",
         REPO_ROOT / "dotfiles" / "btm",
-    ):
-        for file_path in glob.glob(os.path.join(str(folder), "*")):
-            assert os.path.isfile(file_path), f"{file_path} should exist"
+        REPO_ROOT / "hosts" / "desktop",
+        REPO_ROOT / "hosts" / "work_laptop",
+    )
+
+    for package in packages:
+        assert package.is_dir(), f"{package} should exist"
+        managed_files = iter_package_files(package)
+        assert managed_files, f"{package} should contain managed files"
+
+        for file_path in managed_files:
             assert has_non_comment_line(
                 file_path
             ), f"{file_path} has no non-comment lines"
+
+
+def test_readme_layout_paths_exist():
+    readme_layout_paths = (
+        REPO_ROOT / "dotfiles" / "shell",
+        REPO_ROOT / "dotfiles" / "nvim",
+        REPO_ROOT / "dotfiles" / "tmux",
+        REPO_ROOT / "dotfiles" / "terminal",
+        REPO_ROOT / "dotfiles" / "ghostty" / "ghostty.toml",
+        REPO_ROOT / "hosts" / "desktop",
+        REPO_ROOT / "hosts" / "work_laptop",
+    )
+
+    for layout_path in readme_layout_paths:
+        assert layout_path.exists(), f"README layout path missing: {layout_path}"


### PR DESCRIPTION
### Motivation
- Update tests to reflect that per-host overrides live under `hosts/` instead of `dotfiles/desktop` and `dotfiles/work_laptop`.
- Ensure test assertions operate on the actual maintained files (including nested/hidden files) rather than only top-level entries.
- Add a regression guard that README-documented layout paths are present in the repository to avoid drift between docs and repository layout.

### Description
- Replaced legacy overlay checks for `dotfiles/desktop` and `dotfiles/work_laptop` with `hosts/desktop` and `hosts/work_laptop` in `tests/test_dotfiles.py`.
- Switched `has_non_comment_line` to accept a `Path` and added `iter_package_files` using `rglob` to recursively collect managed files.
- Added package existence and non-empty managed-file assertions, and validated that each managed file contains a non-comment line.
- Added `test_readme_layout_paths_exist` which asserts the README layout paths (including `dotfiles/ghostty/ghostty.toml` and host overlays) exist.

### Testing
- Ran `pytest -q tests/test_dotfiles.py` which completed successfully (`2 passed`, 1 warning).
- Ran `ruff check tests/test_dotfiles.py` which passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989dc7248148326a357ee1dcdb0a5a3)