### PR TITLE
Fix Ghostty path expectation in dotfiles test

### DIFF
--- a/tests/test_dotfiles.py
+++ b/tests/test_dotfiles.py
@@ -45,7 +45,7 @@ def test_readme_layout_paths_exist():
         REPO_ROOT / "dotfiles" / "nvim",
         REPO_ROOT / "dotfiles" / "tmux",
         REPO_ROOT / "dotfiles" / "terminal",
-        REPO_ROOT / "dotfiles" / "ghostty" / "ghostty.toml.tmpl",
+        REPO_ROOT / "dotfiles" / "terminal" / ".config" / "tino" / "ghostty.toml.tmpl",
         REPO_ROOT / "hosts" / "desktop",
         REPO_ROOT / "hosts" / "work_laptop",
     )


### PR DESCRIPTION
### Motivation
- The README and docs use the canonical Ghostty template location under `dotfiles/terminal/.config/tino/ghostty.toml.tmpl`, but the test still referenced the old `dotfiles/ghostty` path, causing a mismatch with documented layout expectations.

### Description
- Update `test_readme_layout_paths_exist` in `tests/test_dotfiles.py` to assert `REPO_ROOT / "dotfiles" / "terminal" / ".config" / "tino" / "ghostty.toml.tmpl"` so the test checks the same canonical path documented in `README.md` and `docs/terminal.md`.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_dotfiles.py` which completed with `6 passed, 1 warning`, and ran `ruff check tests/test_dotfiles.py` which reported `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8347bc3b08326ac401c6ee712ba84)