### PR TITLE
Refactor Ghostty setup to orchestrate template sync and idempotent rendering

### DIFF
--- a/scripts/setup-ghostty.sh
+++ b/scripts/setup-ghostty.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+canonical_template="$repo_root/dotfiles/terminal/.config/tino/ghostty.toml.tmpl"
+
 detect_ostype() {
     if [[ -n "${OSTYPE:-}" ]]; then
         printf '%s' "${OSTYPE,,}"
@@ -55,21 +58,91 @@ ensure_ghostty_installed() {
 
     echo "Falling back to cargo for Ghostty install"
     if ! command -v cargo >/dev/null 2>&1; then
-        echo "Error: cargo is required for Ghostty fallback installation" >&2
+        echo "Error: unable to install Ghostty (cargo is required for fallback installation)" >&2
         exit 1
     fi
-    cargo install --locked ghostty
+    if ! cargo install --locked ghostty; then
+        echo "Error: unable to install Ghostty" >&2
+        exit 1
+    fi
+
+    if ! command -v ghostty >/dev/null 2>&1; then
+        echo "Error: unable to install Ghostty" >&2
+        exit 1
+    fi
+}
+
+sync_template() {
+    local target_template="$1"
+    local target_dir
+    target_dir="$(dirname "$target_template")"
+    mkdir -p "$target_dir"
+
+    if [[ ! -f "$target_template" ]] || ! cmp -s "$canonical_template" "$target_template"; then
+        cp "$canonical_template" "$target_template"
+    fi
+}
+
+render_ghostty_config() {
+    local template_file="$1"
+    local target_file="$2"
+    local rendered custom_shader_line escaped_effects
+
+    custom_shader_line=""
+    case "${TINO_TERMINAL_EFFECTS,,}" in
+        off|false|no|0|none|on|true|yes|1|balanced|high)
+            ;;
+        *)
+            escaped_effects="${TINO_TERMINAL_EFFECTS//\"/\\\"}"
+            custom_shader_line="custom-shader = \"${escaped_effects}\""
+            ;;
+    esac
+
+    rendered="$(<"$template_file")"
+    rendered="${rendered//__FONT_FAMILY__/$TINO_TERMINAL_FONT_FAMILY}"
+    rendered="${rendered//__FONT_SIZE__/$TINO_TERMINAL_FONT_SIZE}"
+    rendered="${rendered//__BACKGROUND__/$TINO_TERMINAL_BACKGROUND}"
+    rendered="${rendered//__BACKGROUND_OPACITY__/$TINO_TERMINAL_OPACITY}"
+    rendered="${rendered//__MAX_FPS__/$TINO_TERMINAL_FPS}"
+    rendered="${rendered//__CUSTOM_SHADER_LINE__/$custom_shader_line}"
+    rendered="${rendered//__CURSOR__/$TINO_TERMINAL_CURSOR}"
+
+    for i in $(seq 0 15); do
+        key="TINO_TERMINAL_COLOR_${i}"
+        placeholder="__COLOR_${i}__"
+        rendered="${rendered//${placeholder}/${!key}}"
+    done
+
+    mkdir -p "$(dirname "$target_file")"
+    if [[ -f "$target_file" ]] && [[ "$(<"$target_file")" == "$rendered" ]]; then
+        echo "Configuration already up to date at $target_file"
+        return
+    fi
+
+    printf '%s\n' "$rendered" > "$target_file"
+    echo "Configuration rendered at $target_file"
 }
 
 ensure_ghostty_installed
 
 config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
-profile_script="$config_home/tino/terminal-profile.sh"
-if [[ ! -x "$profile_script" ]]; then
+profile_script="$repo_root/dotfiles/terminal/.config/tino/terminal-profile.sh"
+if [[ ! -f "$canonical_template" ]]; then
+    echo "Error: missing canonical Ghostty template at $canonical_template" >&2
+    exit 1
+fi
+if [[ ! -f "$profile_script" ]]; then
     echo "Error: missing terminal profile contract at $profile_script" >&2
     exit 1
 fi
 
-"$profile_script" ghostty
+template_file="$config_home/tino/ghostty.toml.tmpl"
+sync_template "$template_file"
+
+# shellcheck disable=SC1090
+source "$profile_script"
+load_terminal_profile
+
+render_ghostty_config "$template_file" "$config_home/ghostty/ghostty.toml"
 
 echo "Ghostty installed and configured."


### PR DESCRIPTION
### Motivation
- Centralize Ghostty template management by adding a canonical in-repo template reference and ensure the deployed template in the user config is kept in sync. 
- Make Ghostty configuration rendering idempotent so the script only rewrites `ghostty.toml` when content actually changes. 
- Align script behavior and status messages with existing tests and expected failure semantics (including `unable to install Ghostty`).

### Description
- Added `repo_root` and `canonical_template="$repo_root/dotfiles/terminal/.config/tino/ghostty.toml.tmpl"` and use it as the authoritative template source. 
- Implemented `sync_template()` to copy the canonical template to `$XDG_CONFIG_HOME/tino/ghostty.toml.tmpl` when missing or different. 
- Moved rendering into `render_ghostty_config()` which fills placeholders and compares rendered output to `$XDG_CONFIG_HOME/ghostty/ghostty.toml`, only writing when content differs, and emits deterministic status lines. 
- Preserved package-manager-first install path and improved cargo fallback handling to print `unable to install Ghostty` on failure and to exit on unrecoverable errors. 
- Adjusted profile script resolution to use the repo-shipped contract and sourced it to load terminal profile variables before rendering.

### Testing
- Ran `bash -n scripts/setup-ghostty.sh` to validate shell syntax and it succeeded. 
- Ran `pytest -q tests/test_setup_ghostty.py` and all tests passed (`7 passed`). 
- `shellcheck` was attempted but not available in the environment (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1900946c08326a2f1324d558d05ed)