### PR TITLE
Scope Neovim LSP keymaps to attached buffers

### DIFF
--- a/dotfiles/nvim/.config/nvim/lua/config/keymaps.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/keymaps.lua
@@ -15,7 +15,3 @@ map("n", "<leader>fh", "<cmd>Telescope help_tags<cr>", opts)
 
 map("n", "[d", vim.diagnostic.goto_prev, opts)
 map("n", "]d", vim.diagnostic.goto_next, opts)
-map("n", "<leader>e", vim.diagnostic.open_float, opts)
-map("n", "<leader>ca", vim.lsp.buf.code_action, opts)
-map("n", "gd", vim.lsp.buf.definition, opts)
-map("n", "gr", vim.lsp.buf.references, opts)

--- a/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -21,6 +21,42 @@ return {
             mason_lspconfig.setup(opts)
 
             local lspconfig = require("lspconfig")
+            local lsp_attach_group = vim.api.nvim_create_augroup("UserLspAttachKeymaps", { clear = true })
+
+            vim.api.nvim_create_autocmd("LspAttach", {
+                group = lsp_attach_group,
+                callback = function(event)
+                    local bufnr = event.buf
+                    local client = vim.lsp.get_client_by_id(event.data.client_id)
+
+                    if not client then
+                        return
+                    end
+
+                    local map = function(mode, lhs, rhs, desc)
+                        vim.keymap.set(mode, lhs, rhs, {
+                            buffer = bufnr,
+                            noremap = true,
+                            silent = true,
+                            desc = desc,
+                        })
+                    end
+
+                    map("n", "gd", vim.lsp.buf.definition, "LSP: Go to definition")
+                    map("n", "gr", vim.lsp.buf.references, "LSP: List references")
+
+                    if client:supports_method("textDocument/codeAction") then
+                        map("n", "<leader>ca", vim.lsp.buf.code_action, "LSP: Code action")
+                    end
+
+                    if client:supports_method("textDocument/rename") then
+                        map("n", "<leader>rn", vim.lsp.buf.rename, "LSP: Rename symbol")
+                    end
+
+                    map("n", "<leader>e", vim.diagnostic.open_float, "Diagnostics: Open float")
+                end,
+            })
+
             local required_servers = { "lua_ls", "pyright", "ts_ls", "bashls" }
             local installed_servers = mason_lspconfig.get_installed_servers()
             local installed_lookup = {}


### PR DESCRIPTION
### Motivation
- Prevent global LSP mappings from polluting non-LSP buffers and improve UX by only enabling LSP actions when a server is attached. 
- Keep generic/global mappings (leader, Telescope, diagnostic navigation) available everywhere. 
- Make mapping availability capability-aware so features like code actions and rename are only exposed when supported by the attached server.

### Description
- Removed direct global `vim.lsp.buf.*` mappings from `dotfiles/nvim/.config/nvim/lua/config/keymaps.lua` so non-LSP buffers stay clean. 
- Added an `LspAttach` autocmd and augroup in `dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua` to register buffer-local keymaps when a server attaches. 
- The autocmd callback creates buffer-local mappings for `gd`, `gr`, and diagnostics float, and maps `<leader>ca` and `<leader>rn` only if the attached client supports `textDocument/codeAction` and `textDocument/rename` respectively. 
- Mappings are created with `buffer`, `noremap`, `silent`, and `desc` options for clarity and scope.

### Testing
- Attempted `luac -p dotfiles/nvim/.config/nvim/lua/config/keymaps.lua && luac -p dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua`, but `luac` is not available in the environment (failed). 
- Attempted `nvim --headless '+lua dofile("dotfiles/nvim/.config/nvim/lua/config/keymaps.lua")' '+qa'`, but `nvim` is not available in the environment (failed). 
- Attempted `stylua --check dotfiles/nvim/.config/nvim/lua/config/keymaps.lua dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua`, but `stylua` is not available in the environment (failed). 
- Attempted `lua -e 'assert(loadfile("...keymaps.lua")) ; assert(loadfile("...lsp.lua"))'` to validate Lua load/syntax, but `lua` is not available in the environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a196d483ec8326905dcb9e2e1cfc76)