### PR TITLE
Add declarative bootstrap-dev-env orchestrator with plan/reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/terminal/.config/wezterm/wezterm.lua` → optional GPU-accelerated WezTerm profile aligned with shell/tmux colors
 - `dotfiles/terminal/.config/tino/ghostty.toml.tmpl` → authored Ghostty template (renderer input)
 - `dotfiles/terminal/.config/tino/renderers/*.sh` → provider renderers that generate concrete config files from the terminal profile contract
-- `scripts/install_common.sh` → standard bootstrap script; on macOS/Linux it installs dependencies (`zsh`, `starship`, `tmux`, `neovim`, `cargo`), runs `scripts/setup-nvim.sh` to provision Neovim plugin + Mason LSP assets (headless), runs `scripts/setup-terminal-provider.sh "$terminal_provider"` to install/configure the selected terminal provider and trigger profile rendering, and then calls `scripts/install_dotfiles.sh` so managed rc files/symlinks are deployed to the target user home. For Ghostty, install precedence remains: keep preinstalled binary if present, try native package manager (`brew`/`apt-get`/`dnf`/`pacman`) next, then fall back to `cargo install --locked ghostty`. It installs zsh plugins under `~/.local/share/zsh/plugins` and does not directly edit ad-hoc rc content (Windows skips Ghostty and keeps Windows Terminal flow).
+- `scripts/bootstrap-dev-env.sh` → primary declarative bootstrap workflow with auditable stages. It orchestrates dependency install planning, `scripts/install_dotfiles.sh`, `scripts/setup-nvim.sh`, `scripts/setup-terminal-provider.sh`, and renderer contract validation. It emits both JSON and human-readable reports (host overlay, provider chosen, versions, skipped steps) and supports `--plan` to print exact actions without mutating state.
+- `scripts/install_common.sh` → legacy/compatibility bootstrap script; still available for broader OS-specific automation and optional Windows provisioning flags.
 - `scripts/setup-terminal-provider.sh <provider>` → entry point for provider-specific setup/rendering (`ghostty|wezterm|kitty|alacritty|windows-terminal`) via `~/.config/tino/terminal-profile.sh`
 - `scripts/install_dotfiles.sh` → deploys managed dotfiles into the user target (for example `$HOME`) by writing tracked rc files/symlinks; `dotfiles/shell/.zshrc` is the source of truth for plugin sourcing and `starship init`.
 - `scripts/migrate-shell-config.sh` → optional one-time manual migration that imports compatible legacy `~/.bashrc` exports/aliases/functions into runtime fragments at `~/.config/zsh/{env,aliases,functions}.zsh` (or `$XDG_CONFIG_HOME/zsh/...`) after creating a timestamped backup; it does not edit tracked repository dotfiles and is not required for bootstrap.
@@ -267,7 +268,13 @@ Expected artifacts are written under `.cache/tino/nvim-startup/`:
 - `.cache/tino/nvim-startup/summary.txt`
 
 ```bash
-./scripts/install_common.sh
+./scripts/bootstrap-dev-env.sh
+```
+
+Preview-only plan mode:
+
+```bash
+./scripts/bootstrap-dev-env.sh --plan
 ```
 
 ## Changelog (auto‑updated)

--- a/scripts/bootstrap-dev-env.sh
+++ b/scripts/bootstrap-dev-env.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+scripts_dir="$repo_root/scripts"
+
+plan_mode=0
+host_overlay=""
+provider_override=""
+report_dir="${TINO_BOOTSTRAP_REPORT_DIR:-$repo_root/.cache/tino/bootstrap-dev-env}"
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") [--plan] [--host NAME] [--provider NAME] [--report-dir DIR]
+
+Declarative bootstrap for development environments with auditable stages.
+
+  --plan            Print exact actions without mutating state
+  --host NAME       Explicit host overlay passed to install_dotfiles.sh
+  --provider NAME   Terminal provider override (ghostty|wezterm|kitty|alacritty|windows-terminal)
+  --report-dir DIR  Output directory for reports (default: $report_dir)
+  -h, --help        Show this help message
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --plan)
+            plan_mode=1
+            shift
+            ;;
+        --host)
+            host_overlay="${2:-}"
+            shift 2
+            ;;
+        --provider)
+            provider_override="${2:-}"
+            shift 2
+            ;;
+        --report-dir)
+            report_dir="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+terminal_provider_supported() {
+    case "$1" in
+        ghostty|wezterm|kitty|alacritty|windows-terminal)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+resolve_host_overlay() {
+    local raw_host="$1"
+    local hosts_root="$repo_root/hosts"
+
+    [[ -z "$raw_host" ]] && return 0
+
+    local normalized_lower="${raw_host,,}"
+    local normalized_slug
+    normalized_slug="$(printf '%s' "$normalized_lower" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+    local short_host="${normalized_lower%%.*}"
+    local short_slug
+    short_slug="$(printf '%s' "$short_host" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+
+    local -a candidates=("$raw_host" "$normalized_lower" "$normalized_slug" "$short_host" "$short_slug")
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        [[ -z "$candidate" ]] && continue
+        if [[ -d "$hosts_root/$candidate" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+}
+
+resolve_provider() {
+    local resolved_host="$1"
+    local provider=""
+    local defaults_path="$repo_root/dotfiles/terminal/.config/tino/terminal-defaults.sh"
+    local host_override_path=""
+
+    if [[ -f "$defaults_path" ]]; then
+        # shellcheck disable=SC1090
+        source "$defaults_path"
+    fi
+
+    if [[ -n "$resolved_host" ]]; then
+        host_override_path="$repo_root/hosts/$resolved_host/.config/tino/host-overrides.sh"
+        if [[ -f "$host_override_path" ]]; then
+            # shellcheck disable=SC1090
+            source "$host_override_path"
+        fi
+    fi
+
+    provider="${provider_override:-${TINO_TERMINAL_PROVIDER:-}}"
+    if [[ -z "$provider" ]]; then
+        case "${OSTYPE:-}" in
+            msys*|cygwin*|win32*|windows*) provider="windows-terminal" ;;
+            *) provider="ghostty" ;;
+        esac
+    fi
+
+    if ! terminal_provider_supported "$provider"; then
+        echo "Error: unsupported provider '$provider'" >&2
+        exit 1
+    fi
+
+    printf '%s' "$provider"
+}
+
+version_of() {
+    local binary="$1"
+    if command -v "$binary" >/dev/null 2>&1; then
+        "$binary" --version 2>/dev/null | head -n1 || true
+    else
+        printf 'unavailable'
+    fi
+}
+
+json_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    printf '%s' "$value"
+}
+
+run_stage() {
+    local stage="$1"
+    local command="$2"
+
+    planned_actions+=("$stage::$command")
+
+    if [[ $plan_mode -eq 1 ]]; then
+        skipped_steps+=("$stage (plan mode)")
+        return 0
+    fi
+
+    eval "$command"
+}
+
+if [[ -z "$host_overlay" ]]; then
+    detected_host="$(hostname 2>/dev/null || true)"
+    host_overlay="$(resolve_host_overlay "$detected_host")"
+fi
+
+provider_chosen="$(resolve_provider "$host_overlay")"
+
+mkdir -p "$report_dir"
+json_report="$report_dir/bootstrap-summary.json"
+text_report="$report_dir/bootstrap-summary.txt"
+renderer_report="$report_dir/renderer-contract.json"
+
+planned_actions=()
+skipped_steps=()
+
+# Stages
+run_stage "dependency-install" "bash '$scripts_dir/install_common.sh' --dry-run --set-default-shell=skip --terminal '$provider_chosen'"
+
+dotfiles_cmd="bash '$scripts_dir/install_dotfiles.sh' --conflict=abort"
+if [[ -n "$host_overlay" ]]; then
+    dotfiles_cmd+=" --host '$host_overlay'"
+fi
+run_stage "install-dotfiles" "$dotfiles_cmd"
+
+run_stage "setup-nvim" "bash '$scripts_dir/setup-nvim.sh'"
+run_stage "setup-terminal-provider" "bash '$scripts_dir/setup-terminal-provider.sh' '$provider_chosen'"
+run_stage "renderer-contract-validation" "bash '$repo_root/dotfiles/terminal/.config/tino/validate-renderer-contract.sh' --report-format json --report-file '$renderer_report'"
+
+versions_keys=(bash python nvim stow)
+versions_values=("$(version_of bash)" "$(version_of python)" "$(version_of nvim)" "$(version_of stow)")
+provider_binary="$provider_chosen"
+if [[ "$provider_chosen" == "windows-terminal" ]]; then
+    provider_binary="python"
+fi
+provider_version="$(version_of "$provider_binary")"
+
+{
+    printf 'Bootstrap development environment summary\n'
+    printf '=====================================\n'
+    printf 'Mode: %s\n' "$( [[ $plan_mode -eq 1 ]] && echo 'plan' || echo 'apply' )"
+    printf 'Host overlay: %s\n' "${host_overlay:-none}"
+    printf 'Provider chosen: %s\n' "$provider_chosen"
+    printf 'Provider version: %s\n' "$provider_version"
+    printf '\nPlanned actions:\n'
+    for action in "${planned_actions[@]}"; do
+        printf '  - %s\n' "$action"
+    done
+    if [[ ${#skipped_steps[@]} -gt 0 ]]; then
+        printf '\nSkipped steps:\n'
+        for skip in "${skipped_steps[@]}"; do
+            printf '  - %s\n' "$skip"
+        done
+    fi
+    printf '\nVersions:\n'
+    for i in "${!versions_keys[@]}"; do
+        printf '  - %s: %s\n' "${versions_keys[$i]}" "${versions_values[$i]}"
+    done
+} > "$text_report"
+
+{
+    printf '{\n'
+    printf '  "mode": "%s",\n' "$( [[ $plan_mode -eq 1 ]] && echo 'plan' || echo 'apply' )"
+    printf '  "host_overlay": "%s",\n' "$(json_escape "${host_overlay:-none}")"
+    printf '  "provider_chosen": "%s",\n' "$(json_escape "$provider_chosen")"
+    printf '  "provider_version": "%s",\n' "$(json_escape "$provider_version")"
+    printf '  "planned_actions": [\n'
+    for i in "${!planned_actions[@]}"; do
+        comma=","
+        [[ $i -eq $((${#planned_actions[@]}-1)) ]] && comma=""
+        printf '    "%s"%s\n' "$(json_escape "${planned_actions[$i]}")" "$comma"
+    done
+    printf '  ],\n'
+    printf '  "skipped_steps": [\n'
+    for i in "${!skipped_steps[@]}"; do
+        comma=","
+        [[ $i -eq $((${#skipped_steps[@]}-1)) ]] && comma=""
+        printf '    "%s"%s\n' "$(json_escape "${skipped_steps[$i]}")" "$comma"
+    done
+    printf '  ],\n'
+    printf '  "versions": {\n'
+    for i in "${!versions_keys[@]}"; do
+        comma=","
+        [[ $i -eq $((${#versions_keys[@]}-1)) ]] && comma=""
+        printf '    "%s": "%s"%s\n' "$(json_escape "${versions_keys[$i]}")" "$(json_escape "${versions_values[$i]}")" "$comma"
+    done
+    printf '  }\n'
+    printf '}\n'
+} > "$json_report"
+
+cat "$text_report"
+echo "JSON report: $json_report"

--- a/tests/test_bootstrap_dev_env.py
+++ b/tests/test_bootstrap_dev_env.py
@@ -1,0 +1,96 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _copy_bootstrap_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shutil.copytree(REPO_ROOT / "scripts", repo / "scripts")
+    shutil.copytree(REPO_ROOT / "dotfiles", repo / "dotfiles")
+    return repo
+
+
+def _create_stub(path: Path, log_file: Path) -> None:
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo \"$(basename \"$0\"):$*\" >> '{log_file}'\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def test_bootstrap_dev_env_plan_mode_only_reports(tmp_path: Path) -> None:
+    repo = _copy_bootstrap_repo(tmp_path)
+    log_file = tmp_path / "calls.log"
+
+    _create_stub(repo / "scripts" / "install_common.sh", log_file)
+    _create_stub(repo / "scripts" / "install_dotfiles.sh", log_file)
+    _create_stub(repo / "scripts" / "setup-nvim.sh", log_file)
+    _create_stub(repo / "scripts" / "setup-terminal-provider.sh", log_file)
+    _create_stub(repo / "dotfiles" / "terminal" / ".config" / "tino" / "validate-renderer-contract.sh", log_file)
+
+    report_dir = tmp_path / "reports"
+    env = os.environ.copy()
+    env["PATH"] = f"/usr/bin:/bin:{env['PATH']}"
+
+    subprocess.run(
+        ["/bin/bash", str(repo / "scripts" / "bootstrap-dev-env.sh"), "--plan", "--report-dir", str(report_dir)],
+        check=True,
+        cwd=repo,
+        env=env,
+    )
+
+    assert not log_file.exists()
+
+    payload = json.loads((report_dir / "bootstrap-summary.json").read_text(encoding="utf-8"))
+    assert payload["mode"] == "plan"
+    assert any("dependency-install" in item for item in payload["planned_actions"])
+    assert len(payload["skipped_steps"]) == 5
+
+
+def test_bootstrap_dev_env_apply_runs_all_stages(tmp_path: Path) -> None:
+    repo = _copy_bootstrap_repo(tmp_path)
+    log_file = tmp_path / "calls.log"
+
+    _create_stub(repo / "scripts" / "install_common.sh", log_file)
+    _create_stub(repo / "scripts" / "install_dotfiles.sh", log_file)
+    _create_stub(repo / "scripts" / "setup-nvim.sh", log_file)
+    _create_stub(repo / "scripts" / "setup-terminal-provider.sh", log_file)
+    _create_stub(repo / "dotfiles" / "terminal" / ".config" / "tino" / "validate-renderer-contract.sh", log_file)
+
+    report_dir = tmp_path / "reports"
+
+    subprocess.run(
+        [
+            "/bin/bash",
+            str(repo / "scripts" / "bootstrap-dev-env.sh"),
+            "--provider",
+            "wezterm",
+            "--host",
+            "desktop",
+            "--report-dir",
+            str(report_dir),
+        ],
+        check=True,
+        cwd=repo,
+    )
+
+    calls = log_file.read_text(encoding="utf-8")
+    assert "install_common.sh:--dry-run --set-default-shell=skip --terminal wezterm" in calls
+    assert "install_dotfiles.sh:--conflict=abort --host desktop" in calls
+    assert "setup-nvim.sh:" in calls
+    assert "setup-terminal-provider.sh:wezterm" in calls
+    assert "validate-renderer-contract.sh:--report-format json" in calls
+
+    payload = json.loads((report_dir / "bootstrap-summary.json").read_text(encoding="utf-8"))
+    assert payload["mode"] == "apply"
+    assert payload["host_overlay"] == "desktop"
+    assert payload["provider_chosen"] == "wezterm"
+    assert payload["skipped_steps"] == []


### PR DESCRIPTION
### Motivation

- Provide a single, declarative, replayable bootstrap entrypoint that sequences common setup stages and produces an auditable record of actions and decisions. 
- Allow safe previewing of the exact actions before mutating state via a `--plan` mode so CI/maintainers can review and replay deterministic steps. 

### Description

- Add `scripts/bootstrap-dev-env.sh` which orchestrates staged setup (dependency install planning, `install_dotfiles.sh`, `setup-nvim.sh`, `setup-terminal-provider.sh`, and renderer contract validation) and resolves host overlays and provider choice. 
- Implement `--plan` mode and emit both JSON and human-readable summary reports that include host overlay, provider chosen, versions, planned actions, and skipped steps. 
- Add tests at `tests/test_bootstrap_dev_env.py` that verify plan mode is non-mutating and apply mode invokes all stages and generates the expected report entries. 
- Update `README.md` to make `scripts/bootstrap-dev-env.sh` the primary setup path and document plan usage.

### Testing

- Ran shell validation with `bash -n scripts/bootstrap-dev-env.sh` which succeeded. 
- Ran `pytest -q tests/test_bootstrap_dev_env.py tests/test_validate_renderer_contract.py tests/test_setup_terminal_provider.py` after installing dev requirements with `python -m pip install -r requirements-dev.txt`, and all tests passed (`12 passed, 1 warning`). 
- Ran linter checks with `ruff check tests/test_bootstrap_dev_env.py` which passed. 
- Executed `./scripts/bootstrap-dev-env.sh --plan --report-dir /tmp/tino-bootstrap-report-test` to confirm plan-mode output and report file generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9acb8958c83269b935b7472936d4c)