### PR TITLE
Refactor bootstrap to stop editing user .zshrc and add explicit migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/tmux` → `.tmux.conf`
 - `dotfiles/terminal` → shared terminal defaults in `~/.config/tino/terminal-defaults.sh`
 - `dotfiles/ghostty/ghostty.toml` → **canonical** Ghostty config; `scripts/setup-ghostty.sh` deploys it to `~/.config/ghostty/ghostty.toml`
-- `scripts/install_common.sh` → standard bootstrap script; on macOS/Linux it installs `zsh`, `starship`, `tmux`, `neovim`, `cargo`, and then runs `scripts/setup-ghostty.sh` to install/configure Ghostty (Windows skips Ghostty and keeps Windows Terminal flow).
+- `scripts/install_common.sh` → standard bootstrap script; on macOS/Linux it installs dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and then runs `scripts/setup-ghostty.sh` to install/configure Ghostty. It installs zsh plugins under `~/.local/share/zsh/plugins` but does not modify user shell rc files (Windows skips Ghostty and keeps Windows Terminal flow).
+- `scripts/install_dotfiles.sh` → deploys dotfiles that control runtime shell behavior (`dotfiles/shell/.zshrc` is the source of truth for plugin sourcing and `starship init`).
+- `scripts/migrate-shell-config.sh` → optional one-time manual migration that removes the legacy d0tTino plugin marker block from `~/.zshrc` after creating a timestamped backup.
 - `hosts/desktop` and `hosts/work_laptop` → machine-specific overrides
 
 Example:

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -88,7 +88,9 @@ This repository includes example setups for various tools:
 - `dotfiles/nvim` – Neovim package (`~/.config/nvim/...`).
 - `dotfiles/tmux` – `.tmux.conf`.
 - `dotfiles/ghostty/ghostty.toml.tmpl` – canonical Ghostty configuration template (source of truth) managed by `scripts/setup-ghostty.sh`.
-- `scripts/install_common.sh` – standard bootstrap entrypoint; installs `curl`, `unzip`, `git` everywhere, then on macOS/Linux installs `zsh`, `starship`, `tmux`, `neovim`, `cargo`, and runs `scripts/setup-ghostty.sh` for Ghostty. On Windows it runs PowerShell setup and does not attempt Ghostty install.
+- `scripts/install_common.sh` – standard bootstrap entrypoint; installs `curl`, `unzip`, `git` everywhere, then on macOS/Linux installs dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and runs `scripts/setup-ghostty.sh` for Ghostty. It installs zsh plugins into `~/.local/share/zsh/plugins` but does not edit user rc files. On Windows it runs PowerShell setup and does not attempt Ghostty install.
+- `scripts/install_dotfiles.sh` – deploys dotfiles that control shell runtime behavior; `dotfiles/shell/.zshrc` is the source of truth for plugin sourcing and Starship init.
+- `scripts/migrate-shell-config.sh` – optional one-time manual migration for removing the legacy d0tTino marker block from `~/.zshrc` after writing a backup.
 - `scripts/setup-wsl.sh` – WSL bootstrap helper; installs the same base stack and then runs `scripts/setup-ghostty.sh` so WSL follows the same managed Ghostty profile (Blacklight theme + Nerd Font defaults).
 - `hosts/desktop` and `hosts/work_laptop` – host overlays for machine-specific tweaks.
 - `windows-terminal` – minimal starter `settings.json` for Windows Terminal. The
@@ -126,12 +128,21 @@ From the repository root run:
 
 Platform behavior is explicit:
 
-- **Linux/macOS/WSL**: installs shell/editor/multiplexer stack (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and then installs/configures **Ghostty** via `scripts/setup-ghostty.sh` for a single canonical terminal path and shared theme behavior.
+- **Linux/macOS/WSL**: installs shell/editor/multiplexer dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`), clones zsh plugins locally, and then installs/configures **Ghostty** via `scripts/setup-ghostty.sh` for a single canonical terminal path and shared theme behavior. Runtime shell setup comes from deployed dotfiles, not bootstrap-time rc edits.
 - **Windows**: runs the PowerShell bootstrap path and optional Windows Terminal/WSL setup flags; native Ghostty install is intentionally skipped on Windows itself.
 
 For Ghostty, `scripts/setup-ghostty.sh` renders `dotfiles/ghostty/ghostty.toml.tmpl` into `~/.config/ghostty/ghostty.toml`. Template values are driven by terminal defaults from `~/.config/tino/terminal-defaults.sh` and host-specific overrides from `~/.config/tino/host-overrides.sh` using canonical `TINO_TERMINAL_OPACITY`, `TINO_TERMINAL_FPS`, and `TINO_TERMINAL_EFFECTS` variables.
 
 Optional alternative: use Windows Terminal as your host terminal app while running Ghostty inside WSL for the managed Linux profile, or keep Windows Terminal-only settings for native PowerShell workflows.
