### PR TITLE
Render Ghostty config from host defaults and overrides

### DIFF
--- a/dotfiles/ghostty/ghostty.toml.tmpl
+++ b/dotfiles/ghostty/ghostty.toml.tmpl
@@ -4,7 +4,9 @@ font-size = 13
 
 # Window + background polish
 background = "#000000"
-background-opacity = 0.92
+background-opacity = __BACKGROUND_OPACITY__
+custom-shader-animation-max-fps = __MAX_FPS__
+custom-shader = __EFFECTS__
 window-padding-x = 10
 window-padding-y = 8
 window-theme = "dark"

--- a/scripts/setup-ghostty.sh
+++ b/scripts/setup-ghostty.sh
@@ -13,22 +13,43 @@ if ! command -v ghostty >/dev/null 2>&1; then
     cargo install --locked ghostty
 fi
 
-config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ghostty"
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+config_dir="$config_home/ghostty"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-canonical_source="$repo_root/dotfiles/ghostty/ghostty.toml"
+canonical_template="$repo_root/dotfiles/ghostty/ghostty.toml.tmpl"
 config_file="$config_dir/ghostty.toml"
 mkdir -p "$config_dir"
 
-if [[ ! -f "$canonical_source" ]]; then
-    echo "Error: managed Ghostty config is missing at $canonical_source" >&2
+if [[ ! -f "$canonical_template" ]]; then
+    echo "Error: managed Ghostty template is missing at $canonical_template" >&2
     exit 1
 fi
 
-if [[ -e "$config_file" ]]; then
-    echo "Configuration already exists at $config_file"
+source_if_exists() {
+    local file_path="$1"
+    if [[ -f "$file_path" ]]; then
+        # shellcheck disable=SC1090
+        source "$file_path"
+    fi
+}
+
+source_if_exists "$config_home/tino/terminal-defaults.sh"
+source_if_exists "$config_home/tino/host-overrides.sh"
+
+background_opacity="${TERMINAL_OPACITY:-0.92}"
+max_fps="${TERMINAL_FPS:-60}"
+effects="${TERMINAL_EFFECTS:-\"crt\"}"
+
+template_contents="$(<"$canonical_template")"
+rendered_config="${template_contents//__BACKGROUND_OPACITY__/$background_opacity}"
+rendered_config="${rendered_config//__MAX_FPS__/$max_fps}"
+rendered_config="${rendered_config//__EFFECTS__/$effects}"
+
+if [[ -f "$config_file" ]] && [[ "$(<"$config_file")" == "$rendered_config" ]]; then
+    echo "Configuration already up to date at $config_file"
 else
-    cp "$canonical_source" "$config_file"
-    echo "Configuration copied to $config_file"
+    printf '%s\n' "$rendered_config" >"$config_file"
+    echo "Configuration rendered to $config_file"
 fi
 
 echo "Ghostty installed."

--- a/tests/test_dotfiles.py
+++ b/tests/test_dotfiles.py
@@ -45,7 +45,7 @@ def test_readme_layout_paths_exist():
         REPO_ROOT / "dotfiles" / "nvim",
         REPO_ROOT / "dotfiles" / "tmux",
         REPO_ROOT / "dotfiles" / "terminal",
-        REPO_ROOT / "dotfiles" / "ghostty" / "ghostty.toml",
+        REPO_ROOT / "dotfiles" / "ghostty" / "ghostty.toml.tmpl",
         REPO_ROOT / "hosts" / "desktop",
         REPO_ROOT / "hosts" / "work_laptop",
     )

--- a/tests/test_setup_ghostty.py
+++ b/tests/test_setup_ghostty.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+
 def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
     path.write_text(contents)
     path.chmod(0o755)
@@ -36,7 +37,7 @@ def test_setup_ghostty_requires_cargo(tmp_path: Path) -> None:
     assert "cargo is required" in result.stderr
 
 
