### PR TITLE
Add bashrc-to-zsh migration workflow with modular shell fragments

### DIFF
--- a/dotfiles/shell/.bashrc
+++ b/dotfiles/shell/.bashrc
@@ -2,12 +2,20 @@
 # d0tTino uses zsh as the primary interactive shell configuration.
 
 case $- in
-    *i*)
-        if [ -n "${BASH_VERSION:-}" ]; then
-            printf 'This environment is configured for zsh. Run `zsh` or set it as your login shell.\n' >&2
-        fi
-        ;;
-    *)
-        return
-        ;;
+    *i*) ;;
+    *) return ;;
 esac
+
+migration_script="$HOME/.local/share/d0ttino/scripts/migrate-shell-config.sh"
+if [[ ! -x "${migration_script}" ]]; then
+    migration_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/migrate-shell-config.sh"
+fi
+
+migration_hint_stamp="${XDG_CACHE_HOME:-$HOME/.cache}/d0ttino/bash-migration-hint-shown"
+if [[ ! -f "${migration_hint_stamp}" ]]; then
+    mkdir -p "$(dirname "${migration_hint_stamp}")"
+    printf 'Hint: migrate your legacy ~/.bashrc settings with %s\n' "${migration_script}" >&2
+    : > "${migration_hint_stamp}"
+fi
+
+printf 'This environment is configured for zsh. Run `zsh` or set it as your login shell.\n' >&2

--- a/dotfiles/shell/.config/zsh/aliases.zsh
+++ b/dotfiles/shell/.config/zsh/aliases.zsh
@@ -1,0 +1,2 @@
+# Aliases migrated from legacy ~/.bashrc entries.
+: "${TINO_ZSH_ALIASES_FRAGMENT_LOADED:=1}"

--- a/dotfiles/shell/.config/zsh/env.zsh
+++ b/dotfiles/shell/.config/zsh/env.zsh
@@ -1,0 +1,2 @@
+# Environment variables migrated from legacy ~/.bashrc entries.
+: "${TINO_ZSH_ENV_FRAGMENT_LOADED:=1}"

--- a/dotfiles/shell/.config/zsh/functions.zsh
+++ b/dotfiles/shell/.config/zsh/functions.zsh
@@ -1,0 +1,2 @@
+# Functions migrated from legacy ~/.bashrc entries.
+: "${TINO_ZSH_FUNCTIONS_FRAGMENT_LOADED:=1}"

--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -2,30 +2,30 @@ if [[ "${TINO_ZSH_PROFILE:-0}" == "1" ]]; then
     zmodload zsh/zprof
 fi
 
+source_if_readable() {
+    local file_path="$1"
+    if [[ -r "${file_path}" ]]; then
+        # shellcheck disable=SC1090
+        source "${file_path}"
+    fi
+}
+
+ZSH_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
 ZSH_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/zsh"
 mkdir -p "$ZSH_CACHE_DIR"
 autoload -Uz compinit && compinit -d "$ZSH_CACHE_DIR/zcompdump"
 zstyle ':completion:*' use-cache on
 zstyle ':completion:*' cache-path "$ZSH_CACHE_DIR"
 
+source_if_readable "$ZSH_CONFIG_DIR/env.zsh"
+source_if_readable "$HOME/.config/tino/terminal-defaults.sh"
+source_if_readable "$HOME/.config/tino/host-overrides.sh"
+source_if_readable "$ZSH_CONFIG_DIR/aliases.zsh"
+source_if_readable "$ZSH_CONFIG_DIR/functions.zsh"
+
 ZSH_PLUGIN_DIR="${ZSH_PLUGIN_DIR:-$HOME/.local/share/zsh/plugins}"
