### PR TITLE
Unify terminal profile and add provider selector (--terminal)

### DIFF
--- a/dotfiles/terminal/.config/tino/ghostty.toml.tmpl
+++ b/dotfiles/terminal/.config/tino/ghostty.toml.tmpl
@@ -1,9 +1,8 @@
-# Managed Ghostty profile (Blacklight palette shared across Starship/tmux)
-font-family = "CaskaydiaCove Nerd Font"
-font-size = 13
+# Managed Ghostty profile (generated from ~/.config/tino/terminal-defaults.sh)
+font-family = "__FONT_FAMILY__"
+font-size = __FONT_SIZE__
 
-# Window + background polish
-background = "#000000"
+background = "__BACKGROUND__"
 background-opacity = __BACKGROUND_OPACITY__
 custom-shader-animation-max-fps = __MAX_FPS__
 __CUSTOM_SHADER_LINE__
@@ -11,34 +10,31 @@ window-padding-x = 10
 window-padding-y = 8
 window-theme = "dark"
 
-# Cursor + rendering behavior
-cursor-color = "#FC17DA"
+cursor-color = "__CURSOR__"
 cursor-style = "block"
 cursor-style-blink = true
 shell-integration-features = "cursor,sudo,title"
 copy-on-select = true
 confirm-close-surface = false
 
-# Core UX preferences
 window-title = "Ghostty"
 window-save-state = "always"
 macos-titlebar-style = "tabs"
 mouse-hide-while-typing = true
 
-# Blacklight terminal colors (aligned with tmux + starship)
-palette = "0=#000000"
-palette = "1=#ff66c4"
-palette = "2=#b2ff59"
-palette = "3=#ffff66"
-palette = "4=#66b2ff"
-palette = "5=#845CFF"
-palette = "6=#66fff2"
-palette = "7=#f2f2f2"
-palette = "8=#666666"
-palette = "9=#ff66c4"
-palette = "10=#b2ff59"
-palette = "11=#ffff66"
-palette = "12=#66b2ff"
-palette = "13=#FC17DA"
-palette = "14=#66fff2"
-palette = "15=#ffffff"
+palette = "0=__COLOR_0__"
+palette = "1=__COLOR_1__"
+palette = "2=__COLOR_2__"
+palette = "3=__COLOR_3__"
+palette = "4=__COLOR_4__"
+palette = "5=__COLOR_5__"
+palette = "6=__COLOR_6__"
+palette = "7=__COLOR_7__"
+palette = "8=__COLOR_8__"
+palette = "9=__COLOR_9__"
+palette = "10=__COLOR_10__"
+palette = "11=__COLOR_11__"
+palette = "12=__COLOR_12__"
+palette = "13=__COLOR_13__"
+palette = "14=__COLOR_14__"
+palette = "15=__COLOR_15__"

--- a/dotfiles/terminal/.config/tino/renderers/alacritty.sh
+++ b/dotfiles/terminal/.config/tino/renderers/alacritty.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+config_dir="$config_home/alacritty"
+mkdir -p "$config_dir"
+cat > "$config_dir/alacritty.toml" <<EOC
+# Managed by ~/.config/tino/terminal-profile.sh (provider: alacritty)
+[font]
+size = ${TINO_TERMINAL_FONT_SIZE}
+normal = { family = "${TINO_TERMINAL_FONT_FAMILY}", style = "Regular" }
+
+[window]
+opacity = ${TINO_TERMINAL_OPACITY}
+
+[colors.primary]
+background = "${TINO_TERMINAL_BACKGROUND}"
+foreground = "${TINO_TERMINAL_FOREGROUND}"
+
+[colors.cursor]
+cursor = "${TINO_TERMINAL_CURSOR}"
+
+[colors.selection]
+background = "${TINO_TERMINAL_SELECTION}"
+
+[colors.normal]
+black = "${TINO_TERMINAL_COLOR_0}"
+red = "${TINO_TERMINAL_COLOR_1}"
+green = "${TINO_TERMINAL_COLOR_2}"
+yellow = "${TINO_TERMINAL_COLOR_3}"
+blue = "${TINO_TERMINAL_COLOR_4}"
+magenta = "${TINO_TERMINAL_COLOR_5}"
+cyan = "${TINO_TERMINAL_COLOR_6}"
+white = "${TINO_TERMINAL_COLOR_7}"
+
+[colors.bright]
+black = "${TINO_TERMINAL_COLOR_8}"
+red = "${TINO_TERMINAL_COLOR_9}"
+green = "${TINO_TERMINAL_COLOR_10}"
+yellow = "${TINO_TERMINAL_COLOR_11}"
+blue = "${TINO_TERMINAL_COLOR_12}"
+magenta = "${TINO_TERMINAL_COLOR_13}"
+cyan = "${TINO_TERMINAL_COLOR_14}"
+white = "${TINO_TERMINAL_COLOR_15}"
+EOC
+echo "Rendered Alacritty config to $config_dir/alacritty.toml"

