### PR TITLE
Optimize .zshrc startup phase ordering

### DIFF
--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -94,12 +94,16 @@ tino_defer_eval() {
 ZSH_PLUGIN_DIR="${ZSH_PLUGIN_DIR:-$HOME/.local/share/zsh/plugins}"
 source_if_readable "$ZSH_CONFIG_DIR/aliases.zsh"
 source_if_readable "$ZSH_CONFIG_DIR/functions.zsh"
-source_if_readable "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
-source_if_readable "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 if command -v starship >/dev/null; then
     eval "$(starship init zsh)"
 fi
+
+source_if_readable "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
+
+# Keep syntax-highlighting as the final Phase-1 interactive enhancement so
+# it can wrap widgets defined by prompt/plugins and reduce ordering surprises.
+source_if_readable "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 # Phase 2: deferred non-critical path/env initialization.
 if [[ "${TINO_ZSH_DEFER:-1}" == "1" ]]; then


### PR DESCRIPTION
### Motivation

- Reduce startup surprises by explicitly ordering prompt-critical initialization and interactive enhancements.
- Keep essential setup (aliases/functions and `compinit`) early so prompt and completions remain fast and predictable.
- Initialize the prompt (`starship init zsh`) before deferred non-critical logic to ensure prompt state is available to deferred hooks.
- Ensure `zsh-autosuggestions` is active before `zsh-syntax-highlighting`, and document why syntax-highlighting is loaded last to avoid widget-wrapping/order issues.

### Description

- Reordered Phase-1 initialization in `dotfiles/shell/.zshrc` so `aliases.zsh` and `functions.zsh` remain early and `starship` runs before deferred Phase-2 logic.
- Moved `zsh-autosuggestions` to be sourced before `zsh-syntax-highlighting` and placed `zsh-syntax-highlighting` as the final Phase-1 interactive enhancement.
- Added a comment above the `zsh-syntax-highlighting` source explaining why it is intentionally loaded last.
- Left Phase-2 deferred env/host override sourcing unchanged and avoided introducing any heavyweight frameworks.

### Testing

- Ran `zsh -n dotfiles/shell/.zshrc` to syntax-check the file (failed because `zsh` is not installed in this environment).
- Ran `shellcheck dotfiles/shell/.zshrc` to lint the script (failed because `shellcheck` is not installed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a198261b2883269d688cec0da812fc)