### PR TITLE
Document terminal provider capability matrix and emit machine-readable reports

### DIFF
--- a/docs/generated/terminal-capability-matrix.md
+++ b/docs/generated/terminal-capability-matrix.md
@@ -1,0 +1,7 @@
+| Provider | FPS | Opacity | Effects |
+| --- | --- | --- | --- |
+| ghostty | ✅ applied | ✅ applied | ✅ applied |
+| wezterm | ✅ applied | ✅ applied | ❌ unsupported |
+| kitty | ✅ applied | ✅ applied | ❌ unsupported |
+| alacritty | ❌ unsupported | ✅ applied | ❌ unsupported |
+| windows-terminal | ❌ unsupported | ✅ applied | ✅ applied |

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -142,6 +142,25 @@ For Ghostty, `scripts/setup-terminal-provider.sh ghostty` first checks for an ex
 
 Optional alternative: use Windows Terminal as your host terminal app while running Ghostty inside WSL for the managed Linux profile, or keep Windows Terminal-only settings for native PowerShell workflows.
 
+### Provider capability contract matrix
+
+Capability semantics are a first-class API exposed by `terminal_capability_status` in `dotfiles/terminal/.config/tino/terminal-profile.sh` and validated via `dotfiles/terminal/.config/tino/validate-renderer-contract.sh`.
+
+Regenerate both machine-readable and docs-friendly reports from the same capability table:
+
+```bash
+dotfiles/terminal/.config/tino/validate-renderer-contract.sh --report-format json --report-file .cache/tino/terminal-capability-report.json
+dotfiles/terminal/.config/tino/validate-renderer-contract.sh --report-format markdown --report-file docs/generated/terminal-capability-matrix.md
+```
+
+| Provider | FPS | Opacity | Effects |
+| --- | --- | --- | --- |
+| ghostty | ✅ applied | ✅ applied | ✅ applied |
+| wezterm | ✅ applied | ✅ applied | ❌ unsupported |
+| kitty | ✅ applied | ✅ applied | ❌ unsupported |
+| alacritty | ❌ unsupported | ✅ applied | ❌ unsupported |
+| windows-terminal | ❌ unsupported | ✅ applied | ✅ applied |
+
 
 Stow vs generated terminal files:
 

--- a/dotfiles/terminal/.config/tino/terminal-profile.sh
+++ b/dotfiles/terminal/.config/tino/terminal-profile.sh
@@ -26,6 +26,14 @@ readonly TINO_TERMINAL_PROVIDER_DEFAULT_ORDER=(
     alacritty
 )
 
+readonly TINO_TERMINAL_CONTRACT_PROVIDERS=(
+    ghostty
+    wezterm
+    kitty
+    alacritty
+    windows-terminal
+)
+
 terminal_provider_preferences() {
     local raw_preferences="${TINO_TERMINAL_PROVIDER_PREFERENCES:-}"
     local -a normalized=()

--- a/dotfiles/terminal/.config/tino/validate-renderer-contract.sh
+++ b/dotfiles/terminal/.config/tino/validate-renderer-contract.sh
@@ -1,6 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+report_format=""
+report_file=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --report-format)
+            report_format="${2:-}"
+            shift 2
+            ;;
+        --report-file)
+            report_file="${2:-}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -n "$report_format" ]]; then
+    case "$report_format" in
+        json|markdown)
+            ;;
+        *)
+            echo "Unsupported report format: $report_format (expected: json, markdown)" >&2
+            exit 1
+            ;;
+    esac
+fi
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 
 tmp_dir="$(mktemp -d)"
@@ -20,12 +51,11 @@ export TINO_TERMINAL_EFFECTS="/tmp/tino-shader.glsl"
 # shellcheck disable=SC1090
 source "$XDG_CONFIG_HOME/tino/terminal-profile.sh"
 
-providers=(ghostty wezterm kitty alacritty windows-terminal)
+providers=("${TINO_TERMINAL_CONTRACT_PROVIDERS[@]}")
 validation_repo_root="$tmp_dir/validation-repo"
 mkdir -p "$validation_repo_root"
 for provider in "${providers[@]}"; do
     "$XDG_CONFIG_HOME/tino/terminal-profile.sh" "$provider" "$validation_repo_root" >/dev/null
