### PR TITLE
Refactor Ghostty setup to delegate rendering to terminal provider

### DIFF
--- a/scripts/setup-ghostty.sh
+++ b/scripts/setup-ghostty.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 canonical_template="$repo_root/dotfiles/terminal/.config/tino/ghostty.toml.tmpl"
+terminal_provider_setup="$repo_root/scripts/setup-terminal-provider.sh"
 
 detect_ostype() {
     if [[ -n "${OSTYPE:-}" ]]; then
@@ -83,66 +84,21 @@ sync_template() {
     fi
 }
 
-render_ghostty_config() {
-    local template_file="$1"
-    local target_file="$2"
-    local rendered custom_shader_line escaped_effects
-
-    custom_shader_line=""
-    case "${TINO_TERMINAL_EFFECTS,,}" in
-        off|false|no|0|none|on|true|yes|1|balanced|high)
-            ;;
-        *)
-            escaped_effects="${TINO_TERMINAL_EFFECTS//\"/\\\"}"
-            custom_shader_line="custom-shader = \"${escaped_effects}\""
-            ;;
-    esac
-
-    rendered="$(<"$template_file")"
-    rendered="${rendered//__FONT_FAMILY__/$TINO_TERMINAL_FONT_FAMILY}"
-    rendered="${rendered//__FONT_SIZE__/$TINO_TERMINAL_FONT_SIZE}"
-    rendered="${rendered//__BACKGROUND__/$TINO_TERMINAL_BACKGROUND}"
-    rendered="${rendered//__BACKGROUND_OPACITY__/$TINO_TERMINAL_OPACITY}"
-    rendered="${rendered//__MAX_FPS__/$TINO_TERMINAL_FPS}"
-    rendered="${rendered//__CUSTOM_SHADER_LINE__/$custom_shader_line}"
-    rendered="${rendered//__CURSOR__/$TINO_TERMINAL_CURSOR}"
-
-    for i in $(seq 0 15); do
-        key="TINO_TERMINAL_COLOR_${i}"
-        placeholder="__COLOR_${i}__"
-        rendered="${rendered//${placeholder}/${!key}}"
-    done
-
-    mkdir -p "$(dirname "$target_file")"
-    if [[ -f "$target_file" ]] && [[ "$(<"$target_file")" == "$rendered" ]]; then
-        echo "Configuration already up to date at $target_file"
-        return
-    fi
-
-    printf '%s\n' "$rendered" > "$target_file"
-    echo "Configuration rendered at $target_file"
-}
-
 ensure_ghostty_installed
 
 config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
-profile_script="$repo_root/dotfiles/terminal/.config/tino/terminal-profile.sh"
 if [[ ! -f "$canonical_template" ]]; then
     echo "Error: missing canonical Ghostty template at $canonical_template" >&2
     exit 1
 fi
-if [[ ! -f "$profile_script" ]]; then
-    echo "Error: missing terminal profile contract at $profile_script" >&2
+if [[ ! -x "$terminal_provider_setup" ]]; then
+    echo "Error: missing terminal provider setup at $terminal_provider_setup" >&2
     exit 1
 fi
 
 template_file="$config_home/tino/ghostty.toml.tmpl"
 sync_template "$template_file"
 
-# shellcheck disable=SC1090
-source "$profile_script"
-load_terminal_profile
-
-render_ghostty_config "$template_file" "$config_home/ghostty/ghostty.toml"
+bash "$terminal_provider_setup" ghostty
 
 echo "Ghostty installed and configured."

--- a/scripts/setup-terminal-provider.sh
+++ b/scripts/setup-terminal-provider.sh
@@ -29,10 +29,6 @@ install_with_pkg_manager() {
 
 ensure_provider_installed() {
     case "$provider" in
-        ghostty)
-            bash "$repo_root/scripts/setup-ghostty.sh"
-            return
-            ;;
         wezterm)
             if ! command -v wezterm >/dev/null 2>&1; then
                 if ! install_with_pkg_manager wezterm; then

--- a/tests/test_setup_ghostty.py
+++ b/tests/test_setup_ghostty.py
@@ -43,6 +43,8 @@ def test_setup_ghostty_skips_install_when_preinstalled(tmp_path: Path) -> None:
     scripts_dir = repo / "scripts"
     scripts_dir.mkdir()
     shutil.copy(REPO_ROOT / "scripts" / "setup-ghostty.sh", scripts_dir / "setup-ghostty.sh")
