### PR TITLE
Align terminal renderer capability contracts and add validation

### DIFF
--- a/dotfiles/terminal/.config/tino/renderers/alacritty.sh
+++ b/dotfiles/terminal/.config/tino/renderers/alacritty.sh
@@ -5,6 +5,8 @@ config_dir="$config_home/alacritty"
 mkdir -p "$config_dir"
 cat > "$config_dir/alacritty.toml" <<EOC
 # Managed by ~/.config/tino/terminal-profile.sh (provider: alacritty)
+# tino-contract:unsupported TINO_TERMINAL_FPS
+# tino-contract:unsupported TINO_TERMINAL_EFFECTS
 [font]
 size = ${TINO_TERMINAL_FONT_SIZE}
 normal = { family = "${TINO_TERMINAL_FONT_FAMILY}", style = "Regular" }

--- a/dotfiles/terminal/.config/tino/renderers/kitty.sh
+++ b/dotfiles/terminal/.config/tino/renderers/kitty.sh
@@ -3,11 +3,21 @@ set -euo pipefail
 config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
 config_dir="$config_home/kitty"
 mkdir -p "$config_dir"
+
+kitty_fps="${TINO_TERMINAL_FPS}"
+if [[ "$kitty_fps" -lt 1 ]]; then
+    kitty_fps=1
+fi
+kitty_repaint_delay_ms=$(( (1000 + kitty_fps - 1) / kitty_fps ))
+
 cat > "$config_dir/kitty.conf" <<EOC
 # Managed by ~/.config/tino/terminal-profile.sh (provider: kitty)
 font_family ${TINO_TERMINAL_FONT_FAMILY}
 font_size ${TINO_TERMINAL_FONT_SIZE}
 background_opacity ${TINO_TERMINAL_OPACITY}
+sync_to_monitor yes
+repaint_delay ${kitty_repaint_delay_ms}
+# tino-contract:unsupported TINO_TERMINAL_EFFECTS
 foreground ${TINO_TERMINAL_FOREGROUND}
 background ${TINO_TERMINAL_BACKGROUND}
 cursor ${TINO_TERMINAL_CURSOR}

--- a/dotfiles/terminal/.config/tino/renderers/wezterm.sh
+++ b/dotfiles/terminal/.config/tino/renderers/wezterm.sh
@@ -7,6 +7,7 @@ mkdir -p "$config_dir"
 
 cat > "$config_dir/wezterm.generated.lua" <<EOC
 -- Managed by ~/.config/tino/terminal-profile.sh (provider: wezterm)
+-- tino-contract:unsupported TINO_TERMINAL_EFFECTS
 local wezterm = require("wezterm")
 
 return {

--- a/dotfiles/terminal/.config/tino/renderers/windows-terminal.sh
+++ b/dotfiles/terminal/.config/tino/renderers/windows-terminal.sh
@@ -5,6 +5,14 @@ if [[ -z "$repo_root" ]]; then
     echo "windows-terminal renderer requires repo root path" >&2
     exit 1
 fi
+
+acrylic_enabled="true"
+case "${TINO_TERMINAL_EFFECTS,,}" in
+    off|false|no|0|none)
+        acrylic_enabled="false"
+        ;;
+esac
+
 output="$repo_root/windows-terminal/terminal-profile-overrides.json"
 mkdir -p "$(dirname "$output")"
 cat > "$output" <<EOC
@@ -15,6 +23,7 @@ cat > "$output" <<EOC
         "face": "${TINO_TERMINAL_FONT_FAMILY}",
         "size": ${TINO_TERMINAL_FONT_SIZE}
       },
+      "useAcrylic": ${acrylic_enabled},
       "acrylicOpacity": ${TINO_TERMINAL_OPACITY},
       "colorScheme": "Blacklight"
     }
@@ -43,7 +52,12 @@ cat > "$output" <<EOC
       "cursorColor": "${TINO_TERMINAL_CURSOR}",
       "selectionBackground": "${TINO_TERMINAL_SELECTION}"
     }
-  ]
+  ],
+  "tinoContract": {
+    "unsupported": {
+      "TINO_TERMINAL_FPS": "windows-terminal has no profile-level refresh/fps override; retained as no-op"
+    }
+  }
 }
 EOC
 echo "Rendered Windows Terminal overrides to $output"

--- a/dotfiles/terminal/.config/tino/terminal-profile.sh
+++ b/dotfiles/terminal/.config/tino/terminal-profile.sh
@@ -12,6 +12,51 @@ source_if_exists() {
     fi
 }
 
