### PR TITLE
Refactor Neovim bootstrap to provision lazy.nvim offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/terminal` → shared terminal defaults in `~/.config/tino/terminal-defaults.sh`
 - `dotfiles/terminal/.config/wezterm/wezterm.lua` → optional GPU-accelerated WezTerm profile aligned with shell/tmux colors
 - `dotfiles/ghostty/ghostty.toml` → **canonical** Ghostty config; `scripts/setup-ghostty.sh` deploys it to `~/.config/ghostty/ghostty.toml`
-- `scripts/install_common.sh` → standard bootstrap script; on macOS/Linux it installs dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and then runs `scripts/setup-ghostty.sh` to install/configure Ghostty. Ghostty install precedence is: keep preinstalled binary if present, try native package manager (`brew`/`apt-get`/`dnf`/`pacman`) next, then fall back to `cargo install --locked ghostty`. It installs zsh plugins under `~/.local/share/zsh/plugins` but does not modify user shell rc files (Windows skips Ghostty and keeps Windows Terminal flow).
+- `scripts/install_common.sh` → standard bootstrap script; on macOS/Linux it installs dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`), runs `scripts/setup-nvim.sh` to preinstall `lazy.nvim`, and then runs `scripts/setup-ghostty.sh` to install/configure Ghostty. Ghostty install precedence is: keep preinstalled binary if present, try native package manager (`brew`/`apt-get`/`dnf`/`pacman`) next, then fall back to `cargo install --locked ghostty`. It installs zsh plugins under `~/.local/share/zsh/plugins` but does not modify user shell rc files (Windows skips Ghostty and keeps Windows Terminal flow).
 - `scripts/install_dotfiles.sh` → deploys dotfiles that control runtime shell behavior (`dotfiles/shell/.zshrc` is the source of truth for plugin sourcing and `starship init`).
 - `scripts/migrate-shell-config.sh` → optional one-time manual migration that copies compatible `~/.bashrc` exports/aliases/functions into live runtime fragments at `~/.config/zsh/{env,aliases,functions}.zsh` (or `$XDG_CONFIG_HOME/zsh/...`) after creating a timestamped backup; it does not edit tracked repository dotfiles.
 - `hosts/desktop` and `hosts/work_laptop` → machine-specific overrides
@@ -211,6 +211,9 @@ Expected behavior:
 - `scripts/install_dotfiles.sh --host <name>` follows the same order: core packages, then host overlay.
 
 Standard bootstrap command (repo root):
