### PR TITLE
Harden terminal provider setup failure handling

### DIFF
--- a/scripts/setup-terminal-provider.sh
+++ b/scripts/setup-terminal-provider.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 provider="${1:-}"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+strict_mode="${TINO_TERMINAL_STRICT:-1}"
 
 if [[ -z "$provider" ]]; then
     echo "Usage: $(basename "$0") <ghostty|wezterm|kitty|alacritty|windows-terminal>" >&2
@@ -33,13 +34,49 @@ ensure_provider_installed() {
             return
             ;;
         wezterm)
-            command -v wezterm >/dev/null 2>&1 || install_with_pkg_manager wezterm || true
+            if ! command -v wezterm >/dev/null 2>&1; then
+                if ! install_with_pkg_manager wezterm; then
+                    echo "Warning: automatic install for wezterm failed." >&2
+                fi
+            fi
+            if ! command -v wezterm >/dev/null 2>&1; then
+                if [[ "$strict_mode" == "1" ]]; then
+                    echo "Error: wezterm is still unavailable after installation attempt." >&2
+                    echo "Install wezterm manually (https://wezfurlong.org/wezterm/installation.html) or set TINO_TERMINAL_STRICT=0 to continue without failing." >&2
+                    exit 1
+                fi
+                echo "Warning: wezterm is still unavailable after installation attempt; continuing because TINO_TERMINAL_STRICT=$strict_mode." >&2
+            fi
             ;;
         kitty)
-            command -v kitty >/dev/null 2>&1 || install_with_pkg_manager kitty || true
+            if ! command -v kitty >/dev/null 2>&1; then
+                if ! install_with_pkg_manager kitty; then
+                    echo "Warning: automatic install for kitty failed." >&2
+                fi
+            fi
+            if ! command -v kitty >/dev/null 2>&1; then
+                if [[ "$strict_mode" == "1" ]]; then
+                    echo "Error: kitty is still unavailable after installation attempt." >&2
+                    echo "Install kitty manually (https://sw.kovidgoyal.net/kitty/binary/) or set TINO_TERMINAL_STRICT=0 to continue without failing." >&2
+                    exit 1
+                fi
+                echo "Warning: kitty is still unavailable after installation attempt; continuing because TINO_TERMINAL_STRICT=$strict_mode." >&2
+            fi
             ;;
         alacritty)
-            command -v alacritty >/dev/null 2>&1 || install_with_pkg_manager alacritty || true
+            if ! command -v alacritty >/dev/null 2>&1; then
+                if ! install_with_pkg_manager alacritty; then
+                    echo "Warning: automatic install for alacritty failed." >&2
+                fi
+            fi
+            if ! command -v alacritty >/dev/null 2>&1; then
+                if [[ "$strict_mode" == "1" ]]; then
+                    echo "Error: alacritty is still unavailable after installation attempt." >&2
+                    echo "Install alacritty manually (https://github.com/alacritty/alacritty/blob/master/INSTALL.md) or set TINO_TERMINAL_STRICT=0 to continue without failing." >&2
+                    exit 1
+                fi
+                echo "Warning: alacritty is still unavailable after installation attempt; continuing because TINO_TERMINAL_STRICT=$strict_mode." >&2
+            fi
             ;;
         windows-terminal)
             return
@@ -49,6 +86,22 @@ ensure_provider_installed() {
             exit 1
             ;;
     esac
+}
+
+validate_windows_terminal_inputs() {
+    local generator_script="$repo_root/windows-terminal/generate_settings.py"
+    local base_settings="$repo_root/windows-terminal/settings.base.json"
+    local overrides="$repo_root/windows-terminal/terminal-profile-overrides.json"
+    local output="$repo_root/windows-terminal/settings.json"
+
+    for path in "$generator_script" "$base_settings" "$overrides"; do
+        if [[ ! -f "$path" ]]; then
+            echo "Error: required Windows Terminal input is missing: $path" >&2
+            exit 1
+        fi
+    done
+
+    mkdir -p "$(dirname "$output")"
 }
 
 profile_script="${XDG_CONFIG_HOME:-$HOME/.config}/tino/terminal-profile.sh"