-
 done
 
 check_applied() {
@@ -96,6 +126,79 @@ check_unsupported() {
     esac
 }
 
+symbol_for_status() {
+    case "$1" in
+        applied)
+            printf '✅'
+            ;;
+        unsupported)
+            printf '❌'
+            ;;
+        *)
+            printf '❓'
+            ;;
+    esac
+}
+
+build_report() {
+    local format="$1"
+    local output
+
+    if [[ "$format" == "json" ]]; then
+        output="{\"providers\":["
+    else
+        output="| Provider | FPS | Opacity | Effects |\n| --- | --- | --- | --- |"
+    fi
+
+    local first_provider=1
+    local provider
+    for provider in "${providers[@]}"; do
+        if [[ "$format" == "json" ]]; then
+            if [[ $first_provider -eq 0 ]]; then
+                output+=","
+            fi
+            first_provider=0
+            output+="{\"name\":\"$provider\",\"capabilities\":{"
+        fi
+
+        local first_field=1
+        local field
+        local fps=""
+        local opacity=""
+        local effects=""
+
+        for field in "${TINO_TERMINAL_CONTRACT_FIELDS[@]}"; do
+            local status
+            status="$(terminal_capability_status "$provider" "$field")"
+            if [[ "$format" == "json" ]]; then
+                if [[ $first_field -eq 0 ]]; then
+                    output+=","
+                fi
+                first_field=0
+                output+="\"$field\":\"$status\""
+            else
+                case "$field" in
+                    TINO_TERMINAL_FPS) fps="$(symbol_for_status "$status") $status" ;;
+                    TINO_TERMINAL_OPACITY) opacity="$(symbol_for_status "$status") $status" ;;
+                    TINO_TERMINAL_EFFECTS) effects="$(symbol_for_status "$status") $status" ;;
+                esac
+            fi
+        done
+
+        if [[ "$format" == "json" ]]; then
+            output+="}}"
+        else
+            output+="\n| $provider | $fps | $opacity | $effects |"
+        fi
+    done
+
+    if [[ "$format" == "json" ]]; then
+        output+="]}"
+    fi
+
+    printf '%b\n' "$output"
+}
+
 for provider in "${providers[@]}"; do
     for field in "${TINO_TERMINAL_CONTRACT_FIELDS[@]}"; do
         status="$(terminal_capability_status "$provider" "$field")"
@@ -110,5 +213,15 @@ for provider in "${providers[@]}"; do
     done
 
 done
+
+if [[ -n "$report_format" ]]; then
+    report_payload="$(build_report "$report_format")"
+    if [[ -n "$report_file" ]]; then
+        mkdir -p "$(dirname "$report_file")"
+        printf '%s\n' "$report_payload" > "$report_file"
+    else
+        printf '%s\n' "$report_payload"
+    fi
+fi
 
 echo "Renderer contract validation passed for ${#providers[@]} providers."

--- a/tests/test_validate_renderer_contract.py
+++ b/tests/test_validate_renderer_contract.py
@@ -1,0 +1,54 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_validate_renderer_contract_emits_json_report(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    report_file = tmp_path / "renderer-contract.json"
+
+    subprocess.run(
+        [
+            "bash",
+            "dotfiles/terminal/.config/tino/validate-renderer-contract.sh",
+            "--report-format",
+            "json",
+            "--report-file",
+            str(report_file),
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    report = json.loads(report_file.read_text(encoding="utf-8"))
+    providers = {item["name"]: item["capabilities"] for item in report["providers"]}
+
+    assert providers["ghostty"]["TINO_TERMINAL_EFFECTS"] == "applied"
+    assert providers["wezterm"]["TINO_TERMINAL_EFFECTS"] == "unsupported"
+    assert providers["windows-terminal"]["TINO_TERMINAL_OPACITY"] == "applied"
+
+
+def test_validate_renderer_contract_emits_markdown_report(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    report_file = tmp_path / "renderer-contract.md"
+
+    subprocess.run(
+        [
+            "bash",
+            "dotfiles/terminal/.config/tino/validate-renderer-contract.sh",
+            "--report-format",
+            "markdown",
+            "--report-file",
+            str(report_file),
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    report = report_file.read_text(encoding="utf-8")
+    assert "| Provider | FPS | Opacity | Effects |" in report
+    assert "| windows-terminal | ❌ unsupported | ✅ applied | ✅ applied |" in report


### PR DESCRIPTION
### Motivation
- Make provider capability semantics a first-class API so docs, CI, and renderers share a single source-of-truth and avoid manual drift. 
- Provide machine-readable output for downstream consumers (docs/CI) and allow automated validation of renderer contract behavior. 

### Description
- Added a canonical provider list `TINO_TERMINAL_CONTRACT_PROVIDERS` to `dotfiles/terminal/.config/tino/terminal-profile.sh` (includes `windows-terminal`).
- Extended `dotfiles/terminal/.config/tino/validate-renderer-contract.sh` to accept `--report-format {json|markdown}` and `--report-file`, validate provider+field behavior, and emit JSON or Markdown capability matrices (implements `symbol_for_status` and `build_report`).
- Added a docs section to `docs/terminal.md` documenting capability semantics and regeneration commands and committed a generated artifact at `docs/generated/terminal-capability-matrix.md` produced by the validator.
- Added `tests/test_validate_renderer_contract.py` to assert JSON and Markdown report emission and expected capability entries.

### Testing
- Executed `bash dotfiles/terminal/.config/tino/validate-renderer-contract.sh` and it completed successfully and produced the matrix output.
- Installed test/dev dependencies and ran `pytest -q tests/test_validate_renderer_contract.py tests/test_setup_terminal_provider.py`, which passed (`10 passed`).
- Ran `ruff check tests/test_validate_renderer_contract.py` and it passed (`All checks passed!`).
- Attempted `shellcheck` on the shell scripts but `shellcheck` was not installed in the environment so linting could not be performed there.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a98c43b48326a471817581929f1f)