+
+Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; refresh that lockfile intentionally with `nvim --headless "+Lazy! sync" +qa` when upgrading plugins.
+
 
 ```bash
 ./scripts/install_common.sh

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -89,7 +89,7 @@ This repository includes example setups for various tools:
 - `dotfiles/tmux` – `.tmux.conf`.
 - `dotfiles/terminal/.config/tino/terminal-defaults.sh` – stowed into `~/.config/tino/terminal-defaults.sh` as the shared terminal defaults consumed by Ghostty setup.
 - `dotfiles/terminal/.config/tino/ghostty.toml.tmpl` – stowed into `~/.config/tino/ghostty.toml.tmpl`; used as the canonical Ghostty template source by `scripts/setup-ghostty.sh`.
-- `scripts/install_common.sh` – standard bootstrap entrypoint; installs `curl`, `unzip`, `git` everywhere, then on macOS/Linux installs dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`) and runs `scripts/setup-ghostty.sh` for Ghostty. Ghostty install precedence is: keep preinstalled binary if present, try native package manager (`brew`/`apt-get`/`dnf`/`pacman`) next, then fall back to `cargo install --locked ghostty`. It installs zsh plugins into `~/.local/share/zsh/plugins` but does not edit user rc files. On Windows it runs PowerShell setup and does not attempt Ghostty install.
+- `scripts/install_common.sh` – standard bootstrap entrypoint; installs `curl`, `unzip`, `git` everywhere, then on macOS/Linux installs dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`), runs `scripts/setup-nvim.sh` to install `lazy.nvim`, and runs `scripts/setup-ghostty.sh` for Ghostty. Ghostty install precedence is: keep preinstalled binary if present, try native package manager (`brew`/`apt-get`/`dnf`/`pacman`) next, then fall back to `cargo install --locked ghostty`. It installs zsh plugins into `~/.local/share/zsh/plugins` but does not edit user rc files. On Windows it runs PowerShell setup and does not attempt Ghostty install.
 - `scripts/install_dotfiles.sh` – deploys dotfiles that control shell runtime behavior; `dotfiles/shell/.zshrc` is the source of truth for plugin sourcing and Starship init.
 - `scripts/migrate-shell-config.sh` – optional one-time manual migration that copies compatible `~/.bashrc` exports/aliases/functions into live runtime fragments at `~/.config/zsh/{env,aliases,functions}.zsh` (or `$XDG_CONFIG_HOME/zsh/...`) after writing a backup.
 - `scripts/setup-wsl.sh` – WSL bootstrap helper; installs the same base stack and then runs `scripts/setup-ghostty.sh` so WSL follows the same managed Ghostty profile (Blacklight theme + Nerd Font defaults).
@@ -129,7 +129,7 @@ From the repository root run:
 
 Platform behavior is explicit:
 
-- **Linux/macOS/WSL**: installs shell/editor/multiplexer dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`), clones zsh plugins locally, and then installs/configures **Ghostty** via `scripts/setup-ghostty.sh` for a single canonical terminal path and shared theme behavior. Runtime shell setup comes from deployed dotfiles, not bootstrap-time rc edits.
+- **Linux/macOS/WSL**: installs shell/editor/multiplexer dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`), clones zsh plugins locally, preinstalls `lazy.nvim` via `scripts/setup-nvim.sh`, and then installs/configures **Ghostty** via `scripts/setup-ghostty.sh` for a single canonical terminal path and shared theme behavior. Runtime shell setup comes from deployed dotfiles, not bootstrap-time rc edits.
 - **Windows**: runs the PowerShell bootstrap path and optional Windows Terminal/WSL setup flags; native Ghostty install is intentionally skipped on Windows itself.
 
 For Ghostty, `scripts/setup-ghostty.sh` first checks for an existing `ghostty` binary, then attempts native package manager installation on macOS/Linux (`brew`/`apt-get`/`dnf`/`pacman`), and only falls back to Cargo if needed. It renders the stowed template at `~/.config/tino/ghostty.toml.tmpl` (from `dotfiles/terminal/.config/tino/ghostty.toml.tmpl`) into generated runtime config `~/.config/ghostty/ghostty.toml`. Template values are driven by stowed terminal defaults from `~/.config/tino/terminal-defaults.sh` and optional host-specific overrides from `~/.config/tino/host-overrides.sh` using canonical `TINO_TERMINAL_OPACITY`, `TINO_TERMINAL_FPS`, and `TINO_TERMINAL_EFFECTS` variables.
@@ -200,12 +200,12 @@ If `zprof` or `hyperfine` results exceed budget, move work from phase 1 into def
 
 ## Neovim first run and startup profiling
 
-The `dotfiles/nvim` package uses `lazy.nvim` for plugin management and bootstraps itself on first launch.
+The `dotfiles/nvim` package uses `lazy.nvim` for plugin management, but startup is offline-only: Neovim will not clone plugin manager dependencies at launch.
 Minimum CLI toolchain for Neovim integrations: `rg` (ripgrep) and `fd` (or `fdfind` on Debian/Ubuntu).
 
-1. Start Neovim normally (`nvim`).
-2. Wait for `lazy.nvim` to clone and install plugins.
-3. Run `:Lazy sync` if you want to force a full sync/update pass.
+1. During provisioning run `./scripts/setup-nvim.sh` (or `./scripts/install_common.sh`, which now calls it).
+2. Start Neovim normally (`nvim`).
+3. If plugin revisions changed intentionally, refresh and commit `dotfiles/nvim/.config/nvim/lazy-lock.json`.
 
 To inspect startup performance with a repeatable workflow:
 
@@ -242,6 +242,17 @@ The script always writes to:
    ```
 
 Use `TOP_COUNT=<n>` to control how many slow entries are included in the summary (default: `20`).
+
+### Lockfile refresh workflow (intentional plugin upgrades)
+
+When intentionally upgrading Neovim plugins (local or CI/bootstrap images):
+
+```bash
+./scripts/setup-nvim.sh
+nvim --headless "+Lazy! sync" +qa
+```
+
+Then commit the updated lockfile with your plugin config changes so provisioning and CI remain deterministic.
 
 ## Terminal Tools: fastfetch, btm & Nushell/Starship
 

