### PR TITLE
Adjust zsh prompt-critical startup load order

### DIFF
--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -91,9 +91,14 @@ tino_defer_eval() {
 }
 
 # Phase 1: prompt-critical startup path.
+# Prompt-critical files must load before `starship init` so first-render prompt
+# modules see host/terminal/env overrides. Keep heavy tooling in Phase 2.
 ZSH_PLUGIN_DIR="${ZSH_PLUGIN_DIR:-$HOME/.local/share/zsh/plugins}"
 source_if_readable "$ZSH_CONFIG_DIR/aliases.zsh"
 source_if_readable "$ZSH_CONFIG_DIR/functions.zsh"
+source_if_readable "$ZSH_CONFIG_DIR/env.zsh"
+source_if_readable "$HOME/.config/tino/terminal-defaults.sh"
+source_if_readable "$HOME/.config/tino/host-overrides.sh"
 
 if command -v starship >/dev/null; then
     eval "$(starship init zsh)"
@@ -105,20 +110,12 @@ source_if_readable "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
 # it can wrap widgets defined by prompt/plugins and reduce ordering surprises.
 source_if_readable "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
-# Phase 2: deferred non-critical path/env initialization.
+# Phase 2: deferred non-critical/non-prompt startup path.
 if [[ "${TINO_ZSH_DEFER:-1}" == "1" ]]; then
-    tino_defer_eval 'source_if_readable "$ZSH_CONFIG_DIR/env.zsh"'
-    tino_defer_eval 'source_if_readable "$HOME/.config/tino/terminal-defaults.sh"'
-    tino_defer_eval 'source_if_readable "$HOME/.config/tino/host-overrides.sh"'
-
     if command -v zoxide >/dev/null; then
         tino_defer_eval 'eval "$(zoxide init zsh)"'
     fi
 else
-    source_if_readable "$ZSH_CONFIG_DIR/env.zsh"
-    source_if_readable "$HOME/.config/tino/terminal-defaults.sh"
-    source_if_readable "$HOME/.config/tino/host-overrides.sh"
-
     if command -v zoxide >/dev/null; then
         eval "$(zoxide init zsh)"
     fi

--- a/tests/test_migrate_shell_config.py
+++ b/tests/test_migrate_shell_config.py
@@ -7,6 +7,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _line_index(lines: list[str], needle: str) -> int:
+    return next(index for index, line in enumerate(lines) if needle in line)
+
+
 def test_migrate_shell_config_creates_fragments_backup_and_report(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     (repo / "scripts").mkdir(parents=True)
@@ -183,3 +187,35 @@ def test_minimal_bashrc_shim_uses_env_fallback_for_symlinked_rcfile(tmp_path: Pa
 
     assert "Hint: migrate your legacy ~/.bashrc settings" in result.stderr
     assert str(migration_script) in result.stderr
+
+
+def test_zshrc_loads_prompt_critical_env_before_starship_init() -> None:
+    zshrc = REPO_ROOT / "dotfiles" / "shell" / ".zshrc"
+    lines = zshrc.read_text(encoding="utf-8").splitlines()
+
+    env_index = _line_index(lines, 'source_if_readable "$ZSH_CONFIG_DIR/env.zsh"')
+    terminal_profile_index = _line_index(lines, 'source_if_readable "$HOME/.config/tino/terminal-defaults.sh"')
+    host_profile_index = _line_index(lines, 'source_if_readable "$HOME/.config/tino/host-overrides.sh"')
+    starship_init_index = _line_index(lines, 'eval "$(starship init zsh)"')
+
+    assert env_index < starship_init_index
+    assert terminal_profile_index < starship_init_index
+    assert host_profile_index < starship_init_index
+
+
+def test_zshrc_preserves_interactive_plugin_order_and_defers_zoxide() -> None:
+    zshrc = REPO_ROOT / "dotfiles" / "shell" / ".zshrc"
+    lines = zshrc.read_text(encoding="utf-8").splitlines()
+
+    autosuggestions_index = _line_index(
+        lines,
+        'source_if_readable "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"',
+    )
+    syntax_highlighting_index = _line_index(
+        lines,
+        'source_if_readable "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"',
+    )
+    zoxide_defer_index = _line_index(lines, "tino_defer_eval 'eval \"$(zoxide init zsh)\"'")
+
+    assert autosuggestions_index < syntax_highlighting_index
+    assert syntax_highlighting_index < zoxide_defer_index


### PR DESCRIPTION
### Motivation
- Ensure prompt-rendering tools (Starship and prompt modules) see host/terminal/environment overrides on first render by loading prompt-critical environment before `starship init zsh`.
- Avoid slowing initial prompt by deferring heavy, non-critical tooling (e.g., `zoxide`) while keeping interactive enhancers ordering predictable.

### Description
- Move `source_if_readable "$ZSH_CONFIG_DIR/env.zsh"`, `source_if_readable "$HOME/.config/tino/terminal-defaults.sh"`, and `source_if_readable "$HOME/.config/tino/host-overrides.sh"` into Phase 1 so they run before `eval "$(starship init zsh)"`.
- Remove duplicate sourcing from Phase 2 and keep heavy/non-prompt initializers deferred under `TINO_ZSH_DEFER` (preserving `zoxide init zsh` deferral).
- Add a lightweight guard comment that documents which files are "prompt-critical" vs deferred and preserve existing completion caching and plugin order with `zsh-syntax-highlighting` loaded after autosuggestions.
- Add tests in `tests/test_migrate_shell_config.py` to assert that prompt-critical env files load before Starship and that interactive plugin ordering and `zoxide` deferral are preserved.

### Testing
- Ran `pytest -q tests/test_migrate_shell_config.py`, which completed successfully with `7 passed`.
- Ran `ruff check tests/test_migrate_shell_config.py`, which reported all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b4094fb88326939f139191320f87)