--- a/dotfiles/terminal/.config/tino/renderers/ghostty.sh
+++ b/dotfiles/terminal/.config/tino/renderers/ghostty.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+config_dir="$config_home/ghostty"
+mkdir -p "$config_dir"
+
+template_file="$config_home/tino/ghostty.toml.tmpl"
+if [[ ! -f "$template_file" ]]; then
+    echo "Missing template: $template_file" >&2
+    exit 1
+fi
+
+custom_shader_line=""
+case "${TINO_TERMINAL_EFFECTS,,}" in
+    off|false|no|0|none|on|true|yes|1|balanced|high)
+        ;;
+    *)
+        escaped_effects="${TINO_TERMINAL_EFFECTS//\"/\\\"}"
+        custom_shader_line="custom-shader = \"${escaped_effects}\""
+        ;;
+esac
+
+rendered="$(<"$template_file")"
+rendered="${rendered//__FONT_FAMILY__/$TINO_TERMINAL_FONT_FAMILY}"
+rendered="${rendered//__FONT_SIZE__/$TINO_TERMINAL_FONT_SIZE}"
+rendered="${rendered//__BACKGROUND__/$TINO_TERMINAL_BACKGROUND}"
+rendered="${rendered//__BACKGROUND_OPACITY__/$TINO_TERMINAL_OPACITY}"
+rendered="${rendered//__MAX_FPS__/$TINO_TERMINAL_FPS}"
+rendered="${rendered//__CUSTOM_SHADER_LINE__/$custom_shader_line}"
+rendered="${rendered//__CURSOR__/$TINO_TERMINAL_CURSOR}"
+
+for i in $(seq 0 15); do
+    key="TINO_TERMINAL_COLOR_${i}"
+    placeholder="__COLOR_${i}__"
+    rendered="${rendered//${placeholder}/${!key}}"
+done
+
+printf '%s\n' "$rendered" > "$config_dir/ghostty.toml"
+echo "Rendered Ghostty config to $config_dir/ghostty.toml"

--- a/dotfiles/terminal/.config/tino/renderers/kitty.sh
+++ b/dotfiles/terminal/.config/tino/renderers/kitty.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+config_dir="$config_home/kitty"
+mkdir -p "$config_dir"
+cat > "$config_dir/kitty.conf" <<EOC
+# Managed by ~/.config/tino/terminal-profile.sh (provider: kitty)
+font_family ${TINO_TERMINAL_FONT_FAMILY}
+font_size ${TINO_TERMINAL_FONT_SIZE}
+background_opacity ${TINO_TERMINAL_OPACITY}
+foreground ${TINO_TERMINAL_FOREGROUND}
+background ${TINO_TERMINAL_BACKGROUND}
+cursor ${TINO_TERMINAL_CURSOR}
+selection_background ${TINO_TERMINAL_SELECTION}
+color0 ${TINO_TERMINAL_COLOR_0}
+color1 ${TINO_TERMINAL_COLOR_1}
+color2 ${TINO_TERMINAL_COLOR_2}
+color3 ${TINO_TERMINAL_COLOR_3}
+color4 ${TINO_TERMINAL_COLOR_4}
+color5 ${TINO_TERMINAL_COLOR_5}
+color6 ${TINO_TERMINAL_COLOR_6}
+color7 ${TINO_TERMINAL_COLOR_7}
+color8 ${TINO_TERMINAL_COLOR_8}
+color9 ${TINO_TERMINAL_COLOR_9}
+color10 ${TINO_TERMINAL_COLOR_10}
+color11 ${TINO_TERMINAL_COLOR_11}
+color12 ${TINO_TERMINAL_COLOR_12}
+color13 ${TINO_TERMINAL_COLOR_13}
+color14 ${TINO_TERMINAL_COLOR_14}
+color15 ${TINO_TERMINAL_COLOR_15}
+EOC
+echo "Rendered kitty config to $config_dir/kitty.conf"

--- a/dotfiles/terminal/.config/tino/renderers/wezterm.sh
+++ b/dotfiles/terminal/.config/tino/renderers/wezterm.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+config_dir="$config_home/wezterm"
+mkdir -p "$config_dir"
+
+cat > "$config_dir/wezterm.generated.lua" <<EOC
+-- Managed by ~/.config/tino/terminal-profile.sh (provider: wezterm)
+local wezterm = require("wezterm")
+
+return {
+  font = wezterm.font_with_fallback({"${TINO_TERMINAL_FONT_FAMILY}"}),
+  font_size = ${TINO_TERMINAL_FONT_SIZE}.0,
+  window_background_opacity = ${TINO_TERMINAL_OPACITY},
+  max_fps = ${TINO_TERMINAL_FPS},
+  use_fancy_tab_bar = false,
+  hide_tab_bar_if_only_one_tab = true,
+  window_padding = { left = 10, right = 10, top = 8, bottom = 8 },
+  colors = {
+    foreground = "${TINO_TERMINAL_FOREGROUND}",
+    background = "${TINO_TERMINAL_BACKGROUND}",
+    cursor_bg = "${TINO_TERMINAL_CURSOR}",
+    cursor_fg = "${TINO_TERMINAL_BACKGROUND}",
+    selection_bg = "${TINO_TERMINAL_SELECTION}",
+    ansi = {"${TINO_TERMINAL_COLOR_0}", "${TINO_TERMINAL_COLOR_1}", "${TINO_TERMINAL_COLOR_2}", "${TINO_TERMINAL_COLOR_3}", "${TINO_TERMINAL_COLOR_4}", "${TINO_TERMINAL_COLOR_5}", "${TINO_TERMINAL_COLOR_6}", "${TINO_TERMINAL_COLOR_7}"},
+    brights = {"${TINO_TERMINAL_COLOR_8}", "${TINO_TERMINAL_COLOR_9}", "${TINO_TERMINAL_COLOR_10}", "${TINO_TERMINAL_COLOR_11}", "${TINO_TERMINAL_COLOR_12}", "${TINO_TERMINAL_COLOR_13}", "${TINO_TERMINAL_COLOR_14}", "${TINO_TERMINAL_COLOR_15}"},
+  },
+}
+EOC
+
+echo "Rendered WezTerm config to $config_dir/wezterm.generated.lua"

