### PR TITLE
Unify canonical Starship prompt spec and enforce generated sync in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: pytest tests/test_generate_sources_md.py -q
       - name: Verify plugin registry
         run: python scripts/update_registry.py --check
+      - name: Verify palette artifacts (including Starship)
+        run: python scripts/helpers/generate_palette_artifacts.py --check
       - name: Verify Neovim lockfile coverage
         run: python scripts/check-nvim-lockfile.py
 
@@ -92,6 +94,8 @@ jobs:
         run: pytest -n auto
       - name: Verify plugin registry
         run: python scripts/update_registry.py --check
+      - name: Verify palette artifacts (including Starship)
+        run: python scripts/helpers/generate_palette_artifacts.py --check
       - name: Verify Neovim lockfile coverage
         run: python scripts/check-nvim-lockfile.py
   install-dry-run:

--- a/scripts/helpers/generate_palette_artifacts.py
+++ b/scripts/helpers/generate_palette_artifacts.py
@@ -11,7 +11,11 @@ from pathlib import Path
 if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from scripts.helpers.starship_spec import STARSHIP_MODULES, STARSHIP_PROMPT_FORMAT
+from scripts.helpers.starship_spec import (
+    REQUIRED_MODULE_KEYS,
+    STARSHIP_MODULES,
+    STARSHIP_PROMPT_FORMAT,
+)
 
 ANSI_ORDER = [
     "black",
@@ -61,7 +65,21 @@ def render_palette_toml(name: str, ansi: dict[str, str]) -> str:
     return "\n".join(lines) + "\n"
 
 
+
+
+def _validate_required_starship_modules() -> None:
+    module_map = {section: values for section, values in STARSHIP_MODULES}
+    for section, keys in REQUIRED_MODULE_KEYS.items():
+        if section not in module_map:
+            raise SystemExit(f"Missing required Starship section: {section}")
+        missing = [key for key in keys if key not in module_map[section]]
+        if missing:
+            raise SystemExit(
+                f"Missing required Starship keys in [{section}]: {', '.join(missing)}"
+            )
+
 def render_starship(config: dict[str, object]) -> str:
+    _validate_required_starship_modules()
     default_name = config["default_palette"]
     fmt = STARSHIP_PROMPT_FORMAT
     chunks = [

--- a/scripts/helpers/starship_spec.py
+++ b/scripts/helpers/starship_spec.py
@@ -7,6 +7,18 @@ STARSHIP_PROMPT_FORMAT = (
     "[└─](bold purple)$character\n"
 )
 
+REQUIRED_PROMPT_MODULES: tuple[str, ...] = (
+    "directory",
+    "git_branch",
+    "git_state",
+    "git_status",
+    "python",
+    "kubernetes",
+    "aws",
+    "status",
+    "time",
+)
+
 STARSHIP_MODULES: list[tuple[str, dict[str, object]]] = [
     (
         "directory",
@@ -79,19 +91,14 @@ STARSHIP_MODULES: list[tuple[str, dict[str, object]]] = [
     ("package", {"disabled": True}),
 ]
 
+MODULE_SETTINGS = {section: values for section, values in STARSHIP_MODULES}
+
 REQUIRED_MODULE_KEYS: dict[str, tuple[str, ...]] = {
-    section: tuple(values.keys())
-    for section, values in STARSHIP_MODULES
-    if section
-    in {
-        "directory",
-        "git_branch",
-        "git_state",
-        "git_status",
-        "python",
-        "kubernetes",
-        "aws",
-        "status",
-        "time",
-    }
+    section: tuple(MODULE_SETTINGS[section].keys())
+    for section in REQUIRED_PROMPT_MODULES
+}
+
+REQUIRED_MODULE_VALUES: dict[str, dict[str, object]] = {
+    section: dict(MODULE_SETTINGS[section])
+    for section in REQUIRED_PROMPT_MODULES
 }

--- a/tests/starship_expectations.py
+++ b/tests/starship_expectations.py
@@ -9,7 +9,11 @@ except ModuleNotFoundError:  # Python < 3.11
     import tomli as tomllib
 
 from scripts.helpers.generate_palette_artifacts import ANSI_ORDER
-from scripts.helpers.starship_spec import REQUIRED_MODULE_KEYS, STARSHIP_PROMPT_FORMAT
+from scripts.helpers.starship_spec import (
+    REQUIRED_MODULE_KEYS,
+    REQUIRED_MODULE_VALUES,
+    STARSHIP_PROMPT_FORMAT,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 STARSHIP_PATH = REPO_ROOT / "dotfiles" / "shell" / ".config" / "starship.toml"
@@ -32,6 +36,7 @@ def expected_default_palette() -> tuple[str, dict[str, str]]:
 
 __all__ = [
     "REQUIRED_MODULE_KEYS",
+    "REQUIRED_MODULE_VALUES",
     "STARSHIP_PROMPT_FORMAT",
     "expected_default_palette",
     "load_starship",

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -1,4 +1,10 @@
-from starship_expectations import REQUIRED_MODULE_KEYS, STARSHIP_PROMPT_FORMAT, load_starship
+from starship_expectations import (
+    REQUIRED_MODULE_KEYS,
+    REQUIRED_MODULE_VALUES,
+    STARSHIP_PROMPT_FORMAT,
+    load_starship,
+)
+
 
 def test_starship_time_and_git_status_sections():
     data = load_starship()
@@ -6,9 +12,10 @@ def test_starship_time_and_git_status_sections():
         assert section in data, f'[{section}] section missing'
         for key in keys:
             assert key in data[section], f'{section}.{key} missing'
+            assert data[section].get(key) == REQUIRED_MODULE_VALUES[section][key], (
+                f'{section}.{key} mismatch'
+            )
 
-    assert data['git_status'].get('stashed') == "📦", 'stashed icon mismatch'
-    assert data['status'].get('disabled') is False, '[status] should be enabled'
 
 def test_starship_multiline_format():
     data = load_starship()


### PR DESCRIPTION
### Motivation

- Provide a single source of truth for the Starship prompt format, module ordering, and expected module values so generator output, tests, and CI stay consistent.
- Make generation deterministic and fail-fast when the canonical prompt spec drifts so stale generated artifacts (including `dotfiles/shell/.config/starship.toml`) are detected early.

### Description

- Add canonical prompt contract in `scripts/helpers/starship_spec.py` including `REQUIRED_PROMPT_MODULES`, `MODULE_SETTINGS`, `REQUIRED_MODULE_KEYS`, and `REQUIRED_MODULE_VALUES` and keep `STARSHIP_PROMPT_FORMAT` as the canonical prompt format.
- Update `scripts/helpers/generate_palette_artifacts.py` to import the canonical spec and validate required Starship sections/keys via `_validate_required_starship_modules()` before rendering, so output is deterministic and generation fails if the spec is inconsistent.
- Refactor tests to consume the shared expectations in `tests/starship_expectations.py` by importing `REQUIRED_MODULE_KEYS`, `REQUIRED_MODULE_VALUES`, and `STARSHIP_PROMPT_FORMAT` instead of hardcoding values in individual tests.
- Add CI workflow steps to run the palette artifact generator in check mode (`python scripts/helpers/generate_palette_artifacts.py --check`) in both primary test jobs to fail CI if generated artifacts are out of date.

### Testing

- Ran `python scripts/helpers/generate_palette_artifacts.py --check`, which completed successfully and reported the artifacts are synchronized.
- Ran `ruff check` against the updated helper and test files (`scripts/helpers/starship_spec.py`, `scripts/helpers/generate_palette_artifacts.py`, `tests/starship_expectations.py`, `tests/test_starship.py`), and the checks passed.
- Ran `pytest tests/test_starship.py tests/test_starship_palette.py tests/test_palette_artifacts_sync.py -q`, and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90aaac42483269bc1ac7a79f824c4)