### PR TITLE
Align Neovim visuals with Blacklight palette (nightfox + lualine overrides)

### DIFF
--- a/dotfiles/nvim/.config/nvim/lua/config/theme_overrides.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/theme_overrides.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+function M.apply(palette)
+    vim.api.nvim_set_hl(0, "CursorLine", { bg = "#121212" })
+    vim.api.nvim_set_hl(0, "CursorLineNr", { fg = palette.yellow, bold = true })
+
+    vim.api.nvim_set_hl(0, "DiagnosticError", { fg = palette.pink })
+    vim.api.nvim_set_hl(0, "DiagnosticWarn", { fg = palette.yellow })
+    vim.api.nvim_set_hl(0, "DiagnosticInfo", { fg = palette.blue })
+    vim.api.nvim_set_hl(0, "DiagnosticHint", { fg = palette.cyan })
+
+    vim.api.nvim_set_hl(0, "DiagnosticVirtualTextError", { fg = palette.pink, bg = "#1a0f16" })
+    vim.api.nvim_set_hl(0, "DiagnosticVirtualTextWarn", { fg = palette.yellow, bg = "#1a1a0f" })
+    vim.api.nvim_set_hl(0, "DiagnosticVirtualTextInfo", { fg = palette.blue, bg = "#0f141a" })
+    vim.api.nvim_set_hl(0, "DiagnosticVirtualTextHint", { fg = palette.cyan, bg = "#0f1a1a" })
+end
+
+return M

--- a/dotfiles/nvim/.config/nvim/lua/plugins/colorscheme.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/colorscheme.lua
@@ -1,14 +1,52 @@
 return {
     {
-        "folke/tokyonight.nvim",
+        "EdenEast/nightfox.nvim",
         lazy = false,
         priority = 1000,
-        opts = {
-            style = "moon",
-        },
-        config = function(_, opts)
-            require("tokyonight").setup(opts)
-            vim.cmd.colorscheme("tokyonight")
+        config = function()
+            -- Blacklight palette source of truth lives in terminal layer configs
+            -- (ghostty/tmux, and starship when present) to avoid theme drift.
+            local blacklight = {
+                bg = "#000000",
+                fg = "#f2f2f2",
+                gray = "#666666",
+                pink = "#ff66c4",
+                green = "#b2ff59",
+                yellow = "#ffff66",
+                blue = "#66b2ff",
+                purple = "#845CFF",
+                cyan = "#66fff2",
+                magenta = "#FC17DA",
+                white = "#ffffff",
+            }
+
+            require("nightfox").setup({
+                options = {
+                    transparent = false,
+                },
+                palettes = {
+                    nightfox = {
+                        bg1 = blacklight.bg,
+                        bg0 = blacklight.bg,
+                        bg3 = "#121212",
+                        sel0 = "#1a1a1a",
+                        fg1 = blacklight.fg,
+                        fg0 = blacklight.white,
+                        comment = blacklight.gray,
+                        blue = blacklight.blue,
+                        cyan = blacklight.cyan,
+                        green = blacklight.green,
+                        magenta = blacklight.magenta,
+                        pink = blacklight.pink,
+                        red = blacklight.pink,
+                        yellow = blacklight.yellow,
+                        orange = blacklight.purple,
+                    },
+                },
+            })
+
+            vim.cmd.colorscheme("nightfox")
+            require("config.theme_overrides").apply(blacklight)
         end,
     },
 }

--- a/dotfiles/nvim/.config/nvim/lua/plugins/lualine.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/lualine.lua
@@ -7,8 +7,31 @@ return {
         },
         opts = {
             options = {
-                theme = "tokyonight",
                 globalstatus = true,
+                theme = {
+                    normal = {
+                        a = { bg = "#845CFF", fg = "#000000", gui = "bold" },
+                        b = { bg = "#121212", fg = "#f2f2f2" },
+                        c = { bg = "#000000", fg = "#f2f2f2" },
+                    },
+                    insert = {
+                        a = { bg = "#66b2ff", fg = "#000000", gui = "bold" },
+                    },
+                    visual = {
+                        a = { bg = "#FC17DA", fg = "#000000", gui = "bold" },
+                    },
+                    replace = {
+                        a = { bg = "#ff66c4", fg = "#000000", gui = "bold" },
+                    },
+                    command = {
+                        a = { bg = "#b2ff59", fg = "#000000", gui = "bold" },
+                    },
+                    inactive = {
+                        a = { bg = "#121212", fg = "#666666" },
+                        b = { bg = "#121212", fg = "#666666" },
+                        c = { bg = "#000000", fg = "#666666" },
+                    },
+                },
             },
         },
     },


### PR DESCRIPTION
### Motivation

- Ensure Neovim colors and statusline match the existing Blacklight palette used by terminal/tmux/starship to avoid visual drift. 
- Keep diagnostics, cursorline, and statusline readable with `termguicolors` enabled by making the palette explicit in the editor layer. 
- Provide a small, maintainable override surface so future tweaks remain localized and reference the terminal palette as the source of truth.

### Description

- Replaced `folke/tokyonight.nvim` with `EdenEast/nightfox.nvim` and mapped Nightfox palette entries to the Blacklight color values inside the colorscheme plugin config. 
- Added `lua/config/theme_overrides.lua` which applies explicit highlight overrides via `vim.api.nvim_set_hl` for `CursorLine`, `CursorLineNr`, diagnostic groups, and virtual text backgrounds. 
- Updated `lualine` configuration to an inline theme that uses the same Blacklight color values across modes so the statusline remains consistent with the editor and tmux. 
- Documented in-code that the Blacklight palette source-of-truth is maintained in the terminal layer (ghostty/tmux/starship) to avoid future drift.

### Testing

- Attempted `stylua --check dotfiles/nvim/.config/nvim/lua/plugins/colorscheme.lua dotfiles/nvim/.config/nvim/lua/plugins/lualine.lua dotfiles/nvim/.config/nvim/lua/config/theme_overrides.lua` but `stylua` is not installed in this environment. 
- Attempted `luac -p` to validate Lua syntax but `luac` is not installed in this environment. 
- Attempted `nvim --headless '+lua vim.cmd("qa")'` to exercise the runtime setup but `nvim` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e1964f208326b7b646b24fcd2343)