+    (scripts_dir / "setup-terminal-provider.sh").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (scripts_dir / "setup-terminal-provider.sh").chmod(0o755)
     shutil.copytree(REPO_ROOT / "dotfiles", repo / "dotfiles")
 
     bin_dir = tmp_path / "bin"
@@ -80,6 +82,12 @@ def test_setup_ghostty_installs_and_renders(tmp_path: Path) -> None:
     scripts_dir = repo / "scripts"
     scripts_dir.mkdir()
     shutil.copy(REPO_ROOT / "scripts" / "setup-ghostty.sh", scripts_dir / "setup-ghostty.sh")
+    provider_log = tmp_path / "provider.log"
+    (scripts_dir / "setup-terminal-provider.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        f"echo \"$@\" > '{provider_log}'\n"
+    )
+    (scripts_dir / "setup-terminal-provider.sh").chmod(0o755)
     shutil.copytree(REPO_ROOT / "dotfiles", repo / "dotfiles")
 
     bin_dir = tmp_path / "bin"
@@ -108,11 +116,7 @@ def test_setup_ghostty_installs_and_renders(tmp_path: Path) -> None:
     )
 
     assert cargo_log.read_text().strip() == "install --locked ghostty"
-    config_file = Path(env["XDG_CONFIG_HOME"]) / "ghostty/ghostty.toml"
-    assert config_file.exists()
-    config_contents = config_file.read_text()
-    assert "background-opacity = 0.92" in config_contents
-    assert "custom-shader =" not in config_contents
+    assert provider_log.read_text().strip() == "ghostty"
 
 
 def test_setup_ghostty_installs_with_package_manager_without_cargo(tmp_path: Path) -> None:
@@ -121,6 +125,8 @@ def test_setup_ghostty_installs_with_package_manager_without_cargo(tmp_path: Pat
     scripts_dir = repo / "scripts"
     scripts_dir.mkdir()
     shutil.copy(REPO_ROOT / "scripts" / "setup-ghostty.sh", scripts_dir / "setup-ghostty.sh")
+    (scripts_dir / "setup-terminal-provider.sh").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (scripts_dir / "setup-terminal-provider.sh").chmod(0o755)
     shutil.copytree(REPO_ROOT / "dotfiles", repo / "dotfiles")
 
     bin_dir = tmp_path / "bin"
@@ -161,12 +167,18 @@ def test_setup_ghostty_installs_with_package_manager_without_cargo(tmp_path: Pat
     assert "native package manager" in result.stdout
 
 
-def test_setup_ghostty_renders_host_overrides(tmp_path: Path) -> None:
+def test_setup_ghostty_delegates_rendering_to_terminal_provider(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     scripts_dir = repo / "scripts"
     scripts_dir.mkdir()
     shutil.copy(REPO_ROOT / "scripts" / "setup-ghostty.sh", scripts_dir / "setup-ghostty.sh")
+    provider_log = tmp_path / "provider.log"
+    (scripts_dir / "setup-terminal-provider.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        f"echo \"$@\" >> '{provider_log}'\n"
+    )
+    (scripts_dir / "setup-terminal-provider.sh").chmod(0o755)
     shutil.copytree(REPO_ROOT / "dotfiles", repo / "dotfiles")
 
     bin_dir = tmp_path / "bin"
@@ -204,12 +216,7 @@ def test_setup_ghostty_renders_host_overrides(tmp_path: Path) -> None:
         text=True,
     )
 
-    config_file = config_home / "ghostty" / "ghostty.toml"
-    config_contents = config_file.read_text()
-    assert "background-opacity = 0.73" in config_contents
-    assert "custom-shader-animation-max-fps = 144" in config_contents
-    assert 'custom-shader = "scanlines.glsl"' in config_contents
-    assert "Configuration rendered" in first.stdout
+    assert provider_log.read_text().splitlines() == ["ghostty"]
 
     second = subprocess.run(
         ["/bin/bash", "scripts/setup-ghostty.sh"],
@@ -219,7 +226,7 @@ def test_setup_ghostty_renders_host_overrides(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
     )
-    assert "Configuration already up to date" in second.stdout
+    assert provider_log.read_text().splitlines() == ["ghostty", "ghostty"]
 
 
 def test_managed_ghostty_template_has_required_keys() -> None:
@@ -247,3 +254,11 @@ def test_setup_script_uses_canonical_template_path() -> None:
     script_contents = script_path.read_text()
 
     assert 'canonical_template="$repo_root/dotfiles/terminal/.config/tino/ghostty.toml.tmpl"' in script_contents
+
+
+def test_setup_script_does_not_embed_ghostty_renderer() -> None:
+    script_path = REPO_ROOT / "scripts" / "setup-ghostty.sh"
+    script_contents = script_path.read_text()
+
+    assert "render_ghostty_config" not in script_contents
+    assert "__CUSTOM_SHADER_LINE__" not in script_contents

--- a/tests/test_setup_terminal_provider.py
+++ b/tests/test_setup_terminal_provider.py
@@ -4,11 +4,11 @@ import subprocess
 from pathlib import Path
 
 
-def _create_terminal_profile(tmp_path: Path) -> Path:
+def _create_terminal_profile(tmp_path: Path, body: str = "#!/usr/bin/env bash\nexit 0\n") -> Path:
     xdg_config_home = tmp_path / "xdg"
     profile = xdg_config_home / "tino" / "terminal-profile.sh"
     profile.parent.mkdir(parents=True, exist_ok=True)
-    profile.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    profile.write_text(body, encoding="utf-8")
     profile.chmod(0o755)
     return xdg_config_home
 
@@ -46,6 +46,41 @@ def test_setup_terminal_provider_fails_when_provider_not_installed(tmp_path: Pat
     assert result.returncode != 0
     assert "Error: wezterm is still unavailable after installation attempt." in output
     assert "Terminal provider configured" not in output
+
+
+def test_setup_terminal_provider_ghostty_renders_via_profile_script(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    setup_ghostty = scripts_dir / "setup-ghostty.sh"
+    setup_ghostty.write_text("#!/usr/bin/env bash\nexit 42\n", encoding="utf-8")
+    setup_ghostty.chmod(0o755)
+
+    render_log = tmp_path / "render.log"
+    xdg_config_home = _create_terminal_profile(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        f"echo \"$@\" > '{render_log}'\n",
+    )
+    bin_dir = _create_minimal_bin(tmp_path)
+
+    env = os.environ.copy()
+    env.update({"XDG_CONFIG_HOME": str(xdg_config_home), "PATH": str(bin_dir)})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "ghostty"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert render_log.read_text().strip() == "ghostty " + str(repo)
+    assert "Terminal provider configured: ghostty" in result.stdout
 
 
 def test_setup_terminal_provider_windows_terminal_validates_inputs(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Centralize terminal config rendering so provider-specific rendering lives in one place and `setup-ghostty.sh` only handles install and template sync.
- Remove duplicated renderer logic from the Ghostty install script to avoid divergence and ensure consistent behavior from the canonical renderer at `dotfiles/terminal/.config/tino/renderers/ghostty.sh`.

### Description
- Removed embedded Ghostty renderer and substitution logic (`render_ghostty_config`, shader mapping, placeholder loop) from `scripts/setup-ghostty.sh` and kept it focused on installation and template sync, adding `terminal_provider_setup` variable and delegating rendering by calling `bash "$terminal_provider_setup" ghostty`.
- Deleted the Ghostty branch that caused recursive setup from `scripts/setup-terminal-provider.sh`, ensuring the single rendering path via the terminal profile renderer remains authoritative.
- Updated `tests/test_setup_ghostty.py` to assert delegation to the provider (`setup-terminal-provider.sh`) and to verify that `setup-ghostty.sh` no longer embeds renderer-specific logic.
- Added a new test in `tests/test_setup_terminal_provider.py` to assert Ghostty rendering is invoked via the profile renderer path and that `setup-terminal-provider.sh` reports `Terminal provider configured: ghostty`.

### Testing
- Ran `pytest -q tests/test_setup_ghostty.py tests/test_setup_terminal_provider.py`, which reported: `11 passed`.
- Attempted to run `shellcheck` on `scripts/setup-ghostty.sh` and `scripts/setup-terminal-provider.sh` but the tool was unavailable in the environment (`shellcheck: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5afedbd048326bd783a21056c09b7)