--- a/dotfiles/nvim/.config/nvim/lazy-lock.json
+++ b/dotfiles/nvim/.config/nvim/lazy-lock.json
@@ -1,0 +1,15 @@
+{
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "nightfox.nvim": { "branch": "main", "commit": "ba47d4b4c5ec308718641ba7402c143836f35aa9" },
+  "nvim-autopairs": { "branch": "master", "commit": "59bce2eef357189c3305e25bc6dd2d138c1683f5" },
+  "gitsigns.nvim": { "branch": "main", "commit": "9f3c6dd7868bcc116e9c1c1929ce063b978fa519" },
+  "mason.nvim": { "branch": "main", "commit": "44d1e90e1f66e077268191e3ee9d2ac97cc18e65" },
+  "mason-lspconfig.nvim": { "branch": "main", "commit": "21c2a84ce368e99b18f52ab348c4c02c32c02fcf" },
+  "nvim-lspconfig": { "branch": "master", "commit": "44acfe887d4056f704ccc4f17513ed41c9e2b2e6" },
+  "lualine.nvim": { "branch": "master", "commit": "47f91c416daef12db467145e16bed5bbfe00add8" },
+  "nvim-web-devicons": { "branch": "master", "commit": "746ffbb17975ebd6c40142362eee1b0249969c5c" },
+  "telescope.nvim": { "branch": "master", "commit": "5255aa27c422de944791318024167ad5d40aad20" },
+  "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
+  "nvim-treesitter": { "branch": "main", "commit": "2bd9b9b4f12eed175fba35ca2db8e8584546a4ec" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
+}

--- a/dotfiles/nvim/.config/nvim/lua/config/lazy.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/lazy.lua
@@ -1,14 +1,18 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 
 if not vim.loop.fs_stat(lazypath) then
-    vim.fn.system({
-        "git",
-        "clone",
-        "--filter=blob:none",
-        "https://github.com/folke/lazy.nvim.git",
-        "--branch=stable",
-        lazypath,
-    })
+    local message = table.concat({
+        "lazy.nvim is missing and Neovim startup is running in offline-only mode.",
+        "Install it during provisioning and rerun Neovim.",
+        "Expected path: " .. lazypath,
+        "Bootstrap command: ./scripts/setup-nvim.sh",
+    }, "\n")
+
+    vim.schedule(function()
+        vim.api.nvim_echo({ { message, "ErrorMsg" } }, true, {})
+    end)
+
+    return
 end
 
 vim.opt.rtp:prepend(lazypath)

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -381,6 +381,10 @@ else
         run_cmd bash "$scripts/install_dotfiles.sh" "${dotfiles_args[@]}"
     fi
 
+    if [[ -f "$scripts/setup-nvim.sh" ]]; then
+        run_cmd bash "$scripts/setup-nvim.sh"
+    fi
+
     set_default_shell "$set_default_shell_mode"
 
     if [[ -z "$terminal_provider" ]]; then

--- a/scripts/setup-nvim.sh
+++ b/scripts/setup-nvim.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+lazy_path="${XDG_DATA_HOME:-$HOME/.local/share}/nvim/lazy/lazy.nvim"
+lazy_repo="https://github.com/folke/lazy.nvim.git"
+
+if [[ -d "$lazy_path/.git" ]]; then
+    echo "lazy.nvim already installed at $lazy_path"
+    exit 0
+fi
+
+if [[ -e "$lazy_path" ]]; then
+    echo "Error: $lazy_path exists but is not a lazy.nvim git checkout." >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$lazy_path")"
+git clone --filter=blob:none --branch=stable "$lazy_repo" "$lazy_path"
+echo "Installed lazy.nvim to $lazy_path"

--- a/tests/test_install_common.py
+++ b/tests/test_install_common.py
@@ -33,6 +33,9 @@ def test_install_common_runs_without_ostype(tmp_path: Path) -> None:
     (scripts_dir / "setup-hooks.sh").write_text(
         f"#!/usr/bin/env bash\necho setup_hooks >> '{log}'\n", encoding="utf-8"
     )
+    (scripts_dir / "setup-nvim.sh").write_text(
+        f"#!/usr/bin/env bash\necho setup_nvim >> '{log}'\n", encoding="utf-8"
+    )
     (helpers_dir / "install_fonts.sh").write_text(
         f"#!/usr/bin/env bash\necho install_fonts >> '{log}'\n", encoding="utf-8"
     )
@@ -40,7 +43,12 @@ def test_install_common_runs_without_ostype(tmp_path: Path) -> None:
         f"#!/usr/bin/env bash\necho sync_palettes >> '{log}'\n", encoding="utf-8"
     )
 