+# Contract fields shared across renderers.
+readonly TINO_TERMINAL_CONTRACT_FIELDS=(
+    TINO_TERMINAL_FPS
+    TINO_TERMINAL_OPACITY
+    TINO_TERMINAL_EFFECTS
+)
+
+terminal_capability_status() {
+    local provider="$1"
+    local field="$2"
+
+    case "$provider:$field" in
+        ghostty:TINO_TERMINAL_FPS|ghostty:TINO_TERMINAL_OPACITY|ghostty:TINO_TERMINAL_EFFECTS)
+            printf 'applied'
+            ;;
+        wezterm:TINO_TERMINAL_FPS|wezterm:TINO_TERMINAL_OPACITY)
+            printf 'applied'
+            ;;
+        wezterm:TINO_TERMINAL_EFFECTS)
+            printf 'unsupported'
+            ;;
+        kitty:TINO_TERMINAL_FPS|kitty:TINO_TERMINAL_OPACITY)
+            printf 'applied'
+            ;;
+        kitty:TINO_TERMINAL_EFFECTS)
+            printf 'unsupported'
+            ;;
+        alacritty:TINO_TERMINAL_OPACITY)
+            printf 'applied'
+            ;;
+        alacritty:TINO_TERMINAL_FPS|alacritty:TINO_TERMINAL_EFFECTS)
+            printf 'unsupported'
+            ;;
+        windows-terminal:TINO_TERMINAL_OPACITY|windows-terminal:TINO_TERMINAL_EFFECTS)
+            printf 'applied'
+            ;;
+        windows-terminal:TINO_TERMINAL_FPS)
+            printf 'unsupported'
+            ;;
+        *)
+            printf 'unknown'
+            ;;
+    esac
+}
+
 load_terminal_profile() {
     source_if_exists "$tino_dir/terminal-defaults.sh"
     source_if_exists "$tino_dir/host-overrides.sh"

--- a/dotfiles/terminal/.config/tino/validate-renderer-contract.sh
+++ b/dotfiles/terminal/.config/tino/validate-renderer-contract.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/.config"
+ln -s "$repo_root/dotfiles/terminal/.config/tino" "$tmp_dir/.config/tino"
+
+export HOME="$tmp_dir"
+export XDG_CONFIG_HOME="$tmp_dir/.config"
+# Force an effects value that must be propagated by renderers that support effects.
+export TINO_TERMINAL_EFFECTS="/tmp/tino-shader.glsl"
+
+# shellcheck disable=SC1090
+source "$XDG_CONFIG_HOME/tino/terminal-profile.sh"
+
+providers=(ghostty wezterm kitty alacritty windows-terminal)
+validation_repo_root="$tmp_dir/validation-repo"
+mkdir -p "$validation_repo_root"
+for provider in "${providers[@]}"; do
+    "$XDG_CONFIG_HOME/tino/terminal-profile.sh" "$provider" "$validation_repo_root" >/dev/null
+
+done
+
+check_applied() {
+    local provider="$1"
+    local field="$2"
+
+    case "$provider:$field" in
+        ghostty:TINO_TERMINAL_FPS)
+            rg -q '^custom-shader-animation-max-fps = ' "$XDG_CONFIG_HOME/ghostty/ghostty.toml"
+            ;;
+        ghostty:TINO_TERMINAL_OPACITY)
+            rg -q '^background-opacity = ' "$XDG_CONFIG_HOME/ghostty/ghostty.toml"
+            ;;
+        ghostty:TINO_TERMINAL_EFFECTS)
+            ! rg -q 'tino-contract:unsupported TINO_TERMINAL_EFFECTS' "$XDG_CONFIG_HOME/ghostty/ghostty.toml"
+            ;;
+        wezterm:TINO_TERMINAL_FPS)
+            rg -q 'max_fps = ' "$XDG_CONFIG_HOME/wezterm/wezterm.generated.lua"
+            ;;
+        wezterm:TINO_TERMINAL_OPACITY)
+            rg -q 'window_background_opacity = ' "$XDG_CONFIG_HOME/wezterm/wezterm.generated.lua"
+            ;;
+        kitty:TINO_TERMINAL_FPS)
+            rg -q '^sync_to_monitor yes$' "$XDG_CONFIG_HOME/kitty/kitty.conf"
+            rg -q '^repaint_delay [0-9]+$' "$XDG_CONFIG_HOME/kitty/kitty.conf"
+            ;;
+        kitty:TINO_TERMINAL_OPACITY)
+            rg -q '^background_opacity ' "$XDG_CONFIG_HOME/kitty/kitty.conf"
+            ;;
+        alacritty:TINO_TERMINAL_OPACITY)
+            rg -q '^opacity = ' "$XDG_CONFIG_HOME/alacritty/alacritty.toml"
+            ;;
+        windows-terminal:TINO_TERMINAL_OPACITY)
+            rg -q '"acrylicOpacity"' "$validation_repo_root/windows-terminal/terminal-profile-overrides.json"
+            ;;
+        windows-terminal:TINO_TERMINAL_EFFECTS)
+            rg -q '"useAcrylic"' "$validation_repo_root/windows-terminal/terminal-profile-overrides.json"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+check_unsupported() {
+    local provider="$1"
+    local field="$2"
+
+    case "$provider:$field" in
+        wezterm:TINO_TERMINAL_EFFECTS)
+            rg -q '^-- tino-contract:unsupported TINO_TERMINAL_EFFECTS$' "$XDG_CONFIG_HOME/wezterm/wezterm.generated.lua"
+            ;;
+        kitty:TINO_TERMINAL_EFFECTS)
+            rg -q '^# tino-contract:unsupported TINO_TERMINAL_EFFECTS$' "$XDG_CONFIG_HOME/kitty/kitty.conf"
+            ;;
+        alacritty:TINO_TERMINAL_FPS)
+            rg -q '^# tino-contract:unsupported TINO_TERMINAL_FPS$' "$XDG_CONFIG_HOME/alacritty/alacritty.toml"
+            ;;
+        alacritty:TINO_TERMINAL_EFFECTS)
+            rg -q '^# tino-contract:unsupported TINO_TERMINAL_EFFECTS$' "$XDG_CONFIG_HOME/alacritty/alacritty.toml"
+            ;;
+        windows-terminal:TINO_TERMINAL_FPS)
+            rg -q '"TINO_TERMINAL_FPS"' "$validation_repo_root/windows-terminal/terminal-profile-overrides.json"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+for provider in "${providers[@]}"; do
+    for field in "${TINO_TERMINAL_CONTRACT_FIELDS[@]}"; do
+        status="$(terminal_capability_status "$provider" "$field")"
+        if [[ "$status" == "applied" ]]; then
+            check_applied "$provider" "$field"
+        elif [[ "$status" == "unsupported" ]]; then
+            check_unsupported "$provider" "$field"
+        else
+            echo "unknown capability status for ${provider}:${field}" >&2
+            exit 1
+        fi
+    done
+
+done
+
+echo "Renderer contract validation passed for ${#providers[@]} providers."


