### PR TITLE
Make bash migration hint lookup deterministic

### DIFF
--- a/dotfiles/shell/.bashrc
+++ b/dotfiles/shell/.bashrc
@@ -8,7 +8,11 @@ esac
 
 migration_script="$HOME/.local/share/d0ttino/scripts/migrate-shell-config.sh"
 if [[ ! -x "${migration_script}" ]]; then
-    migration_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/migrate-shell-config.sh"
+    if [[ -n "${D0TTINO_REPO_ROOT:-}" ]]; then
+        migration_script="${D0TTINO_REPO_ROOT}/scripts/migrate-shell-config.sh"
+    else
+        migration_script="scripts/migrate-shell-config.sh"
+    fi
 fi
 
 migration_hint_stamp="${XDG_CACHE_HOME:-$HOME/.cache}/d0ttino/bash-migration-hint-shown"

--- a/tests/test_migrate_shell_config.py
+++ b/tests/test_migrate_shell_config.py
@@ -153,4 +153,27 @@ def test_minimal_bashrc_shim_prints_migration_hint_once(tmp_path: Path) -> None:
     )
 
     assert "Hint: migrate your legacy ~/.bashrc settings" in first.stderr
+    assert "scripts/migrate-shell-config.sh" in first.stderr
     assert "Hint: migrate your legacy ~/.bashrc settings" not in second.stderr
+
+
+def test_minimal_bashrc_shim_uses_env_fallback_for_symlinked_rcfile(tmp_path: Path) -> None:
+    bashrc_symlink = tmp_path / ".bashrc"
+    bashrc_symlink.symlink_to(REPO_ROOT / "dotfiles" / "shell" / ".bashrc")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["D0TTINO_REPO_ROOT"] = "/tmp/custom-d0ttino"
+
+    result = subprocess.run(
+        ["/bin/bash", "--rcfile", str(bashrc_symlink), "-i", "-c", "exit"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Hint: migrate your legacy ~/.bashrc settings" in result.stderr
+    assert "/tmp/custom-d0ttino/scripts/migrate-shell-config.sh" in result.stderr


### PR DESCRIPTION
### Motivation
- Avoid resolving the migration script path from `dirname "${BASH_SOURCE[0]}"` because that makes assumptions about symlink resolution and repository location in `$HOME`.
- Provide a deterministic, safe hint path that works for typical installs and for users who set a repository root via an environment variable.

### Description
- Updated `dotfiles/shell/.bashrc` to prefer `$HOME/.local/share/d0ttino/scripts/migrate-shell-config.sh`, then fall back to `${D0TTINO_REPO_ROOT}/scripts/migrate-shell-config.sh` when `D0TTINO_REPO_ROOT` is set, and otherwise print the generic `scripts/migrate-shell-config.sh` hint.
- Removed the previous `$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)` fallback to avoid relying on the rcfile location or symlink behavior.
- Extended `tests/test_migrate_shell_config.py` to assert the generic hint is printed and added a test that simulates a symlinked `.bashrc` verifying the `D0TTINO_REPO_ROOT` fallback is used.

### Testing
- Ran `pytest tests/test_migrate_shell_config.py`, which passed (`5 passed`).
- Ran `ruff` on the updated test file, which passed (`ruff check tests/test_migrate_shell_config.py`).
- Verified the shell file syntax with `bash -n dotfiles/shell/.bashrc`, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699737b9dc488326929e655c6a9cf770)