+
+If you previously used older bootstrap behavior that injected a `d0tTino zsh plugins` marker block into `~/.zshrc`, run:
+
+```bash
+./scripts/migrate-shell-config.sh
+```
+
+The migration is intentionally manual and creates a timestamped backup before any changes.
+
 
 ## Neovim first run and startup profiling
 

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -121,56 +121,6 @@ clone_plugin_if_missing() {
     run_cmd git clone "$repo_url" "$destination"
 }
 
-update_zshrc_plugins() {
-    local zshrc="$HOME/.zshrc"
-    local start="# >>> d0tTino zsh plugins >>>"
-    local end="# <<< d0tTino zsh plugins <<<"
-    local desired
-    desired=$(cat <<EOF
-$start
-source "$plugin_root/zsh-autosuggestions/zsh-autosuggestions.zsh"
-source "$plugin_root/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-eval "\$(starship init zsh)"
-$end
-EOF
-)
-
-    if [[ -f "$zshrc" ]] && grep -Fq "$start" "$zshrc" && grep -Fq "$end" "$zshrc"; then
-        local tmp
-        tmp=$(mktemp)
-        awk -v start="$start" -v end="$end" -v block="$desired" '
-            $0 == start {
-                print block
-                in_block = 1
-                next
-            }
-            in_block && $0 == end {
-                in_block = 0
-                next
-            }
-            !in_block { print }
-        ' "$zshrc" > "$tmp"
-        if ! cmp -s "$tmp" "$zshrc"; then
-            run_cmd cp "$tmp" "$zshrc"
-        fi
-        rm -f "$tmp"
-        return
-    fi
-
-    if [[ -f "$zshrc" ]] && grep -Fq "$start" "$zshrc"; then
-        return
-    fi
-
-    if [[ ! -f "$zshrc" ]]; then
-        run_cmd touch "$zshrc"
-    fi
-    if [[ -s "$zshrc" ]]; then
-        run_cmd printf "\n%s\n" "$desired" >> "$zshrc"
-    else
-        run_cmd printf "%s\n" "$desired" >> "$zshrc"
-    fi
-}
-
 prompt_set_default_shell() {
     local zsh_path
     zsh_path="$(command -v zsh || true)"
@@ -244,7 +194,6 @@ else
     ensure_deps zsh starship tmux neovim cargo stow
     clone_plugin_if_missing "$autosuggest_repo" "$plugin_root/zsh-autosuggestions"
     clone_plugin_if_missing "$syntax_highlight_repo" "$plugin_root/zsh-syntax-highlighting"
-    update_zshrc_plugins
 
     dotfiles_args=()
     if [[ -n "$host_override" ]]; then

--- a/scripts/migrate-shell-config.sh
+++ b/scripts/migrate-shell-config.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+start="# >>> d0tTino zsh plugins >>>"
+end="# <<< d0tTino zsh plugins <<<"
+zshrc="${HOME}/.zshrc"
+
+if [[ ! -f "$zshrc" ]]; then
+    echo "No ~/.zshrc found; nothing to migrate."
+    exit 0
+fi
+
+if ! grep -Fq "$start" "$zshrc"; then
+    echo "No legacy d0tTino plugin block found in ~/.zshrc; nothing to migrate."
+    exit 0
+fi
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+backup_path="${zshrc}.pre-d0ttino-migration.${timestamp}.bak"
+cp "$zshrc" "$backup_path"
+echo "Backed up ~/.zshrc to $backup_path"
+
+tmp="$(mktemp)"
+awk -v start="$start" -v end="$end" '
+    $0 == start {
+        in_block = 1
+        next
+    }
+    in_block && $0 == end {
+        in_block = 0
+        next
+    }
+    !in_block { print }
+' "$zshrc" > "$tmp"
+
+cp "$tmp" "$zshrc"
+rm -f "$tmp"
+
+echo "Removed legacy d0tTino plugin block from ~/.zshrc"
+echo "Runtime shell config is now controlled by dotfiles/shell/.zshrc via scripts/install_dotfiles.sh"

--- a/tests/test_install_common.py
+++ b/tests/test_install_common.py
@@ -298,7 +298,7 @@ def test_install_common_setup_flags_windows(tmp_path: Path) -> None:
     assert "setup-docker.ps1" in lines
 
 
-def test_install_common_sets_up_zsh_plugins_and_zshrc(tmp_path: Path) -> None:
+def test_install_common_installs_zsh_plugins_without_touching_zshrc(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     repo = tmp_path / "repo_zsh"
     repo.mkdir()
@@ -321,7 +321,8 @@ def test_install_common_sets_up_zsh_plugins_and_zshrc(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     home_dir.mkdir()
     zshrc = home_dir / ".zshrc"
-    zshrc.write_text("# existing\n", encoding="utf-8")
+    existing_zshrc = "# existing\n"
+    zshrc.write_text(existing_zshrc, encoding="utf-8")
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -352,9 +353,7 @@ def test_install_common_sets_up_zsh_plugins_and_zshrc(tmp_path: Path) -> None:
     subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
 
     zshrc_content = zshrc.read_text(encoding="utf-8")
-    assert 'source "' + str(home_dir / ".local/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh") + '"' in zshrc_content
-    assert 'source "' + str(home_dir / ".local/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh") + '"' in zshrc_content
-    assert 'eval "$(starship init zsh)"' in zshrc_content
+    assert zshrc_content == existing_zshrc
 
     apt_lines = apt_log.read_text(encoding="utf-8").splitlines()
     assert any("install -y" in line and "zsh" in line for line in apt_lines)
@@ -363,7 +362,7 @@ def test_install_common_sets_up_zsh_plugins_and_zshrc(tmp_path: Path) -> None:
     assert sum(1 for line in git_lines if line.startswith("clone ")) == 2
 
 
-def test_install_common_zsh_plugin_setup_is_idempotent(tmp_path: Path) -> None:
+def test_install_common_does_not_append_plugin_marker_block_to_existing_zshrc(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     repo = tmp_path / "repo_zsh_idempotent"
     repo.mkdir()
@@ -405,12 +404,15 @@ def test_install_common_zsh_plugin_setup_is_idempotent(tmp_path: Path) -> None:
         "SHELL": "/bin/bash",
     })
 
-    subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
+    zshrc = home_dir / ".zshrc"
+    zshrc.write_text("# my custom config\n", encoding="utf-8")
+
     subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
 
-    zshrc_content = (home_dir / ".zshrc").read_text(encoding="utf-8")
-    assert zshrc_content.count("# >>> d0tTino zsh plugins >>>") == 1
-    assert zshrc_content.count('eval "$(starship init zsh)"') == 1
+    zshrc_content = zshrc.read_text(encoding="utf-8")
+    assert zshrc_content == "# my custom config\n"
+    assert "# >>> d0tTino zsh plugins >>>" not in zshrc_content
+    assert 'eval "$(starship init zsh)"' not in zshrc_content
 
     clone_lines = [line for line in git_log.read_text(encoding="utf-8").splitlines() if line.startswith("clone ")]
     assert len(clone_lines) == 2


### PR DESCRIPTION
### Motivation

- Prevent the bootstrap (`scripts/install_common.sh`) from mutating users' runtime shell RC files so dotfiles remain the single source of truth. 
- Keep bootstrap responsible for installing dependencies and plugin assets, not runtime sourcing and prompt initialization.
- Provide an explicit, one-time migration for existing users who previously had the legacy marker block injected into `~/.zshrc`.

### Description

- Removed the legacy `update_zshrc_plugins()` implementation and its invocation from `scripts/install_common.sh` while keeping `clone_plugin_if_missing()` so plugins are still cloned to `~/.local/share/zsh/plugins`.
- Added `scripts/migrate-shell-config.sh`, a manual migration helper that creates a timestamped backup of `~/.zshrc` and removes only the legacy `# >>> d0tTino zsh plugins >>>` marker block.
- Updated documentation in `README.md` and `docs/terminal.md` to state that bootstrap installs dependencies and plugin assets, while `dotfiles/shell/.zshrc` is the source of truth for runtime shell configuration and to document the migration step.
- Added/updated regression tests in `tests/test_install_common.py` to assert the bootstrap does not append the marker block or `starship init zsh` into a pre-existing `~/.zshrc` while still verifying plugin clone behavior.

### Testing

- Performed shell syntax check: `bash -n scripts/install_common.sh scripts/migrate-shell-config.sh` (passed).
- Ran linter on the modified tests: `python -m ruff check tests/test_install_common.py` (passed).
- Executed the targeted test suite: `pytest -q tests/test_install_common.py`, which completed successfully (`9 passed`, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b42dd53a48326a6485c10ab29d4e3)