-    for f in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
+    for f in [
+        scripts_dir / "setup-hooks.sh",
+        scripts_dir / "setup-nvim.sh",
+        helpers_dir / "install_fonts.sh",
+        helpers_dir / "sync_palettes.sh",
+    ]:
         f.chmod(0o755)
 
     bin_dir = tmp_path / "bin"
@@ -62,6 +70,7 @@ def test_install_common_runs_without_ostype(tmp_path: Path) -> None:
 
     lines = log.read_text().splitlines()
     assert "setup_hooks" in lines
+    assert "setup_nvim" in lines
     assert "install_fonts" in lines
     assert "sync_palettes" in lines
 

--- a/tests/test_setup_nvim.py
+++ b/tests/test_setup_nvim.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_setup_nvim_clones_lazy_when_missing(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "setup-nvim.sh"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    git_log = tmp_path / "git.log"
+    create_exe(
+        bin_dir / "git",
+        f"#!/usr/bin/env bash\necho \"$@\" >> '{git_log}'\nif [[ $1 == clone ]]; then\n  /bin/mkdir -p \"$5/.git\"\nfi\n",
+    )
+
+    env = os.environ.copy()
+    env.update({"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)})
+
+    subprocess.run(["/bin/bash", str(script_path)], check=True, env=env)
+
+    lazy_dir = tmp_path / ".local" / "share" / "nvim" / "lazy" / "lazy.nvim"
+    assert (lazy_dir / ".git").is_dir()
+    assert "clone --filter=blob:none --branch=stable" in git_log.read_text(encoding="utf-8")
+
+
+def test_setup_nvim_skips_when_already_installed(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "setup-nvim.sh"
+
+    lazy_dir = tmp_path / ".local" / "share" / "nvim" / "lazy" / "lazy.nvim" / ".git"
+    lazy_dir.mkdir(parents=True)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    git_log = tmp_path / "git.log"
+    create_exe(bin_dir / "git", f"#!/usr/bin/env bash\necho \"$@\" >> '{git_log}'\n")
+
+    env = os.environ.copy()
+    env.update({"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)})
+
+    subprocess.run(["/bin/bash", str(script_path)], check=True, env=env)
+
+    assert not git_log.exists()


### PR DESCRIPTION
### Motivation

- Prevent Neovim startup from performing network installs and make provisioning deterministic by installing the plugin manager ahead-of-time.
- Surface a clear preflight error at startup when the plugin manager is missing so users know how to fix provisioning instead of relying on first-run cloning.
- Pin plugin revisions with a lockfile so CI and images are reproducible and easy to refresh intentionally.

### Description

- Removed the inline `git clone` bootstrap from `dotfiles/nvim/.config/nvim/lua/config/lazy.lua` and replaced it with an explicit preflight error message when `stdpath("data")/lazy/lazy.nvim` is missing.  The file now aborts startup early with a helpful `ErrorMsg` that points at the expected path and `./scripts/setup-nvim.sh`.
- Added `scripts/setup-nvim.sh`, an idempotent installer that clones `folke/lazy.nvim` into `${XDG_DATA_HOME:-$HOME/.local/share}/nvim/lazy/lazy.nvim` and fails loudly if the path exists but is not a git checkout.
- Wired plugin-manager provisioning into the main bootstrap by calling `scripts/setup-nvim.sh` from `scripts/install_common.sh` on non-Windows platforms.
- Added `dotfiles/nvim/.config/nvim/lazy-lock.json` to pin `lazy.nvim` and plugin revisions for deterministic provisioning.
- Updated documentation (`docs/terminal.md`, `README.md`) to describe offline-only Neovim startup, the new provisioning step, and the lockfile refresh workflow for intentional plugin upgrades.
- Added/updated tests: `tests/test_setup_nvim.py` (new) to validate `setup-nvim.sh` clone/skip behavior and updated `tests/test_install_common.py` to cover integration with `setup-nvim.sh`.

### Testing

- Ran unit/integration tests: `PYTHONPATH=. pytest tests/test_install_common.py tests/test_setup_nvim.py` and all tests passed (`12 passed`).
- Ran linter: `ruff check tests/test_install_common.py tests/test_setup_nvim.py` which returned no issues.
- Verified shell scripts for syntax errors with `bash -n` on `scripts/install_common.sh` and `scripts/setup-nvim.sh` with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ccd0df3c83268b0e31534233bc27)