### PR TITLE
Align Neovim colorscheme fallback, add Mason-based LSP provisioning, and startup regression guard

### DIFF
--- a/dotfiles/nvim/.config/nvim/lua/config/lazy.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/lazy.lua
@@ -21,7 +21,7 @@ require("lazy").setup({
         lazy = true,
     },
     install = {
-        colorscheme = { "tokyonight" },
+        colorscheme = { "nightfox" },
     },
     checker = {
         enabled = false,

--- a/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -1,18 +1,32 @@
 return {
     {
-        "neovim/nvim-lspconfig",
+        "williamboman/mason.nvim",
+        cmd = { "Mason", "MasonInstall", "MasonUpdate" },
+        opts = {},
+    },
+    {
+        "williamboman/mason-lspconfig.nvim",
         event = { "BufReadPre", "BufNewFile" },
-        ft = { "lua", "python", "javascript", "typescript", "sh" },
-        cmd = { "LspInfo", "LspStart" },
-        config = function()
-            local lspconfig = require("lspconfig")
+        dependencies = {
+            "williamboman/mason.nvim",
+            "neovim/nvim-lspconfig",
+        },
+        opts = {
+            ensure_installed = { "lua_ls", "pyright", "ts_ls", "bashls" },
+            automatic_installation = true,
+        },
+        config = function(_, opts)
+            require("mason").setup()
 
-            local servers = { "lua_ls", "pyright", "ts_ls", "bashls" }
-            for _, server in ipairs(servers) do
-                if lspconfig[server] then
-                    lspconfig[server].setup({})
-                end
-            end
+            local mason_lspconfig = require("mason-lspconfig")
+            mason_lspconfig.setup(opts)
+
+            local lspconfig = require("lspconfig")
+            mason_lspconfig.setup_handlers({
+                function(server_name)
+                    lspconfig[server_name].setup({})
+                end,
+            })
         end,
     },
 }

--- a/scripts/benchmark_nvim_startup.sh
+++ b/scripts/benchmark_nvim_startup.sh
@@ -5,6 +5,7 @@ OUTPUT_DIR=".cache/tino/nvim-startup"
 LOG_FILE="${OUTPUT_DIR}/startup.log"
 SUMMARY_FILE="${OUTPUT_DIR}/summary.txt"
 TOP_COUNT="${TOP_COUNT:-20}"
+MAX_STARTUP_MS="${MAX_STARTUP_MS:-}"
 
 mkdir -p "${OUTPUT_DIR}"
 
@@ -16,10 +17,28 @@ fi
 printf 'Running Neovim startup benchmark...\n'
 nvim --headless --startuptime "${LOG_FILE}" +qa
 
+max_startup_ms="$({
+  awk -F':' '
+    match($1, /([0-9]+\.[0-9]+)/, m) {
+      if (m[1] > max) {
+        max = m[1]
+      }
+    }
+    END {
+      if (max > 0) {
+        printf "%.3f", max
+      } else {
+        printf "0.000"
+      }
+    }
+  ' "${LOG_FILE}"
+})"
+
 {
   printf 'Neovim startup benchmark\n'
   printf 'Generated: %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-  printf 'Log file: %s\n\n' "${LOG_FILE}"
+  printf 'Log file: %s\n' "${LOG_FILE}"
+  printf 'Max startup entry (ms): %s\n\n' "${max_startup_ms}"
   printf 'Top %s startup entries (ms)\n' "${TOP_COUNT}"
   printf '%s\n' '----------------------------------------'
 
@@ -37,6 +56,17 @@ nvim --headless --startuptime "${LOG_FILE}" +qa
     | head -n "${TOP_COUNT}" \
     | awk -F'\t' '{printf "%9.3f | %s\n", $1, $2}'
 } > "${SUMMARY_FILE}"
+
+if [[ -n "${MAX_STARTUP_MS}" ]]; then
+  awk -v max="${max_startup_ms}" -v threshold="${MAX_STARTUP_MS}" '
+    BEGIN {
+      if (max > threshold) {
+        printf "Startup regression detected: max startup entry %.3f ms exceeds threshold %.3f ms.\n", max, threshold > "/dev/stderr"
+        exit 1
+      }
+    }
+  '
+fi
 
 printf 'Startup log saved to: %s\n' "${LOG_FILE}"
 printf 'Summary saved to: %s\n' "${SUMMARY_FILE}"

