### PR TITLE
Align WSL terminal bootstrap with Ghostty default

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -180,8 +180,11 @@ You can also pass `--install-wsl` to `install.sh` or `-InstallWSL` to
 
 Run the provided script from the repository root to install the basic tools on
 a fresh Ubuntu/WSL instance. The script uses `apt-get` and may prompt for your
-password. Invoke it directly inside WSL or pass `--setup-wsl` to `install.sh` or
-`-SetupWSL` to `bootstrap.ps1` from Windows to run it via `wsl.exe`:
+password. It follows the same canonical terminal path as Linux/macOS by
+installing and configuring **Ghostty** through `scripts/setup-ghostty.sh`,
+including the managed Blacklight theme and Nerd Font defaults. Invoke it
+directly inside WSL or pass `--setup-wsl` to `install.sh` or `-SetupWSL` to
+`bootstrap.ps1` from Windows to run it via `wsl.exe`:
 
 ```bash
 sudo bash scripts/setup-wsl.sh
@@ -350,7 +353,7 @@ On Windows you can call the PowerShell wrapper or use `bootstrap.ps1` with the
 cargo install ghostty
 ```
 
-Ghostty is the standard terminal profile in this repository. `scripts/setup-ghostty.sh` copies the managed config from `dotfiles/ghostty/ghostty.toml` into `~/.config/ghostty/ghostty.toml`, including Nerd Font defaults, Blacklight colors, opacity, and cursor polish settings.
+Ghostty is the standard terminal profile in this repository on Linux, macOS, and WSL. `scripts/setup-ghostty.sh` copies the managed template from `dotfiles/ghostty/ghostty.toml.tmpl` into `~/.config/ghostty/ghostty.toml`, including Nerd Font defaults, Blacklight colors, opacity, and cursor polish settings.
 
 ```toml
 font-family = "JetBrainsMono Nerd Font"

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -87,8 +87,9 @@ This repository includes example setups for various tools:
 - `dotfiles/shell` – `.zshrc`, `.bashrc`, and `~/.config/starship.toml`.
 - `dotfiles/nvim` – Neovim package (`~/.config/nvim/...`).
 - `dotfiles/tmux` – `.tmux.conf`.
-- `dotfiles/ghostty/ghostty.toml` – canonical Ghostty configuration managed by `scripts/setup-ghostty.sh`.
+- `dotfiles/ghostty/ghostty.toml.tmpl` – canonical Ghostty configuration template managed by `scripts/setup-ghostty.sh`.
 - `scripts/install_common.sh` – standard bootstrap entrypoint; installs `curl`, `unzip`, `git` everywhere, then on macOS/Linux installs `zsh`, `starship`, `tmux`, `neovim`, `cargo`, and runs `scripts/setup-ghostty.sh` for Ghostty. On Windows it runs PowerShell setup and does not attempt Ghostty install.
+- `scripts/setup-wsl.sh` – WSL bootstrap helper; installs the same base stack and then runs `scripts/setup-ghostty.sh` so WSL follows the same managed Ghostty profile (Blacklight theme + Nerd Font defaults).
 - `hosts/desktop` and `hosts/work_laptop` – host overlays for machine-specific tweaks.
 - `windows-terminal` – minimal starter `settings.json` for Windows Terminal. The
   file is built from `common-profiles.json` using `generate_settings.py`.
@@ -125,8 +126,10 @@ From the repository root run:
 
 Platform behavior is explicit:
 
-- **Linux/macOS**: installs shell/editor/multiplexer stack (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and then installs/configures **Ghostty** via `scripts/setup-ghostty.sh`.
-- **Windows**: runs the PowerShell bootstrap path and optional Windows Terminal/WSL setup flags; Ghostty is intentionally skipped.
+- **Linux/macOS/WSL**: installs shell/editor/multiplexer stack (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and then installs/configures **Ghostty** via `scripts/setup-ghostty.sh` for a single canonical terminal path and shared theme behavior.
+- **Windows**: runs the PowerShell bootstrap path and optional Windows Terminal/WSL setup flags; native Ghostty install is intentionally skipped on Windows itself.
+
+Optional alternative: use Windows Terminal as your host terminal app while running Ghostty inside WSL for the managed Linux profile, or keep Windows Terminal-only settings for native PowerShell workflows.
 
 ## Neovim first run and startup profiling
 

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -33,24 +33,11 @@ sudo apt-get install -y \
     curl \
     zsh \
     neovim \
-    tmux
+    tmux \
+    cargo
 
-install_terminal() {
-    local terminal="alacritty"
-
-    if command -v "$terminal" >/dev/null 2>&1; then
-        return
-    fi
-
-    sudo apt-get install -y "$terminal"
-
-    if ! command -v "$terminal" >/dev/null 2>&1; then
-        echo "Error: $terminal installation failed." >&2
-        exit 1
-    fi
-}
-
-install_terminal
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$script_dir/setup-ghostty.sh"
 
 ensure_shallow_plugin_repo() {
     local repo_url="$1"


### PR DESCRIPTION
### Motivation
- Provide a single canonical terminal path across Linux/macOS/WSL so terminal config, fonts, and the Blacklight theme are managed consistently.
- Remove the ad-hoc Alacritty install in the WSL helper and ensure WSL follows the same managed Ghostty profile used by the common installer.

### Description
- Updated `scripts/setup-wsl.sh` to stop installing Alacritty directly and instead install `cargo` and invoke `scripts/setup-ghostty.sh` so the repository-managed Ghostty template is deployed in WSL.
- Added `cargo` to the WSL `apt-get` package list to support installing Ghostty via `cargo` when necessary.
- Updated `docs/installation.md` to document that the WSL setup follows the same canonical Ghostty path and deploys the Blacklight theme and Nerd Font defaults via `scripts/setup-ghostty.sh`.
- Updated `docs/terminal.md` to reference the actual Ghostty template file `dotfiles/ghostty/ghostty.toml.tmpl`, include `scripts/setup-wsl.sh` in the managed flow, and clarify Windows Terminal as an optional host-side alternative.

### Testing
- Performed shell syntax checks with `bash -n scripts/setup-wsl.sh scripts/setup-ghostty.sh scripts/install_common.sh`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e6a833248326aa947dcb2af1aa8b)