### PR TITLE
Refactor Neovim lazy bootstrap with env-gated self-healing

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Terminal profile values flow through one path:
 
 Standard bootstrap command (repo root):
 
-Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; provisioning is handled by `./scripts/setup-nvim.sh` (headless `Lazy! sync` + explicit Mason LSP installs) so first interactive startup is network-free.
+Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; provisioning is handled by `./scripts/setup-nvim.sh` (headless `Lazy! sync` + explicit Mason LSP installs, requires Neovim >= 0.8) so first interactive startup is deterministic. Runtime self-healing is opt-in with `TINO_NVIM_AUTO_BOOTSTRAP=1` (default is disabled/offline-friendly), and `TINO_NVIM_OFFLINE=1` forces warning-only startup behavior.
 
 
 ```bash

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -208,12 +208,14 @@ If `zprof` or `hyperfine` results exceed budget, move work from phase 1 into def
 
 ## Neovim first run and startup profiling
 
-The `dotfiles/nvim` package uses `lazy.nvim` for plugin management, but startup is offline-only: Neovim will not clone plugin manager dependencies at launch.
+The `dotfiles/nvim` package uses `lazy.nvim` for plugin management. Default startup is deterministic and offline-friendly: if `lazy.nvim` is missing, plugin setup is skipped with a clear warning.
 Minimum CLI toolchain for Neovim integrations: `rg` (ripgrep) and `fd` (or `fdfind` on Debian/Ubuntu).
 
-1. During provisioning run `./scripts/setup-nvim.sh` (or `./scripts/install_common.sh`, which now calls it). This performs a headless `Lazy! sync` plus explicit `MasonInstall` for required LSP servers.
+1. During provisioning run `./scripts/setup-nvim.sh` (or `./scripts/install_common.sh`, which now calls it). This performs a headless `Lazy! sync` plus explicit `MasonInstall` for required LSP servers, and verifies Neovim is at least `0.8` before provisioning.
 2. Start Neovim normally (`nvim`) with no first-run network dependency for plugin/LSP assets.
 3. If plugin revisions changed intentionally, refresh and commit `dotfiles/nvim/.config/nvim/lazy-lock.json`.
+4. Runtime auto-bootstrap is opt-in: set `TINO_NVIM_AUTO_BOOTSTRAP=1` to allow Neovim to clone `folke/lazy.nvim` when missing.
+5. Force strict offline behavior with `TINO_NVIM_OFFLINE=1`; Neovim warns and skips plugin setup to avoid partial initialization.
 
 To inspect startup performance with a repeatable workflow:
 

--- a/dotfiles/nvim/.config/nvim/lua/config/lazy.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/lazy.lua
@@ -1,18 +1,59 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+local uv = vim.uv or vim.loop
 
-if not vim.loop.fs_stat(lazypath) then
-    local message = table.concat({
-        "lazy.nvim is missing and Neovim startup is running in offline-only mode.",
-        "Install it during provisioning and rerun Neovim.",
+local function env_enabled(name)
+    local value = vim.env[name]
+    return value == "1" or value == "true" or value == "TRUE"
+end
+
+local function notify_missing_lazy(offline_mode)
+    local details = {
+        "lazy.nvim is missing; plugin setup is skipped to keep startup deterministic.",
         "Expected path: " .. lazypath,
         "Bootstrap command: ./scripts/setup-nvim.sh",
-    }, "\n")
+        "Optional runtime bootstrap: TINO_NVIM_AUTO_BOOTSTRAP=1",
+    }
+
+    if offline_mode then
+        table.insert(details, 2, "Offline mode is enabled via TINO_NVIM_OFFLINE=1.")
+    else
+        table.insert(details, 2, "Enable auto-bootstrap with TINO_NVIM_AUTO_BOOTSTRAP=1 if network access is allowed.")
+    end
 
     vim.schedule(function()
-        vim.api.nvim_echo({ { message, "ErrorMsg" } }, true, {})
+        vim.api.nvim_echo({ { table.concat(details, "\n"), "ErrorMsg" } }, true, {})
     end)
+end
 
-    return
+if not uv.fs_stat(lazypath) then
+    local auto_bootstrap = env_enabled("TINO_NVIM_AUTO_BOOTSTRAP")
+    local offline_mode = env_enabled("TINO_NVIM_OFFLINE")
+
+    if auto_bootstrap and not offline_mode then
+        if vim.fn.executable("git") ~= 1 then
+            notify_missing_lazy(false)
+            return
+        end
+
+        vim.fn.mkdir(vim.fn.fnamemodify(lazypath, ":h"), "p")
+        local cmd = {
+            "git",
+            "clone",
+            "--filter=blob:none",
+            "--branch=stable",
+            "https://github.com/folke/lazy.nvim.git",
+            lazypath,
+        }
+        vim.fn.system(cmd)
+
+        if vim.v.shell_error ~= 0 or not uv.fs_stat(lazypath) then
+            notify_missing_lazy(false)
+            return
+        end
+    else
+        notify_missing_lazy(offline_mode)
+        return
+    end
 end
 
 vim.opt.rtp:prepend(lazypath)

--- a/scripts/setup-nvim.sh
+++ b/scripts/setup-nvim.sh
@@ -4,9 +4,29 @@ set -euo pipefail
 lazy_path="${XDG_DATA_HOME:-$HOME/.local/share}/nvim/lazy/lazy.nvim"
 lazy_repo="https://github.com/folke/lazy.nvim.git"
 required_lsp_servers=(lua_ls pyright ts_ls bashls)
+minimum_nvim_version="0.8"
+
+version_gte() {
+    local current="$1"
+    local minimum="$2"
+    [[ "$(printf '%s\n%s\n' "$minimum" "$current" | sort -V | head -n1)" == "$minimum" ]]
+}
 
 if ! command -v nvim >/dev/null 2>&1; then
     echo "Error: nvim is required for Neovim provisioning." >&2
+    exit 1
+fi
+
+nvim_version_line="$(nvim --version | head -n1)"
+if [[ "$nvim_version_line" =~ v([0-9]+\.[0-9]+(\.[0-9]+)?) ]]; then
+    nvim_version="${BASH_REMATCH[1]}"
+else
+    echo "Error: could not parse Neovim version from: $nvim_version_line" >&2
+    exit 1
+fi
+
+if ! version_gte "$nvim_version" "$minimum_nvim_version"; then
+    echo "Error: Neovim $minimum_nvim_version+ is required for setup-nvim.sh (found $nvim_version)." >&2
     exit 1
 fi
 

--- a/tests/test_setup_nvim.py
+++ b/tests/test_setup_nvim.py
@@ -3,14 +3,31 @@ import subprocess
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
 def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
     path.write_text(contents, encoding="utf-8")
     path.chmod(0o755)
 
 
+def create_fake_nvim(path: Path, *, version: str = "0.9.1", log_path: Path | None = None) -> None:
+    log_snippet = f"echo \"$@\" >> '{log_path}'\n" if log_path else ""
+    create_exe(
+        path,
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [[ ${1:-} == --version ]]; then\n"
+        f"  echo 'NVIM v{version}'\n"
+        "  exit 0\n"
+        "fi\n"
+        + log_snippet
+        + "exit 0\n",
+    )
+
+
 def test_setup_nvim_clones_lazy_when_missing(tmp_path: Path) -> None:
-    repo_root = Path(__file__).resolve().parents[1]
-    script_path = repo_root / "scripts" / "setup-nvim.sh"
+    script_path = REPO_ROOT / "scripts" / "setup-nvim.sh"
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -20,6 +37,9 @@ def test_setup_nvim_clones_lazy_when_missing(tmp_path: Path) -> None:
         f"#!/usr/bin/env bash\necho \"$@\" >> '{git_log}'\nif [[ $1 == clone ]]; then\n  /bin/mkdir -p \"$5/.git\"\nfi\n",
     )
 
+    nvim_log = tmp_path / "nvim.log"
+    create_fake_nvim(bin_dir / "nvim", log_path=nvim_log)
+
     env = os.environ.copy()
     env.update({"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)})
 
@@ -28,11 +48,13 @@ def test_setup_nvim_clones_lazy_when_missing(tmp_path: Path) -> None:
     lazy_dir = tmp_path / ".local" / "share" / "nvim" / "lazy" / "lazy.nvim"
     assert (lazy_dir / ".git").is_dir()
     assert "clone --filter=blob:none --branch=stable" in git_log.read_text(encoding="utf-8")
+    log_text = nvim_log.read_text(encoding="utf-8")
+    assert "+Lazy! sync" in log_text
+    assert "+MasonInstall lua_ls pyright ts_ls bashls" in log_text
 
 
 def test_setup_nvim_skips_when_already_installed(tmp_path: Path) -> None:
-    repo_root = Path(__file__).resolve().parents[1]
-    script_path = repo_root / "scripts" / "setup-nvim.sh"
+    script_path = REPO_ROOT / "scripts" / "setup-nvim.sh"
 
     lazy_dir = tmp_path / ".local" / "share" / "nvim" / "lazy" / "lazy.nvim" / ".git"
     lazy_dir.mkdir(parents=True)
@@ -41,6 +63,7 @@ def test_setup_nvim_skips_when_already_installed(tmp_path: Path) -> None:
     bin_dir.mkdir()
     git_log = tmp_path / "git.log"
     create_exe(bin_dir / "git", f"#!/usr/bin/env bash\necho \"$@\" >> '{git_log}'\n")
+    create_fake_nvim(bin_dir / "nvim")
 
     env = os.environ.copy()
     env.update({"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)})
@@ -48,3 +71,30 @@ def test_setup_nvim_skips_when_already_installed(tmp_path: Path) -> None:
     subprocess.run(["/bin/bash", str(script_path)], check=True, env=env)
 
     assert not git_log.exists()
+
+
+def test_setup_nvim_exits_on_unsupported_neovim_version(tmp_path: Path) -> None:
+    script_path = REPO_ROOT / "scripts" / "setup-nvim.sh"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    create_exe(bin_dir / "git", "#!/usr/bin/env bash\nexit 1\n")
+    create_fake_nvim(bin_dir / "nvim", version="0.7.2")
+
+    env = os.environ.copy()
+    env.update({"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)})
+
+    result = subprocess.run(["/bin/bash", str(script_path)], env=env, text=True, capture_output=True)
+
+    assert result.returncode == 1
+    assert "Neovim 0.8+ is required" in result.stderr
+
+
+def test_lazy_config_supports_auto_bootstrap_and_offline_modes() -> None:
+    lazy_config = (REPO_ROOT / "dotfiles" / "nvim" / ".config" / "nvim" / "lua" / "config" / "lazy.lua").read_text(
+        encoding="utf-8"
+    )
+
+    assert "TINO_NVIM_AUTO_BOOTSTRAP" in lazy_config
+    assert "TINO_NVIM_OFFLINE" in lazy_config
+    assert "git" in lazy_config


### PR DESCRIPTION
### Motivation

- Make Neovim first-run deterministic and avoid partially-initialized states when `lazy.nvim` is absent or network is unavailable.
- Provide an opt-in runtime self-healing path so users can choose to have Neovim fetch `lazy.nvim` at runtime when network access is permitted.
- Ensure provisioning scripts are safe by guarding headless provisioning with a minimal Neovim version check.

### Description

- Updated `dotfiles/nvim/.config/nvim/lua/config/lazy.lua` to detect `lazy.nvim` and: support `TINO_NVIM_AUTO_BOOTSTRAP=1` to clone `folke/lazy.nvim` at runtime when allowed, respect `TINO_NVIM_OFFLINE=1` to keep warning-only behavior, and surface clearer actionable messages; the config now performs the clone via `git` when appropriate and returns early on failure to avoid partial setup.
- Added a minimum Neovim version guard to `scripts/setup-nvim.sh` (`minimum_nvim_version="0.8"`) and a `version_gte` helper that parses `nvim --version` and aborts provisioning if the installed Neovim is older than `0.8`.
- Expanded `tests/test_setup_nvim.py` to introduce a fake `nvim` binary and cover: missing-lazy auto-bootstrap + headless provisioning, already-installed skipping, unsupported Neovim version handling, and presence of the new env knobs in the lazy config.
- Documented behavior and defaults in `README.md` and `docs/terminal.md`, describing `TINO_NVIM_AUTO_BOOTSTRAP` (opt-in), `TINO_NVIM_OFFLINE` (force warning-only), and the Neovim >= `0.8` requirement for provisioning.

### Testing

- Ran `pytest -q tests/test_setup_nvim.py` and all tests passed (`4 passed`).
- Ran `ruff check tests/test_setup_nvim.py` and linting passed (`All checks passed!`).
- Verified script syntax with `bash -n scripts/setup-nvim.sh` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a194663e4083269279fe43a2a8d867)