--- a/tests/test_benchmark_nvim_startup.py
+++ b/tests/test_benchmark_nvim_startup.py
@@ -1,0 +1,82 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_fake_nvim(bin_dir: Path, startup_entries: list[str]) -> None:
+    fake_nvim = bin_dir / "nvim"
+    entries = "\n".join(startup_entries)
+    fake_nvim.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+log_file=""
+while (($#)); do
+  case "$1" in
+    --startuptime)
+      log_file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat >"${log_file}" <<'LOG'
+"""
+        + entries
+        + """
+LOG
+""",
+        encoding="utf-8",
+    )
+    fake_nvim.chmod(fake_nvim.stat().st_mode | stat.S_IEXEC)
+
+
+def test_benchmark_nvim_startup_generates_summary_with_max_entry(tmp_path: Path) -> None:
+    script = REPO_ROOT / "scripts" / "benchmark_nvim_startup.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_nvim(
+        fake_bin,
+        [
+            "000.200: plugin/bootstrap",
+            "004.500: plugin/colorscheme",
+            "002.100: plugin/lsp",
+        ],
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["TOP_COUNT"] = "2"
+
+    subprocess.run(["bash", str(script)], cwd=tmp_path, env=env, check=True)
+
+    summary = (tmp_path / ".cache" / "tino" / "nvim-startup" / "summary.txt").read_text(encoding="utf-8")
+    assert "Max startup entry (ms): 4.500" in summary
+    assert "Top 2 startup entries (ms)" in summary
+    assert "4.500 | plugin/colorscheme" in summary
+
+
+def test_benchmark_nvim_startup_fails_on_threshold_regression(tmp_path: Path) -> None:
+    script = REPO_ROOT / "scripts" / "benchmark_nvim_startup.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_nvim(
+        fake_bin,
+        [
+            "001.000: plugin/bootstrap",
+            "007.250: plugin/lsp",
+        ],
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["MAX_STARTUP_MS"] = "5"
+
+    result = subprocess.run(["bash", str(script)], cwd=tmp_path, env=env, text=True, capture_output=True)
+
+    assert result.returncode == 1
+    assert "Startup regression detected" in result.stderr


### PR DESCRIPTION
### Motivation
- Remove a mismatch between the `lazy.nvim` install fallback and the active colorscheme to ensure predictable default visuals.
- Make LSP availability deterministic across machines by moving from ad-hoc `lspconfig` setup to a reproducible server provisioning layer.
- Detect and fail on Neovim startup regressions by adding a deterministic metric and an optional threshold guard to CI-local benchmarks.

### Description
- Aligned the lazy installer fallback colorscheme by changing `install.colorscheme` from `tokyonight` to `nightfox` in `dotfiles/nvim/.config/nvim/lua/config/lazy.lua`.
- Reworked LSP plugin specs under `lua/plugins/` to add `williamboman/mason.nvim` and `williamboman/mason-lspconfig.nvim`, configured `ensure_installed = { "lua_ls", "pyright", "ts_ls", "bashls" }` and automatic installation with handler-based setup in `dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua`.
- Enhanced `scripts/benchmark_nvim_startup.sh` to compute and include a `Max startup entry (ms)` metric and to optionally fail when `MAX_STARTUP_MS` is set and exceeded, while preserving the existing summary output format.
- Added `tests/test_benchmark_nvim_startup.py` which injects a fake `nvim` binary to validate summary generation and the regression-failure behavior.

### Testing
- Ran `bash -n scripts/benchmark_nvim_startup.sh` which passed (script syntax OK).
- Ran `pytest -q tests/test_benchmark_nvim_startup.py` which passed (2 tests passed).
- Ran `pytest -q tests/test_dotfiles.py` which failed due to a pre-existing missing repository path `dotfiles/ghostty/ghostty.toml.tmpl`, which is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb8862e4483269cb3d27ea2a22911)