### PR TITLE
Make bash migration hint path discovery deterministic

### DIFF
--- a/dotfiles/shell/.bashrc
+++ b/dotfiles/shell/.bashrc
@@ -9,16 +9,25 @@ esac
 migration_script="$HOME/.local/share/d0ttino/scripts/migrate-shell-config.sh"
 if [[ ! -x "${migration_script}" ]]; then
     if [[ -n "${D0TTINO_REPO_ROOT:-}" ]]; then
-        migration_script="${D0TTINO_REPO_ROOT}/scripts/migrate-shell-config.sh"
+        repo_migration_script="${D0TTINO_REPO_ROOT}/scripts/migrate-shell-config.sh"
+        if [[ -x "${repo_migration_script}" ]]; then
+            migration_script="${repo_migration_script}"
+        else
+            migration_script=""
+        fi
     else
-        migration_script="scripts/migrate-shell-config.sh"
+        migration_script=""
     fi
 fi
 
 migration_hint_stamp="${XDG_CACHE_HOME:-$HOME/.cache}/d0ttino/bash-migration-hint-shown"
 if [[ ! -f "${migration_hint_stamp}" ]]; then
     mkdir -p "$(dirname "${migration_hint_stamp}")"
-    printf 'Hint: migrate your legacy ~/.bashrc settings with %s\n' "${migration_script}" >&2
+    if [[ -n "${migration_script}" ]]; then
+        printf 'Hint: migrate your legacy ~/.bashrc settings with %s\n' "${migration_script}" >&2
+    else
+        printf 'Hint: migration helper is not installed. Run ./scripts/install_common.sh, then rerun this shell to get the migration command.\n' >&2
+    fi
     : > "${migration_hint_stamp}"
 fi
 

--- a/tests/test_migrate_shell_config.py
+++ b/tests/test_migrate_shell_config.py
@@ -129,7 +129,7 @@ def test_migrate_shell_config_force_overwrites_existing_fragments(tmp_path: Path
     assert "Migrated env lines to live runtime path" in result.stdout
 
 
-def test_minimal_bashrc_shim_prints_migration_hint_once(tmp_path: Path) -> None:
+def test_minimal_bashrc_shim_prints_bootstrap_hint_once_when_migration_helper_missing(tmp_path: Path) -> None:
     bashrc = REPO_ROOT / "dotfiles" / "shell" / ".bashrc"
 
     home = tmp_path / "home"
@@ -152,12 +152,18 @@ def test_minimal_bashrc_shim_prints_migration_hint_once(tmp_path: Path) -> None:
         check=True,
     )
 
-    assert "Hint: migrate your legacy ~/.bashrc settings" in first.stderr
-    assert "scripts/migrate-shell-config.sh" in first.stderr
-    assert "Hint: migrate your legacy ~/.bashrc settings" not in second.stderr
+    assert "Hint: migration helper is not installed" in first.stderr
+    assert "./scripts/install_common.sh" in first.stderr
+    assert "Hint: migration helper is not installed" not in second.stderr
 
 
 def test_minimal_bashrc_shim_uses_env_fallback_for_symlinked_rcfile(tmp_path: Path) -> None:
+    custom_repo_root = tmp_path / "custom-d0ttino"
+    migration_script = custom_repo_root / "scripts" / "migrate-shell-config.sh"
+    migration_script.parent.mkdir(parents=True)
+    migration_script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    migration_script.chmod(0o755)
+
     bashrc_symlink = tmp_path / ".bashrc"
     bashrc_symlink.symlink_to(REPO_ROOT / "dotfiles" / "shell" / ".bashrc")
 
@@ -165,7 +171,7 @@ def test_minimal_bashrc_shim_uses_env_fallback_for_symlinked_rcfile(tmp_path: Pa
     home.mkdir()
     env = os.environ.copy()
     env["HOME"] = str(home)
-    env["D0TTINO_REPO_ROOT"] = "/tmp/custom-d0ttino"
+    env["D0TTINO_REPO_ROOT"] = str(custom_repo_root)
 
     result = subprocess.run(
         ["/bin/bash", "--rcfile", str(bashrc_symlink), "-i", "-c", "exit"],
@@ -176,4 +182,4 @@ def test_minimal_bashrc_shim_uses_env_fallback_for_symlinked_rcfile(tmp_path: Pa
     )
 
     assert "Hint: migrate your legacy ~/.bashrc settings" in result.stderr
-    assert "/tmp/custom-d0ttino/scripts/migrate-shell-config.sh" in result.stderr
+    assert str(migration_script) in result.stderr


### PR DESCRIPTION
### Motivation
- Ensure the interactive bash shim prints only absolute, valid migration helper paths and never a cwd-relative path that may not exist.
- Prefer the canonical installed helper at `$HOME/.local/share/d0ttino/scripts/migrate-shell-config.sh` and only use the repo-root helper when it actually exists and is executable.
- Provide a clear bootstrap hint when no helper is present instead of showing a misleading path.

### Description
- Updated `dotfiles/shell/.bashrc` to set `migration_script` to `$HOME/.local/share/d0ttino/scripts/migrate-shell-config.sh` and, if missing, to check `$D0TTINO_REPO_ROOT/scripts/migrate-shell-config.sh` only when that target is executable.
- Removed the cwd-relative fallback (`scripts/migrate-shell-config.sh`) and instead set an empty path when no helper exists.
- When no helper is installed, the shim prints a clear bootstrap hint: `./scripts/install_common.sh` (and only prints script paths that actually exist).
- Adjusted `tests/test_migrate_shell_config.py` to cover the new behaviors: missing helper + unset `D0TTINO_REPO_ROOT`, and verifying the repo-root fallback only appears when an executable script exists.

### Testing
- Ran `ruff check tests/test_migrate_shell_config.py` and it passed.
- Ran `pytest -q tests/test_migrate_shell_config.py` and all tests passed (`5 passed`).
- Ran a shell syntax check with `bash -n dotfiles/shell/.bashrc` and it returned without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a494c55c8326b4ea619ef68d3a98)