### PR TITLE
Bootstrap terminal toolchain via install_common.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/tmux` → `.tmux.conf`
 - `dotfiles/terminal` → shared terminal defaults in `~/.config/tino/terminal-defaults.sh`
 - `dotfiles/ghostty/ghostty.toml` → **canonical** Ghostty config; `scripts/setup-ghostty.sh` deploys it to `~/.config/ghostty/ghostty.toml`
+- `scripts/install_common.sh` → standard bootstrap script; on macOS/Linux it installs `zsh`, `starship`, `tmux`, `neovim`, `cargo`, and then runs `scripts/setup-ghostty.sh` to install/configure Ghostty (Windows skips Ghostty and keeps Windows Terminal flow).
 - `hosts/desktop` and `hosts/work_laptop` → machine-specific overrides
 
 Example:
@@ -203,6 +204,12 @@ Expected behavior:
 - Host overlay packages only contain diffs in `~/.config/tino/host-overrides.sh`.
 - On shell startup, `.zshrc` loads defaults first and then host overrides, so host values win when both define the same variable.
 - `scripts/install_dotfiles.sh --host <name>` follows the same order: core packages, then host overlay.
+
+Standard bootstrap command (repo root):
+
+```bash
+./scripts/install_common.sh
+```
 
 ## Changelog (auto‑updated)
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -88,6 +88,7 @@ This repository includes example setups for various tools:
 - `dotfiles/nvim` – Neovim package (`~/.config/nvim/...`).
 - `dotfiles/tmux` – `.tmux.conf`.
 - `dotfiles/ghostty/ghostty.toml` – canonical Ghostty configuration managed by `scripts/setup-ghostty.sh`.
+- `scripts/install_common.sh` – standard bootstrap entrypoint; installs `curl`, `unzip`, `git` everywhere, then on macOS/Linux installs `zsh`, `starship`, `tmux`, `neovim`, `cargo`, and runs `scripts/setup-ghostty.sh` for Ghostty. On Windows it runs PowerShell setup and does not attempt Ghostty install.
 - `hosts/desktop` and `hosts/work_laptop` – host overlays for machine-specific tweaks.
 - `windows-terminal` – minimal starter `settings.json` for Windows Terminal. The
   file is built from `common-profiles.json` using `generate_settings.py`.
@@ -113,6 +114,19 @@ New-Item -ItemType SymbolicLink -Path $Env:USERPROFILE\\AppData\\Local\\Packages
 ```
 
 These examples assume the repository is cloned in a convenient location. Adjust the paths to match your setup.
+
+## Standard bootstrap command
+
+From the repository root run:
+
+```bash
+./scripts/install_common.sh
+```
+
+Platform behavior is explicit:
+
+- **Linux/macOS**: installs shell/editor/multiplexer stack (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and then installs/configures **Ghostty** via `scripts/setup-ghostty.sh`.
+- **Windows**: runs the PowerShell bootstrap path and optional Windows Terminal/WSL setup flags; Ghostty is intentionally skipped.
 
 ## Neovim first run and startup profiling
 
@@ -253,7 +267,7 @@ traditional command palette is available with **Ctrl+Shift+P**.
    stow dotfiles/shell
    stow dotfiles/nvim
    stow dotfiles/tmux
-   ./scripts/setup-ghostty.sh
+   ./scripts/install_common.sh
    ```
 
    Stow cleanly manages symlinks, letting you enable or disable packages with `stow -D <name>`.

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -29,6 +29,13 @@ run_cmd() {
 ensure_deps() {
     local missing=()
     for cmd in "$@"; do
+        if [[ $cmd == "neovim" ]]; then
+            if ! command -v nvim >/dev/null 2>&1; then
+                missing+=("$cmd")
+            fi
+            continue
+        fi
+
         if ! command -v "$cmd" >/dev/null 2>&1; then
             missing+=("$cmd")
         fi
@@ -64,6 +71,20 @@ ensure_deps() {
             exit 1
         fi
     fi
+}
+
+install_terminal_emulator() {
+    case $OSTYPE in
+        darwin*|linux*)
+            run_cmd bash "$scripts/setup-ghostty.sh"
+            ;;
+        msys*|cygwin*|win32*|windows*)
+            echo "Skipping Ghostty install on Windows; use Windows Terminal setup options instead."
+            ;;
+        *)
+            echo "Skipping terminal emulator install for unsupported platform: $OSTYPE"
+            ;;
+    esac
 }
 
 run_pwsh() {
@@ -211,11 +232,12 @@ if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == 
     run_pwsh fix-path.ps1
     run_pwsh helpers/install_common.ps1
 else
-    ensure_deps zsh starship
+    ensure_deps zsh starship tmux neovim cargo
     clone_plugin_if_missing "$autosuggest_repo" "$plugin_root/zsh-autosuggestions"
     clone_plugin_if_missing "$syntax_highlight_repo" "$plugin_root/zsh-syntax-highlighting"
     update_zshrc_plugins
     prompt_set_default_shell
+    install_terminal_emulator
 
     run_cmd bash "$scripts/setup-hooks.sh"
     run_cmd bash "$scripts/helpers/install_fonts.sh"


### PR DESCRIPTION
### Motivation

- Ensure the repository bootstrap installs the tools required by the configured dotfiles (tmux, Neovim) and to make Ghostty the canonical terminal emulator on Unix, while keeping platform conditionals explicit.
- Provide a single documented entrypoint (`./scripts/install_common.sh`) that performs the standard bootstrap and documents the exact toolchain and platform behavior.

### Description

- Updated `scripts/install_common.sh` to include `tmux`, `neovim` (special-cased to check for the `nvim` executable) and `cargo` in the Unix bootstrap dependencies and to call an emulator installer.
- Added an `install_terminal_emulator` helper that invokes `scripts/setup-ghostty.sh` on macOS/Linux and explicitly skips Ghostty on Windows with a clear message, and wired this into the non-Windows bootstrap path.
- Updated `README.md` and `docs/terminal.md` to document `./scripts/install_common.sh` as the standard bootstrap command, enumerate the installed toolchain (`zsh`, `starship`, `tmux`, `neovim`, `cargo` on macOS/Linux), and clarify platform behavior and examples.

### Testing

- Ran `bash -n scripts/install_common.sh` to validate syntax, which succeeded.
- Ran `./scripts/install_common.sh --dry-run` to validate package-manager commands, which printed expected install actions (for example `sudo apt-get install -y zsh starship tmux neovim`) though the script can exit non-zero in this environment when required system commands are absent; output confirms the intended install flow.
- Ran `bash -x ./scripts/install_common.sh --dry-run` to trace execution and confirmed the Unix branches, plugin cloning and the Ghostty invocation; `shellcheck` was not available in this environment so it was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e05387288326b9c56b3878a9fa0c)