### PR TITLE
Make tmux status metrics mtime detection portable

### DIFF
--- a/dotfiles/tmux/.tmux_status_metrics.sh
+++ b/dotfiles/tmux/.tmux_status_metrics.sh
@@ -7,9 +7,26 @@ cache_ttl=10
 
 mkdir -p "$cache_dir"
 
+file_mtime() {
+  local file="$1"
+  local mtime
+
+  if mtime="$(stat -c %Y "$file" 2>/dev/null)"; then
+    printf '%s\n' "$mtime"
+    return 0
+  fi
+
+  if mtime="$(stat -f %m "$file" 2>/dev/null)"; then
+    printf '%s\n' "$mtime"
+    return 0
+  fi
+
+  printf '0\n'
+}
+
 now="$(date +%s)"
 if [[ -f "$cache_file" ]]; then
-  modified="$(stat -c %Y "$cache_file" 2>/dev/null || echo 0)"
+  modified="$(file_mtime "$cache_file")"
   if (( now - modified < cache_ttl )); then
     cat "$cache_file"
     exit 0

--- a/tests/test_dotfiles.py
+++ b/tests/test_dotfiles.py
@@ -88,3 +88,5 @@ def test_tmux_status_metrics_helper_uses_cache() -> None:
     assert "cache_ttl=10" in helper
     assert "tmux-status-metrics" in helper
     assert "/proc/loadavg" in helper
+    assert "stat -c %Y" in helper
+    assert "stat -f %m" in helper


### PR DESCRIPTION
### Motivation
- Ensure the tmux status helper works across platforms by avoiding a single GNU-only `stat` invocation and preventing platform metadata lookup failures from causing the script to exit non-zero.
- Preserve existing cache semantics (`cache_ttl=10`) and behavior while making mtime detection robust on GNU and BSD/macOS systems.

### Description
- Add a `file_mtime()` helper in `dotfiles/tmux/.tmux_status_metrics.sh` that tries `stat -c %Y` (GNU), then `stat -f %m` (BSD/macOS), and falls back to `0` on failure.
- Replace the direct `stat -c %Y` call with `file_mtime "$cache_file"` so metadata failures do not terminate the script and cache logic stays intact.
- Update `tests/test_dotfiles.py` to assert both `stat -c %Y` and `stat -f %m` exist in the helper script so CI will guard portability.

### Testing
- Ran the focused test: `pytest -q tests/test_dotfiles.py -k tmux_status_metrics_helper_uses_cache`, which passed.
- Ran linters and syntax checks: `ruff check tests/test_dotfiles.py` passed and `bash -n dotfiles/tmux/.tmux_status_metrics.sh` passed.
- Ran full test suite `pytest -q tests/test_dotfiles.py`, which had one unrelated failure due to a missing file `dotfiles/ghostty/ghostty.toml.tmpl` and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a831561c6883268da10f682e5a6566)