-def test_setup_ghostty_installs_and_copies(tmp_path: Path) -> None:
+def test_setup_ghostty_installs_and_renders(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     scripts_dir = repo / "scripts"
@@ -50,11 +51,13 @@ def test_setup_ghostty_installs_and_copies(tmp_path: Path) -> None:
     create_exe(bin_dir / "cargo", f"#!/usr/bin/env bash\necho \"$@\" > '{cargo_log}'\n")
 
     env = os.environ.copy()
-    env.update({
-        "PATH": f"{bin_dir}:{env['PATH']}",
-        "HOME": str(tmp_path),
-        "XDG_CONFIG_HOME": str(tmp_path / "config"),
-    })
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "HOME": str(tmp_path),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        }
+    )
 
     subprocess.run(
         ["/bin/bash", "scripts/setup-ghostty.sh"],
@@ -66,19 +69,78 @@ def test_setup_ghostty_installs_and_copies(tmp_path: Path) -> None:
     assert cargo_log.read_text().strip() == "install --locked ghostty"
     config_file = Path(env["XDG_CONFIG_HOME"]) / "ghostty/ghostty.toml"
     assert config_file.exists()
+    config_contents = config_file.read_text()
+    assert "background-opacity = 0.92" in config_contents
+    assert 'custom-shader = "crt"' in config_contents
 
 
-def test_managed_ghostty_config_has_required_keys() -> None:
-    config_path = REPO_ROOT / "dotfiles" / "ghostty" / "ghostty.toml"
-    legacy_config_path = REPO_ROOT / "dotfiles" / "terminal" / ".config" / "ghostty" / "ghostty.toml"
-    contents = config_path.read_text()
+def test_setup_ghostty_renders_host_overrides(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(REPO_ROOT / "scripts" / "setup-ghostty.sh", scripts_dir / "setup-ghostty.sh")
+    shutil.copytree(REPO_ROOT / "dotfiles", repo / "dotfiles")
 
-    assert not legacy_config_path.exists()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    create_exe(bin_dir / "cargo", "#!/usr/bin/env bash\n")
+    create_exe(bin_dir / "ghostty", "#!/usr/bin/env bash\n")
+
+    config_home = tmp_path / "config"
+    tino_dir = config_home / "tino"
+    tino_dir.mkdir(parents=True)
+    (tino_dir / "terminal-defaults.sh").write_text(
+        "TERMINAL_OPACITY=0.91\nTERMINAL_FPS=120\nTERMINAL_EFFECTS='\"scanlines\"'\n"
+    )
+    (tino_dir / "host-overrides.sh").write_text("TERMINAL_OPACITY=0.73\nTERMINAL_FPS=144\n")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "HOME": str(tmp_path),
+            "XDG_CONFIG_HOME": str(config_home),
+        }
+    )
+
+    first = subprocess.run(
+        ["/bin/bash", "scripts/setup-ghostty.sh"],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    config_file = config_home / "ghostty" / "ghostty.toml"
+    config_contents = config_file.read_text()
+    assert "background-opacity = 0.73" in config_contents
+    assert "custom-shader-animation-max-fps = 144" in config_contents
+    assert 'custom-shader = "scanlines"' in config_contents
+    assert "Configuration rendered" in first.stdout
+
+    second = subprocess.run(
+        ["/bin/bash", "scripts/setup-ghostty.sh"],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "Configuration already up to date" in second.stdout
+
+
+def test_managed_ghostty_template_has_required_keys() -> None:
+    template_path = REPO_ROOT / "dotfiles" / "ghostty" / "ghostty.toml.tmpl"
+    contents = template_path.read_text()
 
     required = [
         "font-family = ",
         "font-size = ",
-        "background-opacity = ",
+        "background-opacity = __BACKGROUND_OPACITY__",
+        "custom-shader-animation-max-fps = __MAX_FPS__",
+        "custom-shader = __EFFECTS__",
         "cursor-style = ",
         "window-title = ",
     ]
@@ -89,9 +151,9 @@ def test_managed_ghostty_config_has_required_keys() -> None:
     assert len(palette_entries) >= 16
 
 
-def test_setup_script_uses_canonical_config_path() -> None:
+def test_setup_script_uses_canonical_template_path() -> None:
     script_path = REPO_ROOT / "scripts" / "setup-ghostty.sh"
     script_contents = script_path.read_text()
 
-    assert 'canonical_source="$repo_root/dotfiles/ghostty/ghostty.toml"' in script_contents
+    assert 'canonical_template="$repo_root/dotfiles/ghostty/ghostty.toml.tmpl"' in script_contents
     assert "dotfiles/terminal/.config/ghostty/ghostty.toml" not in script_contents


### PR DESCRIPTION
### Motivation
- Allow host-specific variables to influence the managed Ghostty configuration by rendering a template instead of copying a static file. 
- Expose opacity, FPS, and shader/effects as configurable values surfaced through terminal defaults and host overrides. 
- Keep setup idempotent and safe by providing sensible defaults and only writing the config when content actually changes.

### Description
- Switched `scripts/setup-ghostty.sh` from copying a static `dotfiles/ghostty/ghostty.toml` to rendering `dotfiles/ghostty/ghostty.toml.tmpl` with placeholders for opacity, FPS, and effects. 
- Script now sources `${XDG_CONFIG_HOME:-$HOME/.config}/tino/terminal-defaults.sh` and `.../host-overrides.sh` when present and renders values from `TERMINAL_OPACITY`, `TERMINAL_FPS`, and `TERMINAL_EFFECTS` with safe defaults. 
- Implemented idempotent behavior so `~/.config/ghostty/ghostty.toml` is only rewritten when the rendered content differs. 
- Updated and added tests to validate template presence, rendering defaults, host-overrides precedence, and idempotence, and renamed the managed config file to `ghostty.toml.tmpl`.

### Testing
- Ran `pytest tests/test_setup_ghostty.py tests/test_dotfiles.py` and all tests passed (`7 passed`).
- Ran `ruff check tests/test_setup_ghostty.py tests/test_dotfiles.py` and the linter passed.
- Attempted `shellcheck scripts/setup-ghostty.sh` but `shellcheck` was not available in the environment (no result).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e318c32483268aaf0dde2ee412e6)