### PR TITLE
Capability-driven terminal provider resolver with preference-based fallbacks

### DIFF
--- a/dotfiles/terminal/.config/tino/terminal-profile.sh
+++ b/dotfiles/terminal/.config/tino/terminal-profile.sh
@@ -19,6 +19,35 @@ readonly TINO_TERMINAL_CONTRACT_FIELDS=(
     TINO_TERMINAL_EFFECTS
 )
 
+readonly TINO_TERMINAL_PROVIDER_DEFAULT_ORDER=(
+    ghostty
+    wezterm
+    kitty
+    alacritty
+)
+
+terminal_provider_preferences() {
+    local raw_preferences="${TINO_TERMINAL_PROVIDER_PREFERENCES:-}"
+    local -a normalized=()
+    local -a combined=()
+    local candidate=""
+
+    if [[ -n "$raw_preferences" ]]; then
+        raw_preferences="${raw_preferences//,/ }"
+        for candidate in $raw_preferences; do
+            case "$candidate" in
+                ghostty|wezterm|kitty|alacritty)
+                    normalized+=("$candidate")
+                    ;;
+            esac
+        done
+    fi
+
+    combined=("${normalized[@]}" "${TINO_TERMINAL_PROVIDER_DEFAULT_ORDER[@]}")
+
+    awk '!seen[$0]++' < <(printf '%s\n' "${combined[@]}")
+}
+
 terminal_capability_status() {
     local provider="$1"
     local field="$2"
@@ -137,6 +166,11 @@ render_provider() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ ${1:-} == "--provider-preferences" ]]; then
+        terminal_provider_preferences
+        exit 0
+    fi
+
     if [[ $# -lt 1 ]]; then
         echo "Usage: $(basename "$0") <provider> [repo-root]" >&2
         exit 1

--- a/scripts/setup-terminal-provider.sh
+++ b/scripts/setup-terminal-provider.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 provider="${1:-}"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 strict_mode="${TINO_TERMINAL_STRICT:-1}"
+selected_provider="$provider"
+readonly TERMINAL_CAPABILITY_PROBE_ORDER=(ghostty wezterm kitty alacritty)
 
 if [[ -z "$provider" ]]; then
     echo "Usage: $(basename "$0") <ghostty|wezterm|kitty|alacritty|windows-terminal>" >&2
@@ -39,27 +41,73 @@ install_with_pkg_manager() {
     return 1
 }
 
+provider_binary() {
+    local provider_name="$1"
+
+    case "$provider_name" in
+        ghostty|wezterm|kitty|alacritty)
+            printf '%s' "$provider_name"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+provider_install_url() {
+    local provider_name="$1"
+
+    case "$provider_name" in
+        ghostty)
+            printf '%s' "https://ghostty.org/docs/install/binary"
+            ;;
+        wezterm)
+            printf '%s' "https://wezfurlong.org/wezterm/installation.html"
+            ;;
+        kitty)
+            printf '%s' "https://sw.kovidgoyal.net/kitty/binary/"
+            ;;
+        alacritty)
+            printf '%s' "https://github.com/alacritty/alacritty/blob/master/INSTALL.md"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+provider_is_available() {
+    local provider_name="$1"
+    local binary
+
+    binary="$(provider_binary "$provider_name")" || return 1
+    command -v "$binary" >/dev/null 2>&1
+}
+
 report_unavailable_provider() {
-    local install_url="$1"
+    local provider_name="$1"
+    local install_url
+    install_url="$(provider_install_url "$provider_name")"
 
     if [[ "$strict_mode" == "1" ]]; then
-        echo "Error: $provider is still unavailable after installation attempt." >&2
-        echo "Install $provider manually ($install_url) or set TINO_TERMINAL_STRICT=0 to continue without failing." >&2
+        echo "Error: $provider_name is still unavailable after installation attempt." >&2
+        echo "Install $provider_name manually ($install_url) or set TINO_TERMINAL_STRICT=0 to continue without failing." >&2
         exit 1
     fi
 
-    echo "Warning: $provider is still unavailable after installation attempt; continuing because TINO_TERMINAL_STRICT=$strict_mode." >&2
+    echo "Warning: $provider_name is still unavailable after installation attempt; continuing because TINO_TERMINAL_STRICT=$strict_mode." >&2
 }
 