--- a/dotfiles/terminal/.config/tino/renderers/windows-terminal.sh
+++ b/dotfiles/terminal/.config/tino/renderers/windows-terminal.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="${1:-}"
+if [[ -z "$repo_root" ]]; then
+    echo "windows-terminal renderer requires repo root path" >&2
+    exit 1
+fi
+output="$repo_root/windows-terminal/terminal-profile-overrides.json"
+mkdir -p "$(dirname "$output")"
+cat > "$output" <<EOC
+{
+  "profiles": {
+    "defaults": {
+      "font": {
+        "face": "${TINO_TERMINAL_FONT_FAMILY}",
+        "size": ${TINO_TERMINAL_FONT_SIZE}
+      },
+      "acrylicOpacity": ${TINO_TERMINAL_OPACITY},
+      "colorScheme": "Blacklight"
+    }
+  },
+  "schemes": [
+    {
+      "name": "Blacklight",
+      "black": "${TINO_TERMINAL_COLOR_0}",
+      "red": "${TINO_TERMINAL_COLOR_1}",
+      "green": "${TINO_TERMINAL_COLOR_2}",
+      "yellow": "${TINO_TERMINAL_COLOR_3}",
+      "blue": "${TINO_TERMINAL_COLOR_4}",
+      "purple": "${TINO_TERMINAL_COLOR_5}",
+      "cyan": "${TINO_TERMINAL_COLOR_6}",
+      "white": "${TINO_TERMINAL_COLOR_7}",
+      "brightBlack": "${TINO_TERMINAL_COLOR_8}",
+      "brightRed": "${TINO_TERMINAL_COLOR_9}",
+      "brightGreen": "${TINO_TERMINAL_COLOR_10}",
+      "brightYellow": "${TINO_TERMINAL_COLOR_11}",
+      "brightBlue": "${TINO_TERMINAL_COLOR_12}",
+      "brightPurple": "${TINO_TERMINAL_COLOR_13}",
+      "brightCyan": "${TINO_TERMINAL_COLOR_14}",
+      "brightWhite": "${TINO_TERMINAL_COLOR_15}",
+      "background": "${TINO_TERMINAL_BACKGROUND}",
+      "foreground": "${TINO_TERMINAL_FOREGROUND}",
+      "cursorColor": "${TINO_TERMINAL_CURSOR}",
+      "selectionBackground": "${TINO_TERMINAL_SELECTION}"
+    }
+  ]
+}
+EOC
+echo "Rendered Windows Terminal overrides to $output"

--- a/dotfiles/terminal/.config/tino/terminal-defaults.sh
+++ b/dotfiles/terminal/.config/tino/terminal-defaults.sh
@@ -1,5 +1,31 @@
-# Shared terminal defaults for all hosts.
+# Canonical terminal defaults shared across all providers.
 # Host overlays can override these values from ~/.config/tino/host-overrides.sh.
+
+export TINO_TERMINAL_FONT_FAMILY="CaskaydiaCove Nerd Font"
+export TINO_TERMINAL_FONT_SIZE="13"
+
 export TINO_TERMINAL_OPACITY="0.92"
 export TINO_TERMINAL_FPS="120"
 export TINO_TERMINAL_EFFECTS="on"
+
+export TINO_TERMINAL_BACKGROUND="#000000"
+export TINO_TERMINAL_FOREGROUND="#f2f2f2"
+export TINO_TERMINAL_CURSOR="#FC17DA"
+export TINO_TERMINAL_SELECTION="#301050"
+
+export TINO_TERMINAL_COLOR_0="#000000"
+export TINO_TERMINAL_COLOR_1="#ff66c4"
+export TINO_TERMINAL_COLOR_2="#b2ff59"
+export TINO_TERMINAL_COLOR_3="#ffff66"
+export TINO_TERMINAL_COLOR_4="#66b2ff"
+export TINO_TERMINAL_COLOR_5="#845CFF"
+export TINO_TERMINAL_COLOR_6="#66fff2"
+export TINO_TERMINAL_COLOR_7="#f2f2f2"
+export TINO_TERMINAL_COLOR_8="#666666"
+export TINO_TERMINAL_COLOR_9="#ff66c4"
+export TINO_TERMINAL_COLOR_10="#b2ff59"
+export TINO_TERMINAL_COLOR_11="#ffff66"
+export TINO_TERMINAL_COLOR_12="#66b2ff"
+export TINO_TERMINAL_COLOR_13="#FC17DA"
+export TINO_TERMINAL_COLOR_14="#66fff2"
+export TINO_TERMINAL_COLOR_15="#ffffff"