### PR DESCRIPTION
### Motivation
- Ensure terminal renderers consistently honor shared profile knobs (`TINO_TERMINAL_FPS`, `TINO_TERMINAL_OPACITY`, `TINO_TERMINAL_EFFECTS`) by making provider capabilities explicit. 
- Make unsupported knobs explicit in generated configs so callers can rely on a documented contract.

### Description
- Added a provider capability matrix in `dotfiles/terminal/.config/tino/terminal-profile.sh` via `TINO_TERMINAL_CONTRACT_FIELDS` and `terminal_capability_status` to categorize each provider/field as `applied` or `unsupported`.
- Kitty renderer (`renderers/kitty.sh`) now computes a safe `repaint_delay` from `TINO_TERMINAL_FPS`, emits `sync_to_monitor yes`, and annotates `TINO_TERMINAL_EFFECTS` as unsupported in the generated config.
- Alacritty and WezTerm renderers (`renderers/alacritty.sh`, `renderers/wezterm.sh`) were annotated to explicitly mark unsupported contract fields as comments in the generated outputs.
- Windows Terminal renderer (`renderers/windows-terminal.sh`) maps `TINO_TERMINAL_EFFECTS` to `useAcrylic`, preserves opacity via `acrylicOpacity`, and records `TINO_TERMINAL_FPS` as an explicit unsupported no-op in the JSON `tinoContract` field.
- Added `dotfiles/terminal/.config/tino/validate-renderer-contract.sh`, a lightweight validation script that renders every provider into a temporary config area and verifies each contract field is either applied or explicitly marked unsupported.

### Testing
- Ran a shell syntax check with `bash -n` on the modified scripts which succeeded for the changed files.
- Executed the validation script `dotfiles/terminal/.config/tino/validate-renderer-contract.sh`, which renders all providers into a temporary layout and passed verification for all providers.
- Attempted to run `shellcheck` across the changed files, but `shellcheck` is not available in this environment so linting could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995cfbeb628832698cd6f4ee75bbb3d)