### PR TITLE
Add Neovim startup benchmark script, docs, and optional CI workflow

### DIFF
--- a/.github/workflows/nvim-startup-benchmark.yml
+++ b/.github/workflows/nvim-startup-benchmark.yml
@@ -1,0 +1,25 @@
+name: Neovim Startup Benchmark
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Neovim
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y neovim
+      - name: Run benchmark
+        run: ./scripts/benchmark_nvim_startup.sh
+      - name: Upload startup benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nvim-startup-benchmark
+          path: .cache/tino/nvim-startup/
+          if-no-files-found: warn

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -181,13 +181,41 @@ Minimum CLI toolchain for Neovim integrations: `rg` (ripgrep) and `fd` (or `fdfi
 2. Wait for `lazy.nvim` to clone and install plugins.
 3. Run `:Lazy sync` if you want to force a full sync/update pass.
 
-To inspect startup performance:
+To inspect startup performance with a repeatable workflow:
 
 ```bash
-nvim --startuptime /tmp/nvim-startup.log +qa
+./scripts/benchmark_nvim_startup.sh
 ```
 
-Then open the log and review the slowest entries.
+The script always writes to:
+
+- `.cache/tino/nvim-startup/startup.log`
+- `.cache/tino/nvim-startup/summary.txt`
+
+### Before/after comparison flow
+
+1. Capture a baseline:
+
+   ```bash
+   ./scripts/benchmark_nvim_startup.sh
+   cp .cache/tino/nvim-startup/summary.txt .cache/tino/nvim-startup/summary-before.txt
+   ```
+
+2. Make your Neovim config/plugin changes.
+3. Capture an updated measurement:
+
+   ```bash
+   ./scripts/benchmark_nvim_startup.sh
+   cp .cache/tino/nvim-startup/summary.txt .cache/tino/nvim-startup/summary-after.txt
+   ```
+
+4. Compare results:
+
+   ```bash
+   diff -u .cache/tino/nvim-startup/summary-before.txt .cache/tino/nvim-startup/summary-after.txt
+   ```
+
+Use `TOP_COUNT=<n>` to control how many slow entries are included in the summary (default: `20`).
 
 ## Terminal Tools: fastfetch, btm & Nushell/Starship
 

--- a/scripts/benchmark_nvim_startup.sh
+++ b/scripts/benchmark_nvim_startup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR=".cache/tino/nvim-startup"
+LOG_FILE="${OUTPUT_DIR}/startup.log"
+SUMMARY_FILE="${OUTPUT_DIR}/summary.txt"
+TOP_COUNT="${TOP_COUNT:-20}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+if ! command -v nvim >/dev/null 2>&1; then
+  echo "Neovim (nvim) is not installed or not on PATH." >&2
+  exit 1
+fi
+
+printf 'Running Neovim startup benchmark...\n'
+nvim --headless --startuptime "${LOG_FILE}" +qa
+
+{
+  printf 'Neovim startup benchmark\n'
+  printf 'Generated: %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  printf 'Log file: %s\n\n' "${LOG_FILE}"
+  printf 'Top %s startup entries (ms)\n' "${TOP_COUNT}"
+  printf '%s\n' '----------------------------------------'
+
+  awk -F':' '
+    match($1, /([0-9]+\.[0-9]+)/, m) {
+      line = $2
+      gsub(/^ +/, "", line)
+      gsub(/ +$/, "", line)
+      if (line != "") {
+        printf "%.3f\t%s\n", m[1], line
+      }
+    }
+  ' "${LOG_FILE}" \
+    | sort -nr -k1,1 \
+    | head -n "${TOP_COUNT}" \
+    | awk -F'\t' '{printf "%9.3f | %s\n", $1, $2}'
+} > "${SUMMARY_FILE}"
+
+printf 'Startup log saved to: %s\n' "${LOG_FILE}"
+printf 'Summary saved to: %s\n' "${SUMMARY_FILE}"


### PR DESCRIPTION
### Motivation

- Provide a small, repeatable helper to measure Neovim startup time and surface the top slow contributors. 
- Store outputs under a deterministic cache path for easy before/after comparisons. 
- Offer optional CI visibility by uploading startup logs as artifacts on PRs or manual runs.

### Description

- Add `scripts/benchmark_nvim_startup.sh` which runs `nvim --headless --startuptime <log>` and writes `startup.log` and a sorted `summary.txt` to `.cache/tino/nvim-startup/`, with `TOP_COUNT` configurable (default `20`).
- Update `docs/terminal.md` to document the benchmark workflow and a concise before/after comparison flow using the generated files. 
- Add a non-blocking GitHub Actions workflow `.github/workflows/nvim-startup-benchmark.yml` that installs Neovim, runs the benchmark, and uploads `.cache/tino/nvim-startup/` as artifacts.

### Testing

- `bash -n scripts/benchmark_nvim_startup.sh` succeeded (syntax check passed). 
- `./scripts/benchmark_nvim_startup.sh` was executed but failed at runtime because `nvim` is not installed in the environment (expected behavior for the local run). 
- `ruff check .` was run and reported failures, which are pre-existing lint errors outside the scope of this change. 
- `pytest tests/test_scripts_dry_run.py -q` was executed and produced a failing test due to an existing repository expectation mismatch unrelated to the new script and docs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b56c8d32c83268a5f02e251e284f8)