-ensure_provider_installed() {
-    case "$provider" in
+attempt_provider_install() {
+    local provider_name="$1"
+
+    case "$provider_name" in
         wezterm)
             if ! command -v wezterm >/dev/null 2>&1; then
                 if ! install_with_pkg_manager wezterm; then
                     echo "Warning: automatic install for wezterm failed." >&2
                 fi
             fi
-            command -v wezterm >/dev/null 2>&1 || report_unavailable_provider "https://wezfurlong.org/wezterm/installation.html"
             ;;
         kitty)
             if ! command -v kitty >/dev/null 2>&1; then
@@ -67,7 +115,6 @@ ensure_provider_installed() {
                     echo "Warning: automatic install for kitty failed." >&2
                 fi
             fi
-            command -v kitty >/dev/null 2>&1 || report_unavailable_provider "https://sw.kovidgoyal.net/kitty/binary/"
             ;;
         alacritty)
             if ! command -v alacritty >/dev/null 2>&1; then
@@ -75,7 +122,6 @@ ensure_provider_installed() {
                     echo "Warning: automatic install for alacritty failed." >&2
                 fi
             fi
-            command -v alacritty >/dev/null 2>&1 || report_unavailable_provider "https://github.com/alacritty/alacritty/blob/master/INSTALL.md"
             ;;
         ghostty)
             if ! command -v ghostty >/dev/null 2>&1; then
@@ -94,8 +140,6 @@ ensure_provider_installed() {
                     echo "Warning: cargo is unavailable for ghostty fallback installation." >&2
                 fi
             fi
-
-            command -v ghostty >/dev/null 2>&1 || report_unavailable_provider "https://ghostty.org/docs/install/binary"
             ;;
         windows-terminal)
             return
