### PR TITLE
docs: clarify Ghostty config template source of truth

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -353,7 +353,7 @@ On Windows you can call the PowerShell wrapper or use `bootstrap.ps1` with the
 cargo install ghostty
 ```
 
-Ghostty is the standard terminal profile in this repository on Linux, macOS, and WSL. `scripts/setup-ghostty.sh` copies the managed template from `dotfiles/ghostty/ghostty.toml.tmpl` into `~/.config/ghostty/ghostty.toml`, including Nerd Font defaults, Blacklight colors, opacity, and cursor polish settings.
+Ghostty is the standard terminal profile in this repository on Linux, macOS, and WSL. `scripts/setup-ghostty.sh` renders the managed source-of-truth template `dotfiles/ghostty/ghostty.toml.tmpl` into `~/.config/ghostty/ghostty.toml`, including Nerd Font defaults, Blacklight colors, opacity, and cursor polish settings. Template values come from `~/.config/tino/terminal-defaults.sh` and host-specific overrides from `~/.config/tino/host-overrides.sh`.
 
 ```toml
 font-family = "JetBrainsMono Nerd Font"

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -87,7 +87,7 @@ This repository includes example setups for various tools:
 - `dotfiles/shell` – `.zshrc`, `.bashrc`, and `~/.config/starship.toml`.
 - `dotfiles/nvim` – Neovim package (`~/.config/nvim/...`).
 - `dotfiles/tmux` – `.tmux.conf`.
-- `dotfiles/ghostty/ghostty.toml.tmpl` – canonical Ghostty configuration template managed by `scripts/setup-ghostty.sh`.
+- `dotfiles/ghostty/ghostty.toml.tmpl` – canonical Ghostty configuration template (source of truth) managed by `scripts/setup-ghostty.sh`.
 - `scripts/install_common.sh` – standard bootstrap entrypoint; installs `curl`, `unzip`, `git` everywhere, then on macOS/Linux installs `zsh`, `starship`, `tmux`, `neovim`, `cargo`, and runs `scripts/setup-ghostty.sh` for Ghostty. On Windows it runs PowerShell setup and does not attempt Ghostty install.
 - `scripts/setup-wsl.sh` – WSL bootstrap helper; installs the same base stack and then runs `scripts/setup-ghostty.sh` so WSL follows the same managed Ghostty profile (Blacklight theme + Nerd Font defaults).
 - `hosts/desktop` and `hosts/work_laptop` – host overlays for machine-specific tweaks.
@@ -128,6 +128,8 @@ Platform behavior is explicit:
 
 - **Linux/macOS/WSL**: installs shell/editor/multiplexer stack (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and then installs/configures **Ghostty** via `scripts/setup-ghostty.sh` for a single canonical terminal path and shared theme behavior.
 - **Windows**: runs the PowerShell bootstrap path and optional Windows Terminal/WSL setup flags; native Ghostty install is intentionally skipped on Windows itself.
+
+For Ghostty, `scripts/setup-ghostty.sh` renders `dotfiles/ghostty/ghostty.toml.tmpl` into `~/.config/ghostty/ghostty.toml`. Template values are driven by terminal defaults from `~/.config/tino/terminal-defaults.sh` and host-specific overrides from `~/.config/tino/host-overrides.sh`.
 
 Optional alternative: use Windows Terminal as your host terminal app while running Ghostty inside WSL for the managed Linux profile, or keep Windows Terminal-only settings for native PowerShell workflows.
 


### PR DESCRIPTION
### Motivation
- Make it explicit that the canonical Ghostty configuration is a template file and not the deployed config file. 
- Document where the template is rendered and which files drive template values to avoid confusion when customizing terminal settings.

### Description
- Updated `docs/terminal.md` to mark `dotfiles/ghostty/ghostty.toml.tmpl` as the source-of-truth template and added a short note about the render step and value sources. 
- Updated `docs/installation.md` to state that `scripts/setup-ghostty.sh` renders `dotfiles/ghostty/ghostty.toml.tmpl` into `~/.config/ghostty/ghostty.toml`. 
- Documented that template values come from `~/.config/tino/terminal-defaults.sh` and host-specific overrides from `~/.config/tino/host-overrides.sh`.

### Testing
- Ran repository searches (`rg`) to verify occurrences of `ghostty.toml(.tmpl)?`, `setup-ghostty`, `terminal-defaults`, and `host-overrides` in the updated docs and inspected the diffs; all checks succeeded.
- Verified the local `git diff` and committed the changes successfully, and created the PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e7e060b88326a6bb044b0679cd47)