@@ -63,6 +116,7 @@ fi
 "$profile_script" "$provider" "$repo_root"
 
 if [[ "$provider" == "windows-terminal" ]]; then
+    validate_windows_terminal_inputs
     python "$repo_root/windows-terminal/generate_settings.py" \
       "$repo_root/windows-terminal/settings.base.json" \
       "$repo_root/windows-terminal/settings.json" \

--- a/tests/test_setup_terminal_provider.py
+++ b/tests/test_setup_terminal_provider.py
@@ -1,0 +1,78 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _create_terminal_profile(tmp_path: Path) -> Path:
+    xdg_config_home = tmp_path / "xdg"
+    profile = xdg_config_home / "tino" / "terminal-profile.sh"
+    profile.parent.mkdir(parents=True, exist_ok=True)
+    profile.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    profile.chmod(0o755)
+    return xdg_config_home
+
+
+def _create_minimal_bin(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    return bin_dir
+
+
+def test_setup_terminal_provider_fails_when_provider_not_installed(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    xdg_config_home = _create_terminal_profile(tmp_path)
+    bin_dir = _create_minimal_bin(tmp_path)
+
+    env = os.environ.copy()
+    env.update({"XDG_CONFIG_HOME": str(xdg_config_home), "PATH": str(bin_dir)})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "wezterm"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "Error: wezterm is still unavailable after installation attempt." in output
+    assert "Terminal provider configured" not in output
+
+
+def test_setup_terminal_provider_windows_terminal_validates_inputs(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    windows_terminal_dir = repo / "windows-terminal"
+    scripts_dir.mkdir(parents=True)
+    windows_terminal_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+    shutil.copy(repo_root / "windows-terminal" / "settings.base.json", windows_terminal_dir / "settings.base.json")
+
+    xdg_config_home = _create_terminal_profile(tmp_path)
+    bin_dir = _create_minimal_bin(tmp_path)
+
+    env = os.environ.copy()
+    env.update({"XDG_CONFIG_HOME": str(xdg_config_home), "PATH": str(bin_dir)})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "windows-terminal"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "Error: required Windows Terminal input is missing" in output
+    assert "Terminal provider configured" not in output


### PR DESCRIPTION
### Motivation

- Prevent provider setup from reporting success when package-manager installs silently fail and the provider binary is still missing. 
- Make provisioning/CI fail predictably by default when an expected terminal provider is unavailable. 
- Keep Windows Terminal install path a no-op, but ensure downstream settings generation has valid inputs before writing files.

### Description

- Introduces a strict mode via `TINO_TERMINAL_STRICT` (default `1`) and exposes it as `strict_mode` in `scripts/setup-terminal-provider.sh`.
- Removes silent success paths for `wezterm`, `kitty`, and `alacritty` and replace them with a package-manager attempt followed by a `command -v` verification; on failure the script emits actionable error guidance and exits non-zero when strict mode is enabled.
- Adds `validate_windows_terminal_inputs()` to ensure the Windows Terminal generator, base settings, and override inputs exist before invoking the generator, and creates the output directory as needed.
- Adds tests in `tests/test_setup_terminal_provider.py` that assert failed provider installation returns non-zero and does not print the success summary, and that the Windows Terminal validation path fails when inputs are missing.

### Testing

- Ran `pytest -q tests/test_setup_terminal_provider.py`, which passed (2 tests, both passed).
- Ran `ruff check tests/test_setup_terminal_provider.py`, which passed for the new test file.
- Ran `bash -n scripts/setup-terminal-provider.sh` syntax check, which passed.
- `shellcheck` was not available in the execution environment, so shell linting was limited to `bash -n`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a192a2d8ec832693000ae49fb7eefd)