-
-if [[ -r "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
-    source "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
-fi
-
-if [[ -r "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
-    source "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-fi
-
-
-if [[ -r "$HOME/.config/tino/terminal-defaults.sh" ]]; then
-    source "$HOME/.config/tino/terminal-defaults.sh"
-fi
-
-if [[ -r "$HOME/.config/tino/host-overrides.sh" ]]; then
-    source "$HOME/.config/tino/host-overrides.sh"
-fi
+source_if_readable "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
+source_if_readable "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 if command -v starship >/dev/null; then
     eval "$(starship init zsh)"

--- a/scripts/migrate-shell-config.sh
+++ b/scripts/migrate-shell-config.sh
@@ -1,40 +1,136 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-start="# >>> d0tTino zsh plugins >>>"
-end="# <<< d0tTino zsh plugins <<<"
-zshrc="${HOME}/.zshrc"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+legacy_bashrc="${HOME}/.bashrc"
 
-if [[ ! -f "$zshrc" ]]; then
-    echo "No ~/.zshrc found; nothing to migrate."
-    exit 0
-fi
-
-if ! grep -Fq "$start" "$zshrc"; then
-    echo "No legacy d0tTino plugin block found in ~/.zshrc; nothing to migrate."
-    exit 0
-fi
+target_dir="${repo_root}/dotfiles/shell/.config/zsh"
+env_target="${target_dir}/env.zsh"
+aliases_target="${target_dir}/aliases.zsh"
+functions_target="${target_dir}/functions.zsh"
 
 timestamp="$(date +%Y%m%d-%H%M%S)"
-backup_path="${zshrc}.pre-d0ttino-migration.${timestamp}.bak"
-cp "$zshrc" "$backup_path"
-echo "Backed up ~/.zshrc to $backup_path"
+backup_dir="${HOME}/.config/tino/shell-migration-backups"
+report_dir="${HOME}/.config/tino"
+mkdir -p "${backup_dir}" "${report_dir}" "${target_dir}"
 
-tmp="$(mktemp)"
-awk -v start="$start" -v end="$end" '
-    $0 == start {
-        in_block = 1
-        next
-    }
-    in_block && $0 == end {
-        in_block = 0
-        next
-    }
-    !in_block { print }
-' "$zshrc" > "$tmp"
+if [[ ! -f "${legacy_bashrc}" ]]; then
+    echo "No ~/.bashrc found; nothing to migrate."
+    exit 0
+fi
 
-cp "$tmp" "$zshrc"
-rm -f "$tmp"
+backup_path="${backup_dir}/bashrc.${timestamp}.bak"
+report_path="${report_dir}/shell-migration-report.${timestamp}.txt"
+cp "${legacy_bashrc}" "${backup_path}"
 
-echo "Removed legacy d0tTino plugin block from ~/.zshrc"
-echo "Runtime shell config is now controlled by dotfiles/shell/.zshrc via scripts/install_dotfiles.sh"
+echo "# Migrated from ~/.bashrc on ${timestamp}" > "${env_target}"
+echo "# Review and customize as needed." >> "${env_target}"
+printf '\n' >> "${env_target}"
+
+echo "# Migrated aliases from ~/.bashrc on ${timestamp}" > "${aliases_target}"
+echo "# Review and customize as needed." >> "${aliases_target}"
+printf '\n' >> "${aliases_target}"
+
+echo "# Migrated functions from ~/.bashrc on ${timestamp}" > "${functions_target}"
+echo "# Review and customize as needed." >> "${functions_target}"
+printf '\n' >> "${functions_target}"
+
+{
+    echo "d0tTino shell migration report"
+    echo "Generated: ${timestamp}"
+    echo "Source: ${legacy_bashrc}"
+    echo "Backup: ${backup_path}"
+    echo "Targets:"
+    echo "  - ${env_target}"
+    echo "  - ${aliases_target}"
+    echo "  - ${functions_target}"
+    echo
+    echo "Skipped / incompatible lines:"
+} > "${report_path}"
+
+env_count=0
+alias_count=0
+function_count=0
+skip_count=0
+
+in_function=0
+function_depth=0
+
+count_char() {
+    local line="$1"
+    local char="$2"
+    awk -v line="$line" -v char="$char" 'BEGIN { n = gsub(char, "", line); print n }'
+}
+
+while IFS= read -r line || [[ -n "${line}" ]]; do
+    line_no=${line_no:-0}
+    line_no=$((line_no + 1))
+    trimmed="${line#${line%%[![:space:]]*}}"
+
+    if [[ ${in_function} -eq 1 ]]; then
+        printf '%s\n' "${line}" >> "${functions_target}"
+
+        opens=$(count_char "${line}" "\\{")
+        closes=$(count_char "${line}" "\\}")
+        function_depth=$((function_depth + opens - closes))
+
+        if [[ ${function_depth} -le 0 ]]; then
+            in_function=0
+        fi
+        continue
+    fi
+
+    if [[ -z "${trimmed}" || "${trimmed}" == \#* ]]; then
+        continue
+    fi
+
+    if [[ "${trimmed}" =~ ^(function[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(\)[[:space:]]*\{[[:space:]]*$ ]]; then
+        in_function=1
+        function_count=$((function_count + 1))
+        printf '%s\n' "${line}" >> "${functions_target}"
+        opens=$(count_char "${line}" "\\{")
+        closes=$(count_char "${line}" "\\}")
+        function_depth=$((opens - closes))
+        if [[ ${function_depth} -le 0 ]]; then
+            in_function=0
+        fi
+        continue
+    fi
+
+    if [[ "${trimmed}" =~ ^alias[[:space:]]+[A-Za-z0-9_.-]+= ]]; then
+        alias_count=$((alias_count + 1))
+        printf '%s\n' "${line}" >> "${aliases_target}"
+        continue
+    fi
+
+    if [[ "${trimmed}" =~ ^(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*= ]] \
+        || [[ "${trimmed}" =~ ^(readonly|typeset[[:space:]]+-x|declare[[:space:]]+-x)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*= ]] \
+        || [[ "${trimmed}" =~ ^unset[[:space:]]+[A-Za-z_][A-Za-z0-9_]* ]]; then
+        env_count=$((env_count + 1))
+        printf '%s\n' "${line}" >> "${env_target}"
+        continue
+    fi
+
+    skip_count=$((skip_count + 1))
+    printf 'L%-4s %s\n' "${line_no}" "${line}" >> "${report_path}"
+done < "${legacy_bashrc}"
+
+if [[ ${skip_count} -eq 0 ]]; then
+    echo "(none)" >> "${report_path}"
+fi
+
+{
+    echo
+    echo "Summary:"
+    echo "  env lines: ${env_count}"
+    echo "  alias lines: ${alias_count}"
+    echo "  function blocks: ${function_count}"
+    echo "  skipped lines: ${skip_count}"
+} >> "${report_path}"
+
+echo "Backed up ~/.bashrc to ${backup_path}"
+echo "Migrated env lines: ${env_count} -> ${env_target}"
+echo "Migrated aliases: ${alias_count} -> ${aliases_target}"
+echo "Migrated functions: ${function_count} -> ${functions_target}"
+echo "Migration report: ${report_path}"

--- a/tests/test_migrate_shell_config.py
+++ b/tests/test_migrate_shell_config.py
@@ -1,0 +1,95 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_migrate_shell_config_creates_fragments_backup_and_report(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    shutil.copy(REPO_ROOT / "scripts" / "migrate-shell-config.sh", repo / "scripts" / "migrate-shell-config.sh")
+    target_dir = repo / "dotfiles" / "shell" / ".config" / "zsh"
+    target_dir.mkdir(parents=True)
+
+    home = tmp_path / "home"
+    home.mkdir()
+
+    bashrc = home / ".bashrc"
+    bashrc.write_text(
+        """
+# legacy shell config
+export EDITOR=nvim
+PATH="$HOME/bin:$PATH"
+alias gs='git status'
+function say_hi() {
+  echo hi
+}
+bind '"\\e[A":history-search-backward'
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/migrate-shell-config.sh"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    env_fragment = repo / "dotfiles" / "shell" / ".config" / "zsh" / "env.zsh"
+    aliases_fragment = repo / "dotfiles" / "shell" / ".config" / "zsh" / "aliases.zsh"
+    functions_fragment = repo / "dotfiles" / "shell" / ".config" / "zsh" / "functions.zsh"
+
+    assert "export EDITOR=nvim" in env_fragment.read_text(encoding="utf-8")
+    assert 'PATH="$HOME/bin:$PATH"' in env_fragment.read_text(encoding="utf-8")
+    assert "alias gs='git status'" in aliases_fragment.read_text(encoding="utf-8")
+    assert "function say_hi() {" in functions_fragment.read_text(encoding="utf-8")
+
+    backup_dir = home / ".config" / "tino" / "shell-migration-backups"
+    report_dir = home / ".config" / "tino"
+    backups = list(backup_dir.glob("bashrc.*.bak"))
+    reports = list(report_dir.glob("shell-migration-report.*.txt"))
+
+    assert len(backups) == 1
+    assert len(reports) == 1
+
+    report = reports[0].read_text(encoding="utf-8")
+    assert "bind '" in report
+    assert "skipped lines: 1" in report
+    assert "Migration report:" in result.stdout
+
+
+def test_minimal_bashrc_shim_prints_migration_hint_once(tmp_path: Path) -> None:
+    bashrc = REPO_ROOT / "dotfiles" / "shell" / ".bashrc"
+
+    home = tmp_path / "home"
+    home.mkdir()
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+
+    first = subprocess.run(
+        ["/bin/bash", "--rcfile", str(bashrc), "-i", "-c", "exit"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    second = subprocess.run(
+        ["/bin/bash", "--rcfile", str(bashrc), "-i", "-c", "exit"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Hint: migrate your legacy ~/.bashrc settings" in first.stderr
+    assert "Hint: migrate your legacy ~/.bashrc settings" not in second.stderr


### PR DESCRIPTION
### Motivation
- Provide a reliable one-time migration path for legacy `~/.bashrc` content into the repository-managed zsh configuration and keep a minimal bash compatibility shim. 
- Improve maintainability by splitting runtime shell config into categorized, sourceable fragments (`env`, `aliases`, `functions`) so users can review and customize migrated pieces.

### Description
- Added a migration workflow in `scripts/migrate-shell-config.sh` that parses `~/.bashrc`, categorizes lines into environment assignments, aliases, and function blocks, writes them to `dotfiles/shell/.config/zsh/{env.zsh,aliases.zsh,functions.zsh}`, creates a timestamped backup under `~/.config/tino/shell-migration-backups`, and generates a timestamped migration report listing skipped/incompatible lines and counts. 
- Refactored `dotfiles/shell/.zshrc` to include a `source_if_readable` helper and to source fragments from `$(XDG_CONFIG_HOME)/zsh` in a deterministic order with existence guards. 
- Updated `dotfiles/shell/.bashrc` to remain a minimal compatibility shim and to emit a one-time migration hint pointing to the migration script, guarded by a cache-stamp file. 
- Added baseline fragment files in `dotfiles/shell/.config/zsh/` and added `tests/test_migrate_shell_config.py` to validate migration output and the one-time hint behavior. 

### Testing
- Ran a syntax check with `bash -n scripts/migrate-shell-config.sh dotfiles/shell/.zshrc dotfiles/shell/.bashrc`, which succeeded. 
- Ran `pytest -q tests/test_migrate_shell_config.py`, which passed (`2 passed`). 
- Attempted `pytest -q tests/test_migrate_shell_config.py tests/test_dotfiles.py`, which failed due to an unrelated missing repository layout file (`dotfiles/ghostty/ghostty.toml.tmpl`) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb4a1026c832687b252f7f80ecde7)