### PR TITLE
Split zsh startup into prompt-critical and deferred phases with cached compinit

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -155,9 +155,32 @@ The migration is intentionally manual and creates a timestamped backup before an
 
 ## zsh startup profiling (opt-in)
 
-`dotfiles/shell/.zshrc` supports opt-in profiling via `zprof` so startup overhead stays zero unless explicitly requested.
+`dotfiles/shell/.zshrc` now runs in explicit startup phases so prompt rendering stays fast:
 
-Run an interactive shell once with profiling enabled:
+1. **Prompt-critical path**: completion bootstrap, plugins, and `starship`.
+2. **Deferred path/env initialization**: language managers, host defaults/overrides, and optional tooling (for example `zoxide`).
+
+Deferred execution is on by default (`TINO_ZSH_DEFER=1`). If `zsh-defer` is installed, it is used automatically; otherwise `.zshrc` falls back to a built-in `precmd` queue. Set `TINO_ZSH_DEFER=0` to force immediate loading.
+
+### Completion cache strategy
+
+Completion initialization uses a fast cache path for normal startups and only refreshes metadata when stale:
+
+- Cached path: `compinit -C -d "$XDG_CACHE_HOME/zsh/zcompdump"`
+- Refresh path: full `compinit` when `zcompdump` is missing or older than `TINO_ZSH_COMPINIT_REFRESH_DAYS` (default: `7`).
+
+### Startup budget goals
+
+Use these as guardrails for interactive startup:
+
+- **Warm startup target**: <= `80ms`
+- **Cold startup target**: <= `150ms`
+
+The values are also exposed in shell config (`TINO_ZSH_STARTUP_BUDGET_WARM_MS` and `TINO_ZSH_STARTUP_BUDGET_COLD_MS`) so teams can tune them locally without editing docs.
+
+### Profiling recipe (`TINO_ZSH_PROFILE=1`)
+
+Run:
 
 ```bash
 TINO_ZSH_PROFILE=1 zsh -i -c exit
@@ -165,12 +188,15 @@ TINO_ZSH_PROFILE=1 zsh -i -c exit
 
 When `TINO_ZSH_PROFILE` is unset, profiling is skipped entirely (no `zmodload zsh/zprof` and no profile report at shell exit).
 
-If the `zprof` report shows regressions, defer expensive startup work so it only runs when needed. Typical fixes include:
+For repeatable timing checks, run both warm and cold-ish cases:
 
-- Lazy-loading plugin initialization behind command wrappers.
-- Moving non-essential startup commands into on-demand functions/aliases.
-- Guarding heavyweight blocks with checks for interactive shells and command availability.
+```bash
+hyperfine --warmup 3 'zsh -i -c exit'
+rm -f ~/.cache/zsh/zcompdump
+hyperfine --warmup 1 'zsh -i -c exit'
+```
 
+If `zprof` or `hyperfine` results exceed budget, move work from phase 1 into deferred blocks or on-demand wrappers.
 
 ## Neovim first run and startup profiling
 

--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -10,20 +10,90 @@ source_if_readable() {
     fi
 }
 
+TINO_ZSH_STARTUP_BUDGET_WARM_MS="${TINO_ZSH_STARTUP_BUDGET_WARM_MS:-80}"
+TINO_ZSH_STARTUP_BUDGET_COLD_MS="${TINO_ZSH_STARTUP_BUDGET_COLD_MS:-150}"
+
 ZSH_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
 ZSH_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/zsh"
 mkdir -p "$ZSH_CACHE_DIR"
-autoload -Uz compinit && compinit -d "$ZSH_CACHE_DIR/zcompdump"
-zstyle ':completion:*' use-cache on
-zstyle ':completion:*' cache-path "$ZSH_CACHE_DIR"
 
-source_if_readable "$ZSH_CONFIG_DIR/env.zsh"
-source_if_readable "$HOME/.config/tino/terminal-defaults.sh"
-source_if_readable "$HOME/.config/tino/host-overrides.sh"
+# Faster startup path: use cached completion metadata unless cache is stale.
+tino_compinit() {
+    autoload -Uz compinit
+
+    local compdump_file="$ZSH_CACHE_DIR/zcompdump"
+    local refresh_days="${TINO_ZSH_COMPINIT_REFRESH_DAYS:-7}"
+    local refresh_seconds=$(( refresh_days * 86400 ))
+    local needs_refresh=0
+
+    if [[ ! -s "$compdump_file" ]]; then
+        needs_refresh=1
+    else
+        zmodload -F zsh/stat b:zstat 2>/dev/null
+        if (( $+functions[zstat] )); then
+            local -A file_stat
+            if zstat -A file_stat +mtime -- "$compdump_file" 2>/dev/null; then
+                if (( EPOCHSECONDS - file_stat[mtime] > refresh_seconds )); then
+                    needs_refresh=1
+                fi
+            else
+                needs_refresh=1
+            fi
+        fi
+    fi
+
+    if (( needs_refresh )); then
+        compinit -d "$compdump_file"
+    else
+        compinit -C -d "$compdump_file"
+    fi
+
+    zstyle ':completion:*' use-cache on
+    zstyle ':completion:*' cache-path "$ZSH_CACHE_DIR"
+}
+
+tino_compinit
+
+# Optional deferred initializer. Uses zsh-defer when installed, otherwise
+# falls back to a lightweight precmd queue.
+typeset -ga TINO_DEFER_QUEUE=()
+typeset -gi _TINO_DEFER_HOOK_REGISTERED=0
+
+_tino_run_deferred_queue() {
+    local deferred_block
+    if (( ${#TINO_DEFER_QUEUE[@]} == 0 )); then
+        return
+    fi
+
+    deferred_block="${TINO_DEFER_QUEUE[1]}"
+    TINO_DEFER_QUEUE=("${TINO_DEFER_QUEUE[@]:1}")
+    eval "$deferred_block"
+}
+
+tino_defer_eval() {
+    local deferred_block="$1"
+
+    if [[ -z "$deferred_block" ]]; then
+        return
+    fi
+
+    if (( $+commands[zsh-defer] )); then
+        zsh-defer eval "$deferred_block"
+        return
+    fi
+
+    TINO_DEFER_QUEUE+=("$deferred_block")
+    if (( _TINO_DEFER_HOOK_REGISTERED == 0 )); then
+        autoload -Uz add-zsh-hook
+        add-zsh-hook precmd _tino_run_deferred_queue
+        _TINO_DEFER_HOOK_REGISTERED=1
+    fi
+}
+
+# Phase 1: prompt-critical startup path.
+ZSH_PLUGIN_DIR="${ZSH_PLUGIN_DIR:-$HOME/.local/share/zsh/plugins}"
 source_if_readable "$ZSH_CONFIG_DIR/aliases.zsh"
 source_if_readable "$ZSH_CONFIG_DIR/functions.zsh"
-
-ZSH_PLUGIN_DIR="${ZSH_PLUGIN_DIR:-$HOME/.local/share/zsh/plugins}"
 source_if_readable "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
 source_if_readable "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
@@ -31,8 +101,23 @@ if command -v starship >/dev/null; then
     eval "$(starship init zsh)"
 fi
 
-if command -v zoxide >/dev/null; then
-    eval "$(zoxide init zsh)"
+# Phase 2: deferred non-critical path/env initialization.
+if [[ "${TINO_ZSH_DEFER:-1}" == "1" ]]; then
+    tino_defer_eval 'source_if_readable "$ZSH_CONFIG_DIR/env.zsh"'
+    tino_defer_eval 'source_if_readable "$HOME/.config/tino/terminal-defaults.sh"'
+    tino_defer_eval 'source_if_readable "$HOME/.config/tino/host-overrides.sh"'
+
+    if command -v zoxide >/dev/null; then
+        tino_defer_eval 'eval "$(zoxide init zsh)"'
+    fi
+else
+    source_if_readable "$ZSH_CONFIG_DIR/env.zsh"
+    source_if_readable "$HOME/.config/tino/terminal-defaults.sh"
+    source_if_readable "$HOME/.config/tino/host-overrides.sh"
+
+    if command -v zoxide >/dev/null; then
+        eval "$(zoxide init zsh)"
+    fi
 fi
 
 if [[ "${TINO_ZSH_PROFILE:-0}" == "1" ]]; then


### PR DESCRIPTION
### Motivation
- Reduce interactive shell startup latency by keeping prompt-critical work minimal and deferring non-essential initialization.
- Provide a robust cached completion strategy to avoid repeated expensive `compinit` runs while allowing periodic refreshes.
- Enable optional background/deferred loading via `zsh-defer` with a safe builtin fallback, and make profiling easy to opt into.

### Description
- Refactored `dotfiles/shell/.zshrc` into two phases: a prompt-critical path (completion bootstrap, prompt plugins, `starship`) and a deferred non-critical path (env/defaults/overrides, language managers and optional tooling). 
- Added a cached completion initializer `tino_compinit` that uses `compinit -C` for fast startups and falls back to full `compinit` when the cache file is missing or older than `TINO_ZSH_COMPINIT_REFRESH_DAYS` (default `7`).
- Implemented an optional deferred loader `tino_defer_eval` that prefers `zsh-defer` when available and otherwise enqueues work on a lightweight `precmd` queue; defer behavior is enabled by default via `TINO_ZSH_DEFER=1` and can be disabled with `TINO_ZSH_DEFER=0`.
- Added startup budget defaults `TINO_ZSH_STARTUP_BUDGET_WARM_MS` and `TINO_ZSH_STARTUP_BUDGET_COLD_MS`, and updated `docs/terminal.md` with the phased startup, completion cache strategy, budget goals, and a profiling recipe tied to `TINO_ZSH_PROFILE=1` (including a repeatable `hyperfine` recipe).

### Testing
- Attempted syntax check with `zsh -n dotfiles/shell/.zshrc`, but the runtime environment does not have `zsh` installed so the check could not be executed (failed). 
- Attempted linting with `shellcheck dotfiles/shell/.zshrc`, but `shellcheck` is not available in this environment so linting could not be performed (failed).
- Attempted targeted unit tests with `pytest -q tests/test_install_common.py -k zsh`, but the test run failed due to a missing Python dependency (`requests`) in the environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb5fe12e88326b2ab2f5e74f4330f)