### PR TITLE
Add lazy-loaded nvim-cmp completion and merge LSP capabilities from cmp_nvim_lsp

### DIFF
--- a/dotfiles/nvim/.config/nvim/lua/plugins/cmp.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/cmp.lua
@@ -1,0 +1,36 @@
+return {
+    {
+        "hrsh7th/nvim-cmp",
+        event = "InsertEnter",
+        dependencies = {
+            "hrsh7th/cmp-nvim-lsp",
+            "L3MON4D3/LuaSnip",
+            "saadparwaiz1/cmp_luasnip",
+            "hrsh7th/cmp-path",
+            "hrsh7th/cmp-buffer",
+        },
+        config = function()
+            local cmp = require("cmp")
+
+            cmp.setup({
+                snippet = {
+                    expand = function(args)
+                        require("luasnip").lsp_expand(args.body)
+                    end,
+                },
+                mapping = cmp.mapping.preset.insert({
+                    ["<Tab>"] = cmp.mapping.select_next_item(),
+                    ["<S-Tab>"] = cmp.mapping.select_prev_item(),
+                    ["<CR>"] = cmp.mapping.confirm({ select = true }),
+                }),
+                sources = cmp.config.sources({
+                    { name = "nvim_lsp" },
+                    { name = "luasnip" },
+                    { name = "path" },
+                }, {
+                    { name = "buffer" },
+                }),
+            })
+        end,
+    },
+}

--- a/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/dotfiles/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -61,6 +61,12 @@ return {
             local installed_servers = mason_lspconfig.get_installed_servers()
             local installed_lookup = {}
             local missing_servers = {}
+            local capabilities = vim.lsp.protocol.make_client_capabilities()
+
+            local cmp_nvim_lsp_ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
+            if cmp_nvim_lsp_ok then
+                capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
+            end
 
             for _, server in ipairs(installed_servers) do
                 installed_lookup[server] = true
@@ -68,7 +74,9 @@ return {
 
             for _, server in ipairs(required_servers) do
                 if installed_lookup[server] then
-                    lspconfig[server].setup({})
+                    lspconfig[server].setup({
+                        capabilities = capabilities,
+                    })
                 else
                     table.insert(missing_servers, server)
                 end


### PR DESCRIPTION
### Motivation
- Provide a lightweight, modular completion layer that follows existing `plugins/*` and `lazy.nvim` conventions and improves startup performance by lazy-loading on insert.
- Ensure LSP servers advertise and use completion capabilities provided by `nvim-cmp` so LSP-driven completion behaves correctly.

### Description
- Add a new plugin module at `lua/plugins/cmp.lua` implementing `hrsh7th/nvim-cmp` lazily loaded on `InsertEnter` with dependencies `hrsh7th/cmp-nvim-lsp`, `L3MON4D3/LuaSnip`, `saadparwaiz1/cmp_luasnip`, and path/buffer sources for sane defaults.
- Configure `nvim-cmp` defaults including snippet expansion via `luasnip`, `<Tab>/<S-Tab>` navigation, `<CR>` confirm, and source ordering (LSP, luasnip, path, then buffer).
- Update `lua/plugins/lsp.lua` to build base client capabilities with `vim.lsp.protocol.make_client_capabilities()` and merge `cmp_nvim_lsp.default_capabilities(...)` when available, then pass the merged `capabilities` into each server `setup` invocation.
- Keep the change modular and consistent with the existing `config/*` and `plugins/*` layout so it composes with the current lazy setup.

### Testing
- Ran `pytest -q tests/test_setup_nvim.py tests/test_dotfiles.py` which failed in this environment due to a missing Python dependency: `ModuleNotFoundError: No module named 'requests'`.
- Attempted Lua validation with `luac -p` but `luac` is not installed in this environment, so static Lua parsing could not be performed.
- Attempted to source the files via `nvim --headless` but `nvim` is not available in this environment, so runtime verification inside Neovim could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a835a5566c8326b559331c8d51dc76)