### PR TITLE
Guard Starship prompt initialization in .zshrc

### DIFF
--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -19,7 +19,9 @@ if [[ -r "$HOME/.config/tino/host-overrides.sh" ]]; then
     source "$HOME/.config/tino/host-overrides.sh"
 fi
 
-eval "$(starship init zsh)"
+if command -v starship >/dev/null; then
+    eval "$(starship init zsh)"
+fi
 
 if command -v zoxide >/dev/null; then
     eval "$(zoxide init zsh)"


### PR DESCRIPTION
### Motivation
- Prevent errors when the Starship prompt is not installed by only running its initialization when the `starship` command exists, while keeping prompt initialization in the same plugin/prompt area to preserve ordering.

### Description
- Replaced the single line `eval "$(starship init zsh)"` with a guarded block: `if command -v starship >/dev/null; then\n  eval "$(starship init zsh)"\nfi`, leaving surrounding plugin sourcing and `zoxide` init intact.

### Testing
- Ran `zsh -n dotfiles/shell/.zshrc` to syntax-check the file but it failed due to `zsh` not being available in the environment; no syntax errors could be validated automatically.
- Ran `shellcheck dotfiles/shell/.zshrc` but it failed because `shellcheck` is not installed in the environment; linting could not be completed automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989df18975c83269962ace87ed46dc8)