### PR TITLE
Policy-driven Neovim startup benchmark guardrails (host defaults + CI guardrail)

### DIFF
--- a/.github/workflows/nvim-startup-benchmark.yml
+++ b/.github/workflows/nvim-startup-benchmark.yml
@@ -23,3 +23,17 @@ jobs:
           name: nvim-startup-benchmark
           path: .cache/tino/nvim-startup/
           if-no-files-found: warn
+  threshold-guardrail:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Verify threshold guardrail path with stub Neovim
+        run: pytest tests/test_setup_nvim.py::test_setup_nvim_uses_profile_default_threshold_when_enabled
+

--- a/README.md
+++ b/README.md
@@ -236,7 +236,17 @@ Terminal profile values flow through one path:
 
 Standard bootstrap command (repo root):
 
-Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; provisioning is handled by `./scripts/setup-nvim.sh` (headless `Lazy! sync` + explicit Mason LSP installs, requires Neovim >= 0.8) so first interactive startup is deterministic. Intentional plugin upgrades should use `./scripts/setup-nvim.sh --refresh-lockfile` (runs `Lazy! update` + `Lazy! lock`, then lock coverage validation) and can be re-checked manually with `python scripts/check-nvim-lockfile.py`. Runtime self-healing is opt-in with `TINO_NVIM_AUTO_BOOTSTRAP=1` (default is disabled/offline-friendly), and `TINO_NVIM_OFFLINE=1` forces warning-only startup behavior. Startup benchmarking is available via `scripts/benchmark_nvim_startup.sh`; `scripts/setup-nvim.sh` runs it only when `TINO_NVIM_BENCHMARK_STARTUP=1` (desktop profile enables this by default during `install_common.sh`, constrained environments can opt out with `TINO_NVIM_BENCHMARK_STARTUP=0`). You can enforce a regression threshold with `TINO_NVIM_MAX_STARTUP_MS`.
+Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; provisioning is handled by `./scripts/setup-nvim.sh` (headless `Lazy! sync` + explicit Mason LSP installs, requires Neovim >= 0.8) so first interactive startup is deterministic. Intentional plugin upgrades should use `./scripts/setup-nvim.sh --refresh-lockfile` (runs `Lazy! update` + `Lazy! lock`, then lock coverage validation) and can be re-checked manually with `python scripts/check-nvim-lockfile.py`. Runtime self-healing is opt-in with `TINO_NVIM_AUTO_BOOTSTRAP=1` (default is disabled/offline-friendly), and `TINO_NVIM_OFFLINE=1` forces warning-only startup behavior. Startup benchmarking is available via `scripts/benchmark_nvim_startup.sh`; `scripts/setup-nvim.sh` runs it only when `TINO_NVIM_BENCHMARK_STARTUP=1` and now auto-passes `TINO_NVIM_MAX_STARTUP_MS` from either explicit env override or host profile defaults (`TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS`). Current SLO defaults are desktop=100ms and work_laptop=140ms.
+
+
+### Neovim startup SLO remediation workflow
+
+When a startup benchmark exceeds its threshold (`Startup regression detected`):
+
+1. Reproduce locally with `TINO_NVIM_BENCHMARK_STARTUP=1 ./scripts/setup-nvim.sh` and inspect `.cache/tino/nvim-startup/summary.txt` for top offenders.
+2. If regression is expected (intentional plugin/runtime upgrade), update host policy (`hosts/*/.config/tino/host-overrides.sh`) by adjusting `TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS` and document the rationale in the PR.
+3. If regression is unexpected, revert/optimize the offending plugin change, then rerun `./scripts/setup-nvim.sh` until the benchmark falls back under policy.
+4. Keep `TINO_NVIM_MAX_STARTUP_MS` for temporary strict overrides in CI or local diagnosis; host defaults remain the baseline guardrail.
 
 
 Lock refresh command (repo root):

--- a/hosts/desktop/.config/tino/host-overrides.sh
+++ b/hosts/desktop/.config/tino/host-overrides.sh
@@ -7,3 +7,6 @@ export TINO_TERMINAL_EFFECTS="high"
 # Host-only metadata.
 export TINO_HOST_PROFILE="desktop"
 export TINO_POWER_MODE="performance"
+
+# Neovim startup SLO guardrail defaults for this host profile.
+export TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS="100"

--- a/hosts/work_laptop/.config/tino/host-overrides.sh
+++ b/hosts/work_laptop/.config/tino/host-overrides.sh
@@ -7,3 +7,6 @@ export TINO_TERMINAL_EFFECTS="balanced"
 # Host-only metadata.
 export TINO_HOST_PROFILE="work_laptop"
 export TINO_POWER_MODE="balanced"
