### PR TITLE
Wire Neovim startup benchmarking into setup pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,18 @@ Terminal profile values flow through one path:
 
 Standard bootstrap command (repo root):
 
-Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; provisioning is handled by `./scripts/setup-nvim.sh` (headless `Lazy! sync` + explicit Mason LSP installs, requires Neovim >= 0.8) so first interactive startup is deterministic. Runtime self-healing is opt-in with `TINO_NVIM_AUTO_BOOTSTRAP=1` (default is disabled/offline-friendly), and `TINO_NVIM_OFFLINE=1` forces warning-only startup behavior.
+Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; provisioning is handled by `./scripts/setup-nvim.sh` (headless `Lazy! sync` + explicit Mason LSP installs, requires Neovim >= 0.8) so first interactive startup is deterministic. Runtime self-healing is opt-in with `TINO_NVIM_AUTO_BOOTSTRAP=1` (default is disabled/offline-friendly), and `TINO_NVIM_OFFLINE=1` forces warning-only startup behavior. Startup benchmarking is available via `scripts/benchmark_nvim_startup.sh`; `scripts/setup-nvim.sh` runs it only when `TINO_NVIM_BENCHMARK_STARTUP=1` (desktop profile enables this by default during `install_common.sh`, constrained environments can opt out with `TINO_NVIM_BENCHMARK_STARTUP=0`). You can enforce a regression threshold with `TINO_NVIM_MAX_STARTUP_MS`.
 
