### PR TITLE
Refactor Ghostty custom-shader rendering to emit path-only lines

### DIFF
--- a/dotfiles/ghostty/ghostty.toml.tmpl
+++ b/dotfiles/ghostty/ghostty.toml.tmpl
@@ -6,7 +6,7 @@ font-size = 13
 background = "#000000"
 background-opacity = __BACKGROUND_OPACITY__
 custom-shader-animation-max-fps = __MAX_FPS__
-custom-shader = __CUSTOM_SHADER__
+__CUSTOM_SHADER_LINE__
 window-padding-x = 10
 window-padding-y = 8
 window-theme = "dark"

--- a/scripts/setup-ghostty.sh
+++ b/scripts/setup-ghostty.sh
@@ -153,6 +153,38 @@ validate_number() {
     fi
 }
 
+is_path_like_effects_value() {
+    local raw_value="$1"
+
+    case "$raw_value" in
+        ./*|../*|~/*|/*|*/*|*.glsl)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+validate_effects_value() {
+    local raw_value="$1"
+    local value
+
+    value="$(printf '%s' "$raw_value" | tr '[:upper:]' '[:lower:]')"
+    case "$value" in
+        high|balanced|on|true|yes|1|off|false|no|0|none)
+            return 0
+            ;;
+    esac
+
+    if is_path_like_effects_value "$raw_value"; then
+        return 0
+    fi
+
+    echo "Error: invalid TINO_TERMINAL_EFFECTS '$raw_value'. Use a preset (on/off/balanced/high) or a shader path (e.g. ~/.config/ghostty/shaders/effect.glsl)." >&2
+    exit 1
+}
+
 normalize_effects_to_toml() {
     local raw_value="$1"
     local value
@@ -160,33 +192,32 @@ normalize_effects_to_toml() {
     value="$(printf '%s' "$raw_value" | tr '[:upper:]' '[:lower:]')"
     case "$value" in
         high|balanced|on|true|yes|1)
-            printf '%s' "true"
+            # Preset quality levels rely on Ghostty defaults and do not set custom-shader.
+            printf '%s' ""
             ;;
         off|false|no|0|none)
-            printf '%s' "false"
+            # Off disables extra effects and does not set custom-shader.
+            printf '%s' ""
             ;;
-        *.glsl|*/*)
-            # Treat shader file paths as TOML strings.
+        *)
+            # For valid path-like values, render a TOML string assignment.
             local escaped_value
             escaped_value="${raw_value//\\/\\\\}"
             escaped_value="${escaped_value//\"/\\\"}"
-            printf '"%s"' "$escaped_value"
-            ;;
-        *)
-            echo "Error: unknown TINO_TERMINAL_EFFECTS '$raw_value'. Use one of: on, off, balanced, high, true, false, or a shader path (*.glsl)." >&2
-            exit 1
+            printf 'custom-shader = "%s"' "$escaped_value"
             ;;
     esac
 }
 
 validate_number "$background_opacity" "TINO_TERMINAL_OPACITY" '^[0-9]+([.][0-9]+)?$'
 validate_number "$max_fps" "TINO_TERMINAL_FPS" '^[0-9]+$'
+validate_effects_value "$effects"
 effects_toml="$(normalize_effects_to_toml "$effects")"
 
 template_contents="$(<"$canonical_template")"
 rendered_config="${template_contents//__BACKGROUND_OPACITY__/$background_opacity}"
 rendered_config="${rendered_config//__MAX_FPS__/$max_fps}"
-rendered_config="${rendered_config//__CUSTOM_SHADER__/$effects_toml}"
+rendered_config="${rendered_config//__CUSTOM_SHADER_LINE__/$effects_toml}"
 
 if [[ -f "$config_file" ]] && [[ "$(<"$config_file")" == "$rendered_config" ]]; then
     echo "Configuration already up to date at $config_file"


### PR DESCRIPTION
### Motivation
- Ensure `custom-shader` is only present in the generated Ghostty config when a shader file path is provided, not for preset values. 
- Avoid emitting boolean values for `custom-shader` for presets like `on/high/balanced/off`. 
- Provide a clear shell-level validation to reject arbitrary non-path strings for `TINO_TERMINAL_EFFECTS`.

### Description
- Added `is_path_like_effects_value` and `validate_effects_value` helper functions in `scripts/setup-ghostty.sh` to detect path-like shader values and validate `TINO_TERMINAL_EFFECTS`. 
- Changed `normalize_effects_to_toml` in `scripts/setup-ghostty.sh` to emit an empty insertion for presets (`on/high/balanced/off`) and to emit a full TOML assignment `custom-shader = "..."` only when a path-like shader value is provided. 
- Updated template `dotfiles/ghostty/ghostty.toml.tmpl` to use the placeholder `__CUSTOM_SHADER_LINE__` for conditional insertion, and adjusted the renderer to replace `__CUSTOM_SHADER_LINE__` with the generated line (or empty string). 
- Ensured `off` and other presets do not produce a `custom-shader` line and added a clear error message when an invalid non-path string is supplied.

### Testing
- Ran a syntax check with `/usr/bin/env bash -n scripts/setup-ghostty.sh`, which succeeded. 
- Attempted `shellcheck` but it is not available in this environment, so that linter was not run. 
- Executed the setup script with a stubbed `ghostty` and temporary `XDG_CONFIG_HOME` for the following cases, all of which behaved as expected: `TINO_TERMINAL_EFFECTS=off` produced no `custom-shader` line (success). 
- `TINO_TERMINAL_EFFECTS=on` produced no `custom-shader` line (success). 
- `TINO_TERMINAL_EFFECTS='~/.config/ghostty/shaders/effect.glsl'` produced `custom-shader = "..."` (success). 
- `TINO_TERMINAL_EFFECTS='banana'` caused the script to exit with `rc=1` and printed the validation error (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5054ac4483269a950155855944b1)