+
+# Neovim startup SLO guardrail defaults for this host profile.
+export TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS="140"

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -203,6 +203,29 @@ resolve_terminal_provider_from_config() {
     echo "$provider"
 }
 
+resolve_nvim_benchmark_threshold_from_config() {
+    local host_name="$1"
+    local host_override_path=""
+
+    if [[ -n "$host_name" ]]; then
+        host_override_path="$repo_root/hosts/$host_name/.config/tino/host-overrides.sh"
+        if [[ -f "$host_override_path" ]]; then
+            local host_threshold=""
+            local profile_default_threshold=""
+            host_threshold="$({ source "$host_override_path"; printf '%s' "${TINO_NVIM_MAX_STARTUP_MS:-}"; })"
+            profile_default_threshold="$({ source "$host_override_path"; printf '%s' "${TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS:-}"; })"
+            if [[ -n "$host_threshold" ]]; then
+                echo "$host_threshold"
+                return
+            fi
+            if [[ -n "$profile_default_threshold" ]]; then
+                echo "$profile_default_threshold"
+                return
+            fi
+        fi
+    fi
+}
+
 run_pwsh() {
     local script=$1
     shift
@@ -474,6 +497,12 @@ else
         setup_nvim_host="${host_override:-${resolved_host:-}}"
         if [[ -z "${TINO_NVIM_BENCHMARK_STARTUP:-}" && "$setup_nvim_host" == "desktop" ]]; then
             benchmark_env+=(TINO_NVIM_BENCHMARK_STARTUP=1)
+        fi
+        if [[ -z "${TINO_NVIM_MAX_STARTUP_MS:-}" ]]; then
+            resolved_nvim_threshold="$(resolve_nvim_benchmark_threshold_from_config "$setup_nvim_host")"
+            if [[ -n "$resolved_nvim_threshold" ]]; then
+                benchmark_env+=(TINO_NVIM_MAX_STARTUP_MS="$resolved_nvim_threshold")
+            fi
         fi
         run_cmd env "${benchmark_env[@]}" bash "$scripts/setup-nvim.sh"
     fi

--- a/scripts/setup-nvim.sh
+++ b/scripts/setup-nvim.sh
@@ -11,6 +11,7 @@ benchmark_script="$repo_root/scripts/benchmark_nvim_startup.sh"
 lockfile_check_script="$repo_root/scripts/check-nvim-lockfile.py"
 benchmark_startup="${TINO_NVIM_BENCHMARK_STARTUP:-0}"
 benchmark_threshold="${TINO_NVIM_MAX_STARTUP_MS:-}"
+benchmark_profile_default_threshold="${TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS:-}"
 refresh_lockfile=0
 
 for arg in "$@"; do
@@ -91,9 +92,14 @@ nvim --headless "+MasonInstall ${required_lsp_servers[*]}" +qa
 
 if [[ "$benchmark_startup" == "1" ]]; then
     if [[ -f "$benchmark_script" ]]; then
+        effective_benchmark_threshold="$benchmark_threshold"
+        if [[ -z "$effective_benchmark_threshold" && -n "$benchmark_profile_default_threshold" ]]; then
+            effective_benchmark_threshold="$benchmark_profile_default_threshold"
+        fi
+
         echo "Running startup benchmark (TINO_NVIM_BENCHMARK_STARTUP=1)..."
-        if [[ -n "$benchmark_threshold" ]]; then
-            TINO_NVIM_MAX_STARTUP_MS="$benchmark_threshold" bash "$benchmark_script"
+        if [[ -n "$effective_benchmark_threshold" ]]; then
+            TINO_NVIM_MAX_STARTUP_MS="$effective_benchmark_threshold" bash "$benchmark_script"
         else
             bash "$benchmark_script"
         fi

--- a/tests/test_install_common.py
+++ b/tests/test_install_common.py
@@ -843,12 +843,17 @@ def test_install_common_enables_nvim_benchmark_by_default_for_desktop_host(tmp_p
 
     setup_nvim_log = tmp_path / "setup_nvim_desktop.log"
     (scripts_dir / "setup-nvim.sh").write_text(
-        f"#!/usr/bin/env bash\nprintf '%s\\n' \"${{TINO_NVIM_BENCHMARK_STARTUP:-unset}}\" >> '{setup_nvim_log}'\n",
+        f"#!/usr/bin/env bash\nprintf '%s,%s\\n' \"${{TINO_NVIM_BENCHMARK_STARTUP:-unset}}\" \"${{TINO_NVIM_MAX_STARTUP_MS:-unset}}\" >> '{setup_nvim_log}'\n",
         encoding="utf-8",
     )
     (scripts_dir / "setup-nvim.sh").chmod(0o755)
 
     (repo / "hosts" / "desktop").mkdir(parents=True)
+    (repo / "hosts" / "desktop" / ".config" / "tino").mkdir(parents=True)
+    (repo / "hosts" / "desktop" / ".config" / "tino" / "host-overrides.sh").write_text(
+        "export TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS=\"100\"\n",
+        encoding="utf-8",
+    )
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -865,7 +870,7 @@ def test_install_common_enables_nvim_benchmark_by_default_for_desktop_host(tmp_p
 
     subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
 
-    assert setup_nvim_log.read_text(encoding="utf-8").splitlines() == ["1"]
+    assert setup_nvim_log.read_text(encoding="utf-8").splitlines() == ["1,100"]
 
 
 def test_install_common_respects_explicit_nvim_benchmark_disable(tmp_path: Path) -> None:

--- a/tests/test_setup_nvim.py
+++ b/tests/test_setup_nvim.py
@@ -168,6 +168,34 @@ def test_setup_nvim_benchmark_threshold_failure_bubbles_up(tmp_path: Path) -> No
     assert "Startup regression detected" in result.stderr
 
 
+def test_setup_nvim_uses_profile_default_threshold_when_enabled(tmp_path: Path) -> None:
+    script_path = REPO_ROOT / "scripts" / "setup-nvim.sh"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    create_exe(
+        bin_dir / "git",
+        "#!/usr/bin/env bash\nif [[ $1 == clone ]]; then\n  /bin/mkdir -p \"$5/.git\"\nfi\n",
+    )
+
+    create_fake_nvim(bin_dir / "nvim", startup_ms="8.750")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(tmp_path),
+            "TINO_NVIM_BENCHMARK_STARTUP": "1",
+            "TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS": "5",
+        }
+    )
+
+    result = subprocess.run(["/bin/bash", str(script_path)], env=env, text=True, capture_output=True, cwd=tmp_path)
+
+    assert result.returncode == 1
+    assert "Startup regression detected" in result.stderr
+
+
 def test_lazy_config_supports_auto_bootstrap_and_offline_modes() -> None:
     lazy_config = (REPO_ROOT / "dotfiles" / "nvim" / ".config" / "nvim" / "lua" / "config" / "lazy.lua").read_text(
         encoding="utf-8"


### PR DESCRIPTION
### Motivation

- Make optional Neovim startup benchmarking enforceable via policy-level host/profile defaults instead of ad-hoc env vars.
- Provide sane SLO defaults per host profile (desktop vs laptop) so teams can set baseline guardrails.
- Ensure `setup-nvim` automatically applies the effective threshold when benchmark mode is enabled and add CI coverage + remediation guidance for regressions.

### Description

- Add host/profile default SLO variables in host override files by exporting `TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS` in `hosts/desktop/.config/tino/host-overrides.sh` (100ms) and `hosts/work_laptop/.config/tino/host-overrides.sh` (140ms).
- Update `scripts/setup-nvim.sh` to compute an effective threshold (`explicit TINO_NVIM_MAX_STARTUP_MS` first, then fallback to `TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS`) and pass `TINO_NVIM_MAX_STARTUP_MS` into the benchmark invocation when present.
- Add `resolve_nvim_benchmark_threshold_from_config()` to `scripts/install_common.sh` and inject the resolved threshold into the `setup-nvim.sh` invocation when no explicit threshold is set by the caller.
- Add a CI guardrail job in `.github/workflows/nvim-startup-benchmark.yml` that runs a focused pytest against a stubbed Neovim to exercise the threshold-path.
- Update tests to cover the new behavior (`tests/test_setup_nvim.py` adds `test_setup_nvim_uses_profile_default_threshold_when_enabled` and `tests/test_install_common.py` updated to assert the injected threshold), and document the SLO + remediation workflow in `README.md`.

### Testing

- Ran `pytest tests/test_setup_nvim.py tests/test_install_common.py tests/test_benchmark_nvim_startup.py` and all tests passed (`31 passed`).
- Ran `ruff check tests/test_setup_nvim.py tests/test_install_common.py tests/test_benchmark_nvim_startup.py` and the Python linter checks passed.
- `shellcheck` was not available in the environment, so shell linting was not executed (recommend running `shellcheck scripts/setup-nvim.sh scripts/install_common.sh` in CI or locally).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a373b7008326b25df15650fa124e)