+Reproducible benchmark command (repo root):
+
+```bash
+TINO_NVIM_BENCHMARK_STARTUP=1 TINO_NVIM_MAX_STARTUP_MS=250 ./scripts/setup-nvim.sh
+```
+
+Expected artifacts are written under `.cache/tino/nvim-startup/`:
+
+- `.cache/tino/nvim-startup/startup.log`
+- `.cache/tino/nvim-startup/summary.txt`
 
 ```bash
 ./scripts/install_common.sh

--- a/scripts/benchmark_nvim_startup.sh
+++ b/scripts/benchmark_nvim_startup.sh
@@ -5,7 +5,7 @@ OUTPUT_DIR=".cache/tino/nvim-startup"
 LOG_FILE="${OUTPUT_DIR}/startup.log"
 SUMMARY_FILE="${OUTPUT_DIR}/summary.txt"
 TOP_COUNT="${TOP_COUNT:-20}"
-MAX_STARTUP_MS="${MAX_STARTUP_MS:-}"
+MAX_STARTUP_MS="${TINO_NVIM_MAX_STARTUP_MS:-${MAX_STARTUP_MS:-}}"
 
 mkdir -p "${OUTPUT_DIR}"
 

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -419,7 +419,12 @@ else
     fi
 
     if [[ -f "$scripts/setup-nvim.sh" ]]; then
-        run_cmd bash "$scripts/setup-nvim.sh"
+        benchmark_env=()
+        setup_nvim_host="${host_override:-${resolved_host:-}}"
+        if [[ -z "${TINO_NVIM_BENCHMARK_STARTUP:-}" && "$setup_nvim_host" == "desktop" ]]; then
+            benchmark_env+=(TINO_NVIM_BENCHMARK_STARTUP=1)
+        fi
+        run_cmd env "${benchmark_env[@]}" bash "$scripts/setup-nvim.sh"
     fi
 
     set_default_shell "$set_default_shell_mode"

--- a/scripts/setup-nvim.sh
+++ b/scripts/setup-nvim.sh
@@ -7,6 +7,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 lsp_servers_file="$repo_root/dotfiles/nvim/.config/nvim/lsp_servers.txt"
 minimum_nvim_version="0.8"
+benchmark_script="$repo_root/scripts/benchmark_nvim_startup.sh"
+benchmark_startup="${TINO_NVIM_BENCHMARK_STARTUP:-0}"
+benchmark_threshold="${TINO_NVIM_MAX_STARTUP_MS:-}"
 
 version_gte() {
     local current="$1"
@@ -59,5 +62,18 @@ nvim --headless "+Lazy! sync" +qa
 
 echo "Installing Mason LSP servers (headless): ${required_lsp_servers[*]}"
 nvim --headless "+MasonInstall ${required_lsp_servers[*]}" +qa
+
+if [[ "$benchmark_startup" == "1" ]]; then
+    if [[ -f "$benchmark_script" ]]; then
+        echo "Running startup benchmark (TINO_NVIM_BENCHMARK_STARTUP=1)..."
+        if [[ -n "$benchmark_threshold" ]]; then
+            TINO_NVIM_MAX_STARTUP_MS="$benchmark_threshold" bash "$benchmark_script"
+        else
+            bash "$benchmark_script"
+        fi
+    else
+        echo "Warning: benchmark script not found at $benchmark_script" >&2
+    fi
+fi
 
 echo "Neovim provisioning complete."

--- a/tests/test_benchmark_nvim_startup.py
+++ b/tests/test_benchmark_nvim_startup.py
@@ -74,7 +74,29 @@ def test_benchmark_nvim_startup_fails_on_threshold_regression(tmp_path: Path) ->
 
     env = os.environ.copy()
     env["PATH"] = f"{fake_bin}:{env['PATH']}"
-    env["MAX_STARTUP_MS"] = "5"
+    env["TINO_NVIM_MAX_STARTUP_MS"] = "5"
+
+    result = subprocess.run(["bash", str(script)], cwd=tmp_path, env=env, text=True, capture_output=True)
+
+    assert result.returncode == 1
+    assert "Startup regression detected" in result.stderr
+
+
+def test_benchmark_nvim_startup_supports_legacy_threshold_env(tmp_path: Path) -> None:
+    script = REPO_ROOT / "scripts" / "benchmark_nvim_startup.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_nvim(
+        fake_bin,
+        [
+            "001.000: plugin/bootstrap",
+            "003.250: plugin/lsp",
+        ],
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["MAX_STARTUP_MS"] = "2"
 
     result = subprocess.run(["bash", str(script)], cwd=tmp_path, env=env, text=True, capture_output=True)
 

--- a/tests/test_install_common.py
+++ b/tests/test_install_common.py
@@ -676,3 +676,100 @@ def test_install_common_dry_run_lists_required_rg_and_fd_packages(tmp_path: Path
     assert "apt-get install -y" in output
     assert "ripgrep" in output
     assert "fd-find" in output
+
+
+def test_install_common_enables_nvim_benchmark_by_default_for_desktop_host(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_dotfiles_desktop_benchmark"
+    repo.mkdir()
+
+    scripts_dir = repo / "scripts"
+    helpers_dir = scripts_dir / "helpers"
+    helpers_dir.mkdir(parents=True)
+
+    shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+
+    for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
+        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    (scripts_dir / "install_dotfiles.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (scripts_dir / "install_dotfiles.sh").chmod(0o755)
+
+    setup_nvim_log = tmp_path / "setup_nvim_desktop.log"
+    (scripts_dir / "setup-nvim.sh").write_text(
+        f"#!/usr/bin/env bash\nprintf '%s\\n' \"${{TINO_NVIM_BENCHMARK_STARTUP:-unset}}\" >> '{setup_nvim_log}'\n",
+        encoding="utf-8",
+    )
+    (scripts_dir / "setup-nvim.sh").chmod(0o755)
+
+    (repo / "hosts" / "desktop").mkdir(parents=True)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for exe in ["curl", "unzip", "zsh", "tmux", "nvim", "cargo", "stow"]:
+        create_exe(bin_dir / exe)
+    create_exe(bin_dir / "starship", "#!/usr/bin/env bash\nif [[ $1 == init && $2 == zsh ]]; then\n  echo 'STARSHIP_INIT'\nfi\n")
+    create_git_stub(bin_dir / "git", tmp_path / "git_desktop.log")
+    create_exe(bin_dir / "hostname", "#!/usr/bin/env bash\necho desktop\n")
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+
+    env = os.environ.copy()
+    env.update({"OSTYPE": "linux-gnu", "PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path / 'home')})
+
+    subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
+
+    assert setup_nvim_log.read_text(encoding="utf-8").splitlines() == ["1"]
+
+
+def test_install_common_respects_explicit_nvim_benchmark_disable(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_dotfiles_desktop_disable_benchmark"
+    repo.mkdir()
+
+    scripts_dir = repo / "scripts"
+    helpers_dir = scripts_dir / "helpers"
+    helpers_dir.mkdir(parents=True)
+
+    shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+
+    for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
+        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    (scripts_dir / "install_dotfiles.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (scripts_dir / "install_dotfiles.sh").chmod(0o755)
+
+    setup_nvim_log = tmp_path / "setup_nvim_disable.log"
+    (scripts_dir / "setup-nvim.sh").write_text(
+        f"#!/usr/bin/env bash\nprintf '%s\\n' \"${{TINO_NVIM_BENCHMARK_STARTUP:-unset}}\" >> '{setup_nvim_log}'\n",
+        encoding="utf-8",
+    )
+    (scripts_dir / "setup-nvim.sh").chmod(0o755)
+
+    (repo / "hosts" / "desktop").mkdir(parents=True)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for exe in ["curl", "unzip", "zsh", "tmux", "nvim", "cargo", "stow"]:
+        create_exe(bin_dir / exe)
+    create_exe(bin_dir / "starship", "#!/usr/bin/env bash\nif [[ $1 == init && $2 == zsh ]]; then\n  echo 'STARSHIP_INIT'\nfi\n")
+    create_git_stub(bin_dir / "git", tmp_path / "git_disable.log")
+    create_exe(bin_dir / "hostname", "#!/usr/bin/env bash\necho desktop\n")
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "OSTYPE": "linux-gnu",
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(tmp_path / 'home'),
+            "TINO_NVIM_BENCHMARK_STARTUP": "0",
+        }
+    )
+
+    subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
+
+    assert setup_nvim_log.read_text(encoding="utf-8").splitlines() == ["0"]

--- a/tests/test_setup_nvim.py
+++ b/tests/test_setup_nvim.py
@@ -16,7 +16,7 @@ def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
     path.chmod(0o755)
 
 
-def create_fake_nvim(path: Path, *, version: str = "0.9.1", log_path: Path | None = None) -> None:
+def create_fake_nvim(path: Path, *, version: str = "0.9.1", log_path: Path | None = None, startup_ms: str = "3.500") -> None:
     log_snippet = f"echo \"$@\" >> '{log_path}'\n" if log_path else ""
     create_exe(
         path,
@@ -25,6 +25,19 @@ def create_fake_nvim(path: Path, *, version: str = "0.9.1", log_path: Path | Non
         "if [[ ${1:-} == --version ]]; then\n"
         f"  echo 'NVIM v{version}'\n"
         "  exit 0\n"
+        "fi\n"
+        "if [[ ${1:-} == --headless ]]; then\n"
+        "  startup_log=''\n"
+        "  args=(\"$@\")\n"
+        "  for ((i=0; i<${#args[@]}; i++)); do\n"
+        "    if [[ ${args[$i]} == --startuptime ]]; then\n"
+        "      startup_log=${args[$((i+1))]}\n"
+        "      break\n"
+        "    fi\n"
+        "  done\n"
+        "  if [[ -n $startup_log ]]; then\n"
+        f"    cat > \"$startup_log\" <<'LOG'\n{startup_ms}: fake/startup\nLOG\n"
+        "  fi\n"
         "fi\n"
         + log_snippet
         + "exit 0\n",
@@ -94,6 +107,65 @@ def test_setup_nvim_exits_on_unsupported_neovim_version(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "Neovim 0.8+ is required" in result.stderr
+
+
+def test_setup_nvim_runs_startup_benchmark_when_enabled(tmp_path: Path) -> None:
+    script_path = REPO_ROOT / "scripts" / "setup-nvim.sh"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    create_exe(
+        bin_dir / "git",
+        "#!/usr/bin/env bash\nif [[ $1 == clone ]]; then\n  /bin/mkdir -p \"$5/.git\"\nfi\n",
+    )
+
+    nvim_log = tmp_path / "nvim.log"
+    create_fake_nvim(bin_dir / "nvim", log_path=nvim_log, startup_ms="2.250")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(tmp_path),
+            "TINO_NVIM_BENCHMARK_STARTUP": "1",
+            "TOP_COUNT": "1",
+        }
+    )
+
+    subprocess.run(["/bin/bash", str(script_path)], check=True, env=env, cwd=tmp_path)
+
+    summary_path = tmp_path / ".cache" / "tino" / "nvim-startup" / "summary.txt"
+    assert summary_path.exists()
+    summary_text = summary_path.read_text(encoding="utf-8")
+    assert "Max startup entry (ms): 2.250" in summary_text
+
+
+def test_setup_nvim_benchmark_threshold_failure_bubbles_up(tmp_path: Path) -> None:
+    script_path = REPO_ROOT / "scripts" / "setup-nvim.sh"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    create_exe(
+        bin_dir / "git",
+        "#!/usr/bin/env bash\nif [[ $1 == clone ]]; then\n  /bin/mkdir -p \"$5/.git\"\nfi\n",
+    )
+
+    create_fake_nvim(bin_dir / "nvim", startup_ms="8.750")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(tmp_path),
+            "TINO_NVIM_BENCHMARK_STARTUP": "1",
+            "TINO_NVIM_MAX_STARTUP_MS": "5",
+        }
+    )
+
+    result = subprocess.run(["/bin/bash", str(script_path)], env=env, text=True, capture_output=True, cwd=tmp_path)
+
+    assert result.returncode == 1
+    assert "Startup regression detected" in result.stderr
 
 
 def test_lazy_config_supports_auto_bootstrap_and_offline_modes() -> None:


### PR DESCRIPTION
### Motivation
- Add a reproducible Neovim startup benchmarking step to the canonical provisioning flow so desktop setups can catch regressions early. 
- Make the benchmark opt-in for constrained environments while enabling it by default for the desktop host profile. 

### Description
- Add an optional post-provision benchmark phase to `scripts/setup-nvim.sh` gated by `TINO_NVIM_BENCHMARK_STARTUP=1` and able to forward threshold via `TINO_NVIM_MAX_STARTUP_MS`. 
- Update `scripts/benchmark_nvim_startup.sh` to prefer `TINO_NVIM_MAX_STARTUP_MS` while preserving legacy `MAX_STARTUP_MS` compatibility and to emit artifacts under `.cache/tino/nvim-startup/`. 
- Wire desktop-default behavior in `scripts/install_common.sh` so the desktop host runs `setup-nvim.sh` with `TINO_NVIM_BENCHMARK_STARTUP=1` unless explicitly overridden. 
- Document usage and reproducible command in the README dotfiles section and add tests that cover benchmark execution, threshold propagation, env compatibility, and desktop default-on behavior. 

### Testing
- Ran `python -m py_compile tests/test_setup_nvim.py tests/test_install_common.py tests/test_benchmark_nvim_startup.py` which succeeded. 
- Performed shell syntax checks with `bash -n scripts/setup-nvim.sh scripts/benchmark_nvim_startup.sh scripts/install_common.sh` which succeeded. 
- Ran linter with `ruff check tests/test_setup_nvim.py tests/test_benchmark_nvim_startup.py tests/test_install_common.py` which succeeded. 
- Executed targeted test selection with `PYTHONPATH=. pytest -q tests/test_setup_nvim.py tests/test_benchmark_nvim_startup.py tests/test_install_common.py -k 'setup_nvim or benchmark_nvim_startup or enables_nvim_benchmark_by_default_for_desktop_host or respects_explicit_nvim_benchmark_disable'` and all selected benchmark-related tests passed; a full run of the larger `tests/test_install_common.py` in this environment exposed unrelated pre-existing assertion mismatches not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b59cb15883268e31239ab40beefc)