@@ -105,6 +149,51 @@ ensure_provider_installed() {
             exit 1
             ;;
     esac
+}
+
+resolve_provider_via_capability_probe() {
+    local -a candidates=()
+    local candidate
+
+    if [[ -x "$profile_script" ]]; then
+        mapfile -t candidates < <("$profile_script" --provider-preferences 2>/dev/null || true)
+    fi
+
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        candidates=("${TERMINAL_CAPABILITY_PROBE_ORDER[@]}")
+    fi
+
+    for candidate in "${candidates[@]}"; do
+        if provider_is_available "$candidate"; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+ensure_provider_installed() {
+    if [[ "$provider" == "windows-terminal" ]]; then
+        return
+    fi
+
+    attempt_provider_install "$provider"
+    if provider_is_available "$provider"; then
+        selected_provider="$provider"
+        return
+    fi
+
+    local fallback_provider=""
+    if fallback_provider="$(resolve_provider_via_capability_probe)"; then
+        selected_provider="$fallback_provider"
+        if [[ "$selected_provider" != "$provider" ]]; then
+            echo "Warning: preferred provider '$provider' is unavailable; using '$selected_provider' based on capability probe." >&2
+        fi
+        return
+    fi
+
+    report_unavailable_provider "$provider"
 }
 
 validate_windows_terminal_inputs() {
@@ -130,9 +219,9 @@ if [[ ! -x "$profile_script" ]]; then
 fi
 
 ensure_provider_installed
-"$profile_script" "$provider" "$repo_root"
+"$profile_script" "$selected_provider" "$repo_root"
 
-if [[ "$provider" == "windows-terminal" ]]; then
+if [[ "$selected_provider" == "windows-terminal" ]]; then
     validate_windows_terminal_inputs
     python "$repo_root/windows-terminal/generate_settings.py" \
       "$repo_root/windows-terminal/settings.base.json" \
@@ -140,4 +229,4 @@ if [[ "$provider" == "windows-terminal" ]]; then
       --terminal-overrides "$repo_root/windows-terminal/terminal-profile-overrides.json"
 fi
 
-echo "Terminal provider configured: $provider"
+echo "Terminal provider configured: $selected_provider"

--- a/tests/test_setup_terminal_provider.py
+++ b/tests/test_setup_terminal_provider.py
@@ -13,11 +13,17 @@ def _create_terminal_profile(tmp_path: Path, body: str = "#!/usr/bin/env bash\ne
     return xdg_config_home
 
 
-def _create_minimal_bin(tmp_path: Path) -> Path:
+def _create_minimal_bin(tmp_path: Path, *, include_kitty: bool = False) -> Path:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
     (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
     (bin_dir / "bash").symlink_to("/bin/bash")
+
+    if include_kitty:
+        kitty = bin_dir / "kitty"
+        kitty.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        kitty.chmod(0o755)
+
     return bin_dir
 
 
@@ -160,3 +166,109 @@ def test_setup_terminal_provider_rejects_unsupported_provider(tmp_path: Path) ->
     output = f"{result.stdout}\n{result.stderr}"
     assert result.returncode != 0
     assert "Unsupported provider: bad-term" in output
+
+
+def test_setup_terminal_provider_falls_back_to_first_available_provider(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    render_log = tmp_path / "render.log"
+    xdg_config_home = _create_terminal_profile(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        f"echo \"$@\" > '{render_log}'\n",
+    )
+    bin_dir = _create_minimal_bin(tmp_path, include_kitty=True)
+
+    env = os.environ.copy()
+    env.update({"XDG_CONFIG_HOME": str(xdg_config_home), "PATH": str(bin_dir)})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "ghostty"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert "using 'kitty' based on capability probe" in output
+    assert render_log.read_text().strip() == "kitty " + str(repo)
+    assert "Terminal provider configured: kitty" in result.stdout
+
+
+def test_setup_terminal_provider_non_strict_continues_when_no_provider_available(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    render_log = tmp_path / "render.log"
+    xdg_config_home = _create_terminal_profile(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        f"echo \"$@\" > '{render_log}'\n",
+    )
+    bin_dir = _create_minimal_bin(tmp_path)
+
+    env = os.environ.copy()
+    env.update({"XDG_CONFIG_HOME": str(xdg_config_home), "PATH": str(bin_dir), "TINO_TERMINAL_STRICT": "0"})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "wezterm"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert "Warning: wezterm is still unavailable after installation attempt; continuing" in output
+    assert render_log.read_text().strip() == "wezterm " + str(repo)
+    assert "Terminal provider configured: wezterm" in result.stdout
+
+
+
+def test_setup_terminal_provider_uses_preference_env_for_fallback_order(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    render_log = tmp_path / "render.log"
+    xdg_config_home = _create_terminal_profile(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        "if [[ ${1:-} == '--provider-preferences' ]]; then\n"
+        "  echo alacritty\n"
+        "  echo kitty\n"
+        "  exit 0\n"
+        "fi\n"
+        f"echo \"$@\" > '{render_log}'\n",
+    )
+    bin_dir = _create_minimal_bin(tmp_path, include_kitty=True)
+    alacritty = bin_dir / "alacritty"
+    alacritty.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    alacritty.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({"XDG_CONFIG_HOME": str(xdg_config_home), "PATH": str(bin_dir)})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "ghostty"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert render_log.read_text().strip() == "alacritty " + str(repo)
+    assert "Terminal provider configured: alacritty" in result.stdout


### PR DESCRIPTION
### Motivation
- Replace the previous hard-fail behavior when a requested terminal provider cannot be installed with a capability-driven resolver that can probe and fall back to the first available provider. 
- Allow administrators to express a preference order via environment so fallback ordering can be customized.

### Description
- Reworked `scripts/setup-terminal-provider.sh` to track `selected_provider`, probe provider availability, attempt install for the preferred provider, and if that fails auto-select the first viable provider from the probe order `ghostty -> wezterm -> kitty -> alacritty`.
- Added availability helpers and metadata functions in `scripts/setup-terminal-provider.sh`: `provider_binary`, `provider_install_url`, `provider_is_available`, `attempt_provider_install`, and `resolve_provider_via_capability_probe` to encapsulate detection and fallback logic.
- Preserved strict-mode behavior via `TINO_TERMINAL_STRICT` so the script still errors when no providers are available in strict mode and otherwise continues with a warning when non-strict.
- Extended `dotfiles/terminal/.config/tino/terminal-profile.sh` with `TINO_TERMINAL_PROVIDER_PREFERENCES` support via `terminal_provider_preferences` (dedup + append default order) and exposed an invokable `--provider-preferences` entrypoint so the setup script can query fallback preference ordering without sourcing render code.
- Added tests to `tests/test_setup_terminal_provider.py` to exercise fallback behavior, strict and non-strict branches, and preference-driven ordering, and updated test helpers to simulate binaries.

### Testing
- Ran `pytest tests/test_setup_terminal_provider.py` and all tests passed (`8 passed`).
- Ran `ruff check tests/test_setup_terminal_provider.py` and it passed.
- Performed shell syntax check with `bash -n` on the changed shell files and no syntax errors were reported, but `shellcheck` was not available in the environment.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84c69b4d483268b23b9cacce40c30)