--- a/dotfiles/terminal/.config/tino/terminal-profile.sh
+++ b/dotfiles/terminal/.config/tino/terminal-profile.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+tino_dir="$config_home/tino"
+
+source_if_exists() {
+    local file_path="$1"
+    if [[ -f "$file_path" ]]; then
+        # shellcheck disable=SC1090
+        source "$file_path"
+    fi
+}
+
+load_terminal_profile() {
+    source_if_exists "$tino_dir/terminal-defaults.sh"
+    source_if_exists "$tino_dir/host-overrides.sh"
+
+    export TINO_TERMINAL_FONT_FAMILY="${TINO_TERMINAL_FONT_FAMILY:-CaskaydiaCove Nerd Font}"
+    export TINO_TERMINAL_FONT_SIZE="${TINO_TERMINAL_FONT_SIZE:-13}"
+    export TINO_TERMINAL_OPACITY="${TINO_TERMINAL_OPACITY:-0.92}"
+    export TINO_TERMINAL_FPS="${TINO_TERMINAL_FPS:-120}"
+    export TINO_TERMINAL_EFFECTS="${TINO_TERMINAL_EFFECTS:-on}"
+
+    export TINO_TERMINAL_BACKGROUND="${TINO_TERMINAL_BACKGROUND:-#000000}"
+    export TINO_TERMINAL_FOREGROUND="${TINO_TERMINAL_FOREGROUND:-#f2f2f2}"
+    export TINO_TERMINAL_CURSOR="${TINO_TERMINAL_CURSOR:-#FC17DA}"
+    export TINO_TERMINAL_SELECTION="${TINO_TERMINAL_SELECTION:-#301050}"
+
+    export TINO_TERMINAL_COLOR_0="${TINO_TERMINAL_COLOR_0:-#000000}"
+    export TINO_TERMINAL_COLOR_1="${TINO_TERMINAL_COLOR_1:-#ff66c4}"
+    export TINO_TERMINAL_COLOR_2="${TINO_TERMINAL_COLOR_2:-#b2ff59}"
+    export TINO_TERMINAL_COLOR_3="${TINO_TERMINAL_COLOR_3:-#ffff66}"
+    export TINO_TERMINAL_COLOR_4="${TINO_TERMINAL_COLOR_4:-#66b2ff}"
+    export TINO_TERMINAL_COLOR_5="${TINO_TERMINAL_COLOR_5:-#845CFF}"
+    export TINO_TERMINAL_COLOR_6="${TINO_TERMINAL_COLOR_6:-#66fff2}"
+    export TINO_TERMINAL_COLOR_7="${TINO_TERMINAL_COLOR_7:-#f2f2f2}"
+    export TINO_TERMINAL_COLOR_8="${TINO_TERMINAL_COLOR_8:-#666666}"
+    export TINO_TERMINAL_COLOR_9="${TINO_TERMINAL_COLOR_9:-#ff66c4}"
+    export TINO_TERMINAL_COLOR_10="${TINO_TERMINAL_COLOR_10:-#b2ff59}"
+    export TINO_TERMINAL_COLOR_11="${TINO_TERMINAL_COLOR_11:-#ffff66}"
+    export TINO_TERMINAL_COLOR_12="${TINO_TERMINAL_COLOR_12:-#66b2ff}"
+    export TINO_TERMINAL_COLOR_13="${TINO_TERMINAL_COLOR_13:-#FC17DA}"
+    export TINO_TERMINAL_COLOR_14="${TINO_TERMINAL_COLOR_14:-#66fff2}"
+    export TINO_TERMINAL_COLOR_15="${TINO_TERMINAL_COLOR_15:-#ffffff}"
+}
+
+normalize_effects() {
+    printf '%s' "${1,,}"
+}
+
+is_effects_enabled() {
+    local normalized
+    normalized="$(normalize_effects "$1")"
+    case "$normalized" in
+        off|false|no|0|none)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+render_provider() {
+    local provider="$1"
+    local repo_root="${2:-}"
+
+    load_terminal_profile
+
+    case "$provider" in
+        ghostty)
+            "$tino_dir/renderers/ghostty.sh"
+            ;;
+        wezterm)
+            "$tino_dir/renderers/wezterm.sh"
+            ;;
+        kitty)
+            "$tino_dir/renderers/kitty.sh"
+            ;;
+        alacritty)
+            "$tino_dir/renderers/alacritty.sh"
+            ;;
+        windows-terminal)
+            "$tino_dir/renderers/windows-terminal.sh" "$repo_root"
+            ;;
+        *)
+            echo "Unsupported terminal provider: $provider" >&2
+            return 1
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ $# -lt 1 ]]; then
+        echo "Usage: $(basename "$0") <provider> [repo-root]" >&2
+        exit 1
+    fi
+    render_provider "$@"
+fi

--- a/dotfiles/terminal/.config/wezterm/wezterm.lua
+++ b/dotfiles/terminal/.config/wezterm/wezterm.lua
@@ -1,21 +1,14 @@
-local wezterm = require("wezterm")
+local generated = os.getenv("XDG_CONFIG_HOME")
+if generated == nil or generated == "" then
+    generated = os.getenv("HOME") .. "/.config"
+end
+
+local profile = generated .. "/wezterm/wezterm.generated.lua"
+local ok, conf = pcall(dofile, profile)
+if ok then
+    return conf
+end
 
 return {
-    font = wezterm.font_with_fallback({
-        "JetBrainsMono Nerd Font",
-        "CaskaydiaCove Nerd Font",
-    }),
     font_size = 13.0,
-    color_scheme = "Tokyo Night",
-    window_background_opacity = 0.90,
-    max_fps = 165,
-    enable_wayland = true,
-    use_fancy_tab_bar = false,
-    hide_tab_bar_if_only_one_tab = true,
-    window_padding = {
-        left = 10,
-        right = 10,
-        top = 8,
-        bottom = 8,
-    },
 }

