### PR TITLE
Centralize Neovim LSP server inventory across runtime and provisioning

### DIFF
--- a/dotfiles/nvim/.config/nvim/lsp_servers.txt
+++ b/dotfiles/nvim/.config/nvim/lsp_servers.txt
@@ -1,0 +1,4 @@
+lua_ls
+pyright
+ts_ls
+bashls

--- a/dotfiles/nvim/.config/nvim/lua/config/lsp_servers.lua
+++ b/dotfiles/nvim/.config/nvim/lua/config/lsp_servers.lua
@@ -1,0 +1,26 @@
+local M = {}
+
+local function module_dir()
+    local source = debug.getinfo(1, "S").source
+    local path = source:sub(2)
+    return vim.fn.fnamemodify(path, ":h")
+end
+
+local function load_servers()
+    local servers_path = module_dir() .. "/../../lsp_servers.txt"
+    local lines = vim.fn.readfile(servers_path)
+    local servers = {}
+
+    for _, line in ipairs(lines) do
+        local server = vim.trim(line)
+        if server ~= "" then
+            table.insert(servers, server)
+        end
+    end
+
+    return servers
+end
+
+M.servers = load_servers()
+
+return M

--- a/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -57,7 +57,7 @@ return {
                 end,
             })
 
-            local required_servers = { "lua_ls", "pyright", "ts_ls", "bashls" }
+            local required_servers = require("config.lsp_servers").servers
             local installed_servers = mason_lspconfig.get_installed_servers()
             local installed_lookup = {}
             local missing_servers = {}
@@ -79,7 +79,7 @@ return {
                     vim.notify(
                         "Missing Mason LSP servers: "
                             .. table.concat(missing_servers, ", ")
-                            .. ". Run ./scripts/setup-nvim.sh to provision them.",
+                            .. ". Run ./scripts/setup-nvim.sh (canonical provisioning flow) to provision them.",
                         vim.log.levels.WARN
                     )
                 end)

--- a/scripts/setup-nvim.sh
+++ b/scripts/setup-nvim.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 lazy_path="${XDG_DATA_HOME:-$HOME/.local/share}/nvim/lazy/lazy.nvim"
 lazy_repo="https://github.com/folke/lazy.nvim.git"
-required_lsp_servers=(lua_ls pyright ts_ls bashls)
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+lsp_servers_file="$repo_root/dotfiles/nvim/.config/nvim/lsp_servers.txt"
 minimum_nvim_version="0.8"
 
 version_gte() {
@@ -11,6 +13,17 @@ version_gte() {
     local minimum="$2"
     [[ "$(printf '%s\n%s\n' "$minimum" "$current" | sort -V | head -n1)" == "$minimum" ]]
 }
+
+if [[ ! -f "$lsp_servers_file" ]]; then
+    echo "Error: expected canonical LSP server inventory at $lsp_servers_file" >&2
+    exit 1
+fi
+
+mapfile -t required_lsp_servers < <(sed -e 's/#.*$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$lsp_servers_file" | awk 'NF')
+if [[ ${#required_lsp_servers[@]} -eq 0 ]]; then
+    echo "Error: no LSP servers were defined in $lsp_servers_file" >&2
+    exit 1
+fi
 
 if ! command -v nvim >/dev/null 2>&1; then
     echo "Error: nvim is required for Neovim provisioning." >&2

--- a/tests/test_setup_nvim.py
+++ b/tests/test_setup_nvim.py
@@ -6,6 +6,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def read_canonical_lsp_servers() -> list[str]:
+    lsp_servers_file = REPO_ROOT / "dotfiles" / "nvim" / ".config" / "nvim" / "lsp_servers.txt"
+    return [line.strip() for line in lsp_servers_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
 def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
     path.write_text(contents, encoding="utf-8")
     path.chmod(0o755)
@@ -50,7 +55,8 @@ def test_setup_nvim_clones_lazy_when_missing(tmp_path: Path) -> None:
     assert "clone --filter=blob:none --branch=stable" in git_log.read_text(encoding="utf-8")
     log_text = nvim_log.read_text(encoding="utf-8")
     assert "+Lazy! sync" in log_text
-    assert "+MasonInstall lua_ls pyright ts_ls bashls" in log_text
+    expected_servers = " ".join(read_canonical_lsp_servers())
+    assert f"+MasonInstall {expected_servers}" in log_text
 
 
 def test_setup_nvim_skips_when_already_installed(tmp_path: Path) -> None:
@@ -98,3 +104,23 @@ def test_lazy_config_supports_auto_bootstrap_and_offline_modes() -> None:
     assert "TINO_NVIM_AUTO_BOOTSTRAP" in lazy_config
     assert "TINO_NVIM_OFFLINE" in lazy_config
     assert "git" in lazy_config
+
+
+
+def test_lsp_runtime_and_setup_use_same_canonical_server_inventory() -> None:
+    canonical_servers = read_canonical_lsp_servers()
+
+    lsp_config = (
+        REPO_ROOT / "dotfiles" / "nvim" / ".config" / "nvim" / "lua" / "plugins" / "lsp.lua"
+    ).read_text(encoding="utf-8")
+    lsp_servers_module = (
+        REPO_ROOT / "dotfiles" / "nvim" / ".config" / "nvim" / "lua" / "config" / "lsp_servers.lua"
+    ).read_text(encoding="utf-8")
+    setup_script = (REPO_ROOT / "scripts" / "setup-nvim.sh").read_text(encoding="utf-8")
+
+    assert canonical_servers
+    assert 'require("config.lsp_servers").servers' in lsp_config
+    assert "lsp_servers.txt" in lsp_servers_module
+    assert "lsp_servers_file" in setup_script
+    assert "canonical provisioning flow" in lsp_config
+


### PR DESCRIPTION
### Motivation
- Remove duplicated hardcoded LSP server lists and provide a single canonical inventory for both runtime and provisioning. 
- Make provisioning (`scripts/setup-nvim.sh`) and plugin runtime (`lua/plugins/lsp.lua`) consume the same source of truth to avoid drift. 
- Add tests to assert the runtime and setup script reference the canonical inventory. 

### Description
- Added a canonical server list file at `dotfiles/nvim/.config/nvim/lsp_servers.txt` containing the Mason server names. 
- Added a shared Lua module `dotfiles/nvim/.config/nvim/lua/config/lsp_servers.lua` that loads and exports the canonical list as `servers`. 
- Updated `dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua` to use `require("config.lsp_servers").servers` instead of an inline table and preserved the missing-server warning while updating the text to point to the canonical provisioning flow. 
- Updated `scripts/setup-nvim.sh` to read and validate the same `lsp_servers.txt` before invoking `nvim --headless "+MasonInstall ..."`. 
- Extended `tests/test_setup_nvim.py` to derive expected `MasonInstall` args from the canonical file and to assert that both runtime and setup reference the canonical inventory. 

### Testing
- Ran `pytest -q tests/test_setup_nvim.py` and all tests in that file passed (`5 passed`). 
- Ran `ruff check tests/test_setup_nvim.py` and lint checks passed. 
- Ran `bash -n scripts/setup-nvim.sh` and the script passed shell syntax validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a9099d108326af9c07b128f409d7)