--- a/scripts/install-windows-terminal.ps1
+++ b/scripts/install-windows-terminal.ps1
@@ -4,13 +4,21 @@ if (-not (Test-Path $wtDir)) {
     New-Item -ItemType Directory -Path $wtDir -Force | Out-Null
 }
 
-# Regenerate settings from the shared profile template before copying.
 $repoRoot = Split-Path $PSScriptRoot -Parent
+
+# Render canonical terminal profile overrides when bash is available.
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+    & $bash.Path -lc "`"$HOME/.config/tino/terminal-profile.sh`" windows-terminal `"$repoRoot`""
+}
+
+# Regenerate settings from the shared profile template before copying.
 $python = Get-Command python -ErrorAction SilentlyContinue
 if ($python) {
-    & $python (Join-Path $repoRoot 'windows-terminal/generate_settings.py') \
-        (Join-Path $repoRoot 'windows-terminal/settings.base.json') \
-        (Join-Path $repoRoot 'windows-terminal/settings.json')
+    & $python (Join-Path $repoRoot 'windows-terminal/generate_settings.py') `
+        (Join-Path $repoRoot 'windows-terminal/settings.base.json') `
+        (Join-Path $repoRoot 'windows-terminal/settings.json') `
+        --terminal-overrides (Join-Path $repoRoot 'windows-terminal/terminal-profile-overrides.json')
 }
 
 $source = Join-Path $repoRoot 'windows-terminal\settings.json'

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -150,22 +150,14 @@ ensure_deps() {
     fi
 }
 
-install_terminal_emulator() {
-    if [[ ! -f "$scripts/setup-ghostty.sh" ]]; then
+install_terminal_provider() {
+    local provider="$1"
+
+    if [[ ! -f "$scripts/setup-terminal-provider.sh" ]]; then
         return
     fi
 
-    case $OSTYPE in
-        darwin*|linux*)
-            run_cmd bash "$scripts/setup-ghostty.sh"
-            ;;
-        msys*|cygwin*|win32*|windows*)
-            echo "Skipping Ghostty install on Windows; use Windows Terminal setup options instead."
-            ;;
-        *)
-            echo "Skipping terminal emulator install for unsupported platform: $OSTYPE"
-            ;;
-    esac
+    run_cmd bash "$scripts/setup-terminal-provider.sh" "$provider"
 }
 
 run_pwsh() {
@@ -220,6 +212,7 @@ prompt_set_default_shell() {
 
 install_winget=false
 install_windows_terminal=false
+terminal_provider=""
 install_wsl=false
 setup_wsl=false
 setup_docker=false
@@ -234,6 +227,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --windows-terminal)
             install_windows_terminal=true
+            ;;
+        --terminal)
+            terminal_provider=$2
+            shift
             ;;
         --install-wsl)
             install_wsl=true
@@ -260,6 +257,16 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+
+if [[ -n "$terminal_provider" ]]; then
+    case "$terminal_provider" in
+        ghostty|wezterm|kitty|alacritty|windows-terminal) ;;
+        *)
+            echo "Error: unsupported --terminal provider '$terminal_provider'" >&2
+            exit 1
+            ;;
+    esac
+fi
 
 # Ensure core utilities are available
 ensure_deps curl unzip git
@@ -290,7 +297,11 @@ else
     fi
 
     prompt_set_default_shell
-    install_terminal_emulator
+
+    if [[ -z "$terminal_provider" ]]; then
+        terminal_provider="ghostty"
+    fi
+    install_terminal_provider "$terminal_provider"
 
     run_cmd bash "$scripts/setup-hooks.sh"
     run_cmd bash "$scripts/helpers/install_fonts.sh"
@@ -299,6 +310,14 @@ fi
 
 if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
     if $install_winget; then run_pwsh setup-winget.ps1; fi
+    if [[ -z "$terminal_provider" ]]; then
+        terminal_provider="windows-terminal"
+    fi
+
+    if [[ "$terminal_provider" == "windows-terminal" ]]; then
+        install_windows_terminal=true
+    fi
+
     if $install_windows_terminal; then run_pwsh install-windows-terminal.ps1; fi
     if $install_wsl; then run_pwsh install-wsl.ps1; fi
     if $setup_wsl; then run_pwsh setup-wsl.ps1; fi

--- a/scripts/setup-ghostty.sh
+++ b/scripts/setup-ghostty.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install Ghostty via native package manager first, then cargo fallback.
-# This script also provisions the repository-managed rich profile
-# (font, Blacklight colors, opacity, and UI polish settings).
 detect_ostype() {
     if [[ -n "${OSTYPE:-}" ]]; then
         printf '%s' "${OSTYPE,,}"
@@ -24,31 +21,25 @@ install_ghostty_with_pkg_manager() {
     local normalized_ostype
     normalized_ostype="$(detect_ostype)"
 
-    if [[ "$normalized_ostype" == darwin* ]]; then
-        if command -v brew >/dev/null 2>&1; then
-            brew install --cask ghostty
-            return
-        fi
-        return
+    if [[ "$normalized_ostype" == darwin* ]] && command -v brew >/dev/null 2>&1; then
+        brew install --cask ghostty
+        return 0
     fi
 
     if [[ "$normalized_ostype" == linux* ]]; then
         if command -v apt-get >/dev/null 2>&1; then
             run_with_optional_sudo apt-get update
             run_with_optional_sudo apt-get install -y ghostty
-            return
-        fi
-
-        if command -v dnf >/dev/null 2>&1; then
+            return 0
+        elif command -v dnf >/dev/null 2>&1; then
             run_with_optional_sudo dnf install -y ghostty
-            return
-        fi
-
-        if command -v pacman >/dev/null 2>&1; then
+            return 0
+        elif command -v pacman >/dev/null 2>&1; then
             run_with_optional_sudo pacman -S --noconfirm ghostty
-            return
+            return 0
         fi
     fi
+    return 1
 }
 
 ensure_ghostty_installed() {
@@ -57,173 +48,28 @@ ensure_ghostty_installed() {
         return
     fi
 
-    if install_ghostty_with_pkg_manager; then
-        if command -v ghostty >/dev/null 2>&1; then
-            echo "Installed Ghostty via native package manager"
-            return
-        fi
+    if install_ghostty_with_pkg_manager && command -v ghostty >/dev/null 2>&1; then
+        echo "Installed Ghostty via native package manager"
+        return
     fi
 
-    echo "Native package manager install unavailable or did not provide 'ghostty'; falling back to cargo"
-
-    if command -v cargo >/dev/null 2>&1; then
-        echo "Using existing cargo to install Ghostty"
-        cargo install --locked ghostty
-    else
-        local normalized_ostype
-        normalized_ostype="$(detect_ostype)"
-
-        if [[ "$normalized_ostype" == darwin* ]] && command -v brew >/dev/null 2>&1; then
-            echo "cargo not found; installing rustup/cargo with Homebrew for Ghostty fallback"
-            brew install rustup-init
-            rustup-init -y
-            export PATH="$HOME/.cargo/bin:$PATH"
-        elif [[ "$normalized_ostype" == linux* ]]; then
-            if command -v apt-get >/dev/null 2>&1; then
-                echo "cargo not found; installing cargo with apt-get for Ghostty fallback"
-                run_with_optional_sudo apt-get update
-                run_with_optional_sudo apt-get install -y cargo
-            elif command -v dnf >/dev/null 2>&1; then
-                echo "cargo not found; installing cargo with dnf for Ghostty fallback"
-                run_with_optional_sudo dnf install -y cargo
-            elif command -v pacman >/dev/null 2>&1; then
-                echo "cargo not found; installing cargo with pacman for Ghostty fallback"
-                run_with_optional_sudo pacman -S --noconfirm cargo
-            fi
-        fi
-
-        if ! command -v cargo >/dev/null 2>&1; then
-            echo "Error: unable to install Ghostty via native package manager and cargo is unavailable." >&2
-            echo "Install Rust/Cargo (https://rustup.rs) and re-run this script to use the cargo fallback." >&2
-            exit 1
-        fi
-
-        echo "Using newly installed cargo to install Ghostty"
-        cargo install --locked ghostty
-    fi
-
-    if ! command -v ghostty >/dev/null 2>&1; then
-        echo "Error: Ghostty install completed but 'ghostty' binary is still unavailable" >&2
+    echo "Falling back to cargo for Ghostty install"
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo "Error: cargo is required for Ghostty fallback installation" >&2
         exit 1
     fi
-
-    echo "Installed Ghostty via cargo"
+    cargo install --locked ghostty
 }
 
 ensure_ghostty_installed
 
 config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
-config_dir="$config_home/ghostty"
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-canonical_template="$repo_root/dotfiles/terminal/.config/tino/ghostty.toml.tmpl"
-config_file="$config_dir/ghostty.toml"
-mkdir -p "$config_dir"
-
-if [[ ! -f "$canonical_template" ]]; then
-    echo "Error: managed Ghostty template is missing at $canonical_template" >&2
+profile_script="$config_home/tino/terminal-profile.sh"
+if [[ ! -x "$profile_script" ]]; then
+    echo "Error: missing terminal profile contract at $profile_script" >&2
     exit 1
 fi
 
-source_if_exists() {
-    local file_path="$1"
-    if [[ -f "$file_path" ]]; then
-        # shellcheck disable=SC1090
-        source "$file_path"
-    fi
-}
+"$profile_script" ghostty
 
-# Load shared defaults first, then host-specific overrides from
-# ~/.config/tino/host-overrides.sh using canonical
-# TINO_TERMINAL_OPACITY/TINO_TERMINAL_FPS/TINO_TERMINAL_EFFECTS variables.
-source_if_exists "$config_home/tino/terminal-defaults.sh"
-source_if_exists "$config_home/tino/host-overrides.sh"
-
-background_opacity="${TINO_TERMINAL_OPACITY:-0.92}"
-max_fps="${TINO_TERMINAL_FPS:-120}"
-effects="${TINO_TERMINAL_EFFECTS:-on}"
-
-validate_number() {
-    local value="$1"
-    local name="$2"
-    local pattern="$3"
-
-    if [[ ! "$value" =~ $pattern ]]; then
-        echo "Error: $name must be numeric, got '$value'" >&2
-        exit 1
-    fi
-}
-
-is_path_like_effects_value() {
-    local raw_value="$1"
-
-    case "$raw_value" in
-        ./*|../*|~/*|/*|*/*|*.glsl)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
-validate_effects_value() {
-    local raw_value="$1"
-    local value
-
-    value="$(printf '%s' "$raw_value" | tr '[:upper:]' '[:lower:]')"
-    case "$value" in
-        high|balanced|on|true|yes|1|off|false|no|0|none)
-            return 0
-            ;;
-    esac
-
-    if is_path_like_effects_value "$raw_value"; then
-        return 0
-    fi
-
-    echo "Error: invalid TINO_TERMINAL_EFFECTS '$raw_value'. Use a preset (on/off/balanced/high) or a shader path (e.g. ~/.config/ghostty/shaders/effect.glsl)." >&2
-    exit 1
-}
-
-normalize_effects_to_toml() {
-    local raw_value="$1"
-    local value
-
-    value="$(printf '%s' "$raw_value" | tr '[:upper:]' '[:lower:]')"
-    case "$value" in
-        high|balanced|on|true|yes|1)
-            # Preset quality levels rely on Ghostty defaults and do not set custom-shader.
-            printf '%s' ""
-            ;;
-        off|false|no|0|none)
-            # Off disables extra effects and does not set custom-shader.
-            printf '%s' ""
-            ;;
-        *)
-            # For valid path-like values, render a TOML string assignment.
-            local escaped_value
-            escaped_value="${raw_value//\\/\\\\}"
-            escaped_value="${escaped_value//\"/\\\"}"
-            printf 'custom-shader = "%s"' "$escaped_value"
-            ;;
-    esac
-}
-
-validate_number "$background_opacity" "TINO_TERMINAL_OPACITY" '^[0-9]+([.][0-9]+)?$'
-validate_number "$max_fps" "TINO_TERMINAL_FPS" '^[0-9]+$'
-validate_effects_value "$effects"
-effects_toml="$(normalize_effects_to_toml "$effects")"
-
-template_contents="$(<"$canonical_template")"
-rendered_config="${template_contents//__BACKGROUND_OPACITY__/$background_opacity}"
-rendered_config="${rendered_config//__MAX_FPS__/$max_fps}"
-rendered_config="${rendered_config//__CUSTOM_SHADER_LINE__/$effects_toml}"
-
-if [[ -f "$config_file" ]] && [[ "$(<"$config_file")" == "$rendered_config" ]]; then
-    echo "Configuration already up to date at $config_file"
-else
-    printf '%s\n' "$rendered_config" >"$config_file"
-    echo "Configuration rendered to $config_file"
-fi
-
-echo "Ghostty installed."
+echo "Ghostty installed and configured."

--- a/scripts/setup-terminal-provider.sh
+++ b/scripts/setup-terminal-provider.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider="${1:-}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -z "$provider" ]]; then
+    echo "Usage: $(basename "$0") <ghostty|wezterm|kitty|alacritty|windows-terminal>" >&2
+    exit 1
+fi
+
+install_with_pkg_manager() {
+    local pkg="$1"
+    if command -v brew >/dev/null 2>&1; then
+        brew install "$pkg" && return 0
+    fi
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update && sudo apt-get install -y "$pkg" && return 0
+    fi
+    if command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y "$pkg" && return 0
+    fi
+    if command -v pacman >/dev/null 2>&1; then
+        sudo pacman -S --noconfirm "$pkg" && return 0
+    fi
+    return 1
+}
+
+ensure_provider_installed() {
+    case "$provider" in
+        ghostty)
+            bash "$repo_root/scripts/setup-ghostty.sh"
+            return
+            ;;
+        wezterm)
+            command -v wezterm >/dev/null 2>&1 || install_with_pkg_manager wezterm || true
+            ;;
+        kitty)
+            command -v kitty >/dev/null 2>&1 || install_with_pkg_manager kitty || true
+            ;;
+        alacritty)
+            command -v alacritty >/dev/null 2>&1 || install_with_pkg_manager alacritty || true
+            ;;
+        windows-terminal)
+            return
+            ;;
+        *)
+            echo "Unsupported provider: $provider" >&2
+            exit 1
+            ;;
+    esac
+}
+
+profile_script="${XDG_CONFIG_HOME:-$HOME/.config}/tino/terminal-profile.sh"
+if [[ ! -x "$profile_script" ]]; then
+    echo "Error: missing terminal profile contract at $profile_script" >&2
+    exit 1
+fi
+
+if [[ "$provider" != "ghostty" ]]; then
+    ensure_provider_installed
+fi
+"$profile_script" "$provider" "$repo_root"
+
+if [[ "$provider" == "windows-terminal" ]]; then
+    python "$repo_root/windows-terminal/generate_settings.py" \
+      "$repo_root/windows-terminal/settings.base.json" \
+      "$repo_root/windows-terminal/settings.json" \
+      --terminal-overrides "$repo_root/windows-terminal/terminal-profile-overrides.json"
+fi
+
+echo "Terminal provider configured: $provider"

--- a/windows-terminal/generate_settings.py
+++ b/windows-terminal/generate_settings.py
@@ -34,17 +34,41 @@ def merge_profiles(common: dict[str, object], override: dict[str, object]) -> di
             merged.append(prof)
 
     merged.extend(override_map.values())
-    # Append any profiles without guid
     merged.extend([p for p in override_list if not p.get("guid")])
     result["list"] = merged
     return result
 
 
-def generate(base: Path, common: Path, output: Path) -> None:
+def merge_terminal_overrides(data: dict[str, object], overrides: dict[str, object]) -> dict[str, object]:
+    profiles_override = overrides.get("profiles", {})
+    profiles = data.get("profiles", {})
+    defaults_override = profiles_override.get("defaults", {})
+    if defaults_override:
+        profile_defaults = profiles.get("defaults", {})
+        profile_defaults.update(defaults_override)
+        profiles["defaults"] = profile_defaults
+        data["profiles"] = profiles
+
+    if "schemes" in overrides:
+        scheme_map = {scheme.get("name"): scheme for scheme in data.get("schemes", []) if scheme.get("name")}
+        for scheme in overrides["schemes"]:
+            name = scheme.get("name")
+            if name and name in scheme_map:
+                scheme_map[name].update(scheme)
+            else:
+                data.setdefault("schemes", []).append(scheme)
+    return data
+
+
+def generate(base: Path, common: Path, output: Path, terminal_overrides: Path | None = None) -> None:
     data = load_json(base)
     profiles = data.get("profiles", {})
     merged = merge_profiles(load_json(common), profiles)
     data["profiles"] = merged
+
+    if terminal_overrides and terminal_overrides.exists():
+        data = merge_terminal_overrides(data, load_json(terminal_overrides))
+
     output.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
@@ -53,5 +77,11 @@ if __name__ == "__main__":
     parser.add_argument("base", type=Path, help="Path to base settings JSON")
     parser.add_argument("output", type=Path, help="Where to write merged settings")
     parser.add_argument("--common", type=Path, default=Path(__file__).parent / "common-profiles.json")
+    parser.add_argument(
+        "--terminal-overrides",
+        type=Path,
+        default=Path(__file__).parent / "terminal-profile-overrides.json",
+        help="Optional generated profile overrides from canonical terminal settings",
+    )
     args = parser.parse_args()
-    generate(args.base, args.common, args.output)
+    generate(args.base, args.common, args.output, args.terminal_overrides)

--- a/windows-terminal/terminal-profile-overrides.json
+++ b/windows-terminal/terminal-profile-overrides.json
@@ -1,0 +1,37 @@
+{
+  "profiles": {
+    "defaults": {
+      "font": {
+        "face": "CaskaydiaCove Nerd Font",
+        "size": 13
+      },
+      "acrylicOpacity": 0.92,
+      "colorScheme": "Blacklight"
+    }
+  },
+  "schemes": [
+    {
+      "name": "Blacklight",
+      "black": "#000000",
+      "red": "#ff66c4",
+      "green": "#b2ff59",
+      "yellow": "#ffff66",
+      "blue": "#66b2ff",
+      "purple": "#845CFF",
+      "cyan": "#66fff2",
+      "white": "#f2f2f2",
+      "brightBlack": "#666666",
+      "brightRed": "#ff66c4",
+      "brightGreen": "#b2ff59",
+      "brightYellow": "#ffff66",
+      "brightBlue": "#66b2ff",
+      "brightPurple": "#FC17DA",
+      "brightCyan": "#66fff2",
+      "brightWhite": "#ffffff",
+      "background": "#000000",
+      "foreground": "#f2f2f2",
+      "cursorColor": "#FC17DA",
+      "selectionBackground": "#301050"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a single canonical source for terminal appearance values (font, size, palette, opacity, fps, effects) so all terminal providers render consistently. 
- Allow the installer to configure exactly one terminal provider via a selector to avoid installing multiple conflicting terminal configs. 
- Ensure host-specific overrides apply uniformly across providers by centralizing rendering behind a contract. 

### Description
- Add a terminal profile contract at `dotfiles/terminal/.config/tino/terminal-profile.sh` that loads canonical defaults and host overrides and dispatches to per-provider renderers. 
- Move shared values into `dotfiles/terminal/.config/tino/terminal-defaults.sh` and convert the Ghostty template to placeholder-driven `dotfiles/terminal/.config/tino/ghostty.toml.tmpl`. 
- Add per-provider renderers under `dotfiles/terminal/.config/tino/renderers/` for `ghostty`, `wezterm`, `kitty`, `alacritty`, and `windows-terminal` which generate provider-specific runtime files (e.g., `wezterm.generated.lua`, `ghostty.toml`, `alacritty.toml`, etc.). 
- Refactor `scripts/install_common.sh` to accept `--terminal ghostty|wezterm|kitty|alacritty|windows-terminal`, validate the provider, and configure exactly one provider by default (`ghostty` on Unix and `windows-terminal` on Windows) via the new `scripts/setup-terminal-provider.sh`. 
- Simplify `scripts/setup-ghostty.sh` to focus on installation and call the contract for rendering, and make Windows Terminal generation merge canonical overrides by updating `windows-terminal/generate_settings.py` and `scripts/install-windows-terminal.ps1` to consume `terminal-profile-overrides.json`. 

### Testing
- Performed shell syntax checks with `bash -n` on the modified shell scripts which passed. 
- Verified Python compilation for the Windows Terminal generator with `python -m py_compile windows-terminal/generate_settings.py` which succeeded. 
- Executed a smoke render test by running the profile contract in a temporary `HOME`/`XDG_CONFIG_HOME` for all providers and confirmed generated files exist (`wezterm.generated.lua`, `ghostty.toml`, `kitty.conf`, `alacritty.toml`, and `windows-terminal/terminal-profile-overrides.json`). 
- Validated Windows Terminal output by running `python windows-terminal/generate_settings.py windows-terminal/settings.base.json /tmp/settings.out.json --terminal-overrides windows-terminal/terminal-profile-overrides.json` and asserting the merged JSON contains the expected `font` and `Blacklight` scheme; the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb010c2b883268ea5544c6227c036)