### PR TITLE
Optimize Neovim setup to avoid unnecessary sync/install work

### DIFF
--- a/scripts/setup-nvim.sh
+++ b/scripts/setup-nvim.sh
@@ -14,6 +14,65 @@ benchmark_threshold="${TINO_NVIM_MAX_STARTUP_MS:-}"
 benchmark_profile_default_threshold="${TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS:-}"
 refresh_lockfile=0
 
+lazy_lock_and_plugins_in_sync() {
+    local sync_check
+    sync_check="$(nvim --headless +'lua <<"EOF"\
+local ok_config, config = pcall(require, "lazy.core.config")\
+local ok_lock, lock = pcall(require, "lazy.core.lock")\
+if not (ok_config and ok_lock) then\
+  vim.cmd("cquit 1")\
+end\
+\
+local locked = lock.load()\
+if type(locked) ~= "table" then\
+  vim.cmd("cquit 1")\
+end\
+\
+for name, plugin in pairs(config.plugins) do\
+  if plugin._ and plugin._.installed and not locked[name] then\
+    vim.cmd("cquit 1")\
+  end\
+end\
+\
+for name, pin in pairs(locked) do\
+  local plugin = config.plugins[name]\
+  if not plugin or vim.fn.isdirectory(plugin.dir) == 0 then\
+    vim.cmd("cquit 1")\
+  end\
+\
+  local head = vim.fn.system({ "git", "-C", plugin.dir, "rev-parse", "HEAD" })\
+  if vim.v.shell_error ~= 0 then\
+    vim.cmd("cquit 1")\
+  end\
+\
+  head = (head:gsub("%s+", ""))\
+  if pin.commit ~= head then\
+    vim.cmd("cquit 1")\
+  end\
+end\
+\
+print("in-sync")\
+vim.cmd("qa!")\
+EOF' +qa 2>/dev/null || true)"
+
+    [[ "$sync_check" == *"in-sync"* ]]
+}
+
+get_installed_mason_servers() {
+    nvim --headless +'lua <<"EOF"\
+local ok_registry, registry = pcall(require, "mason-registry")\
+if not ok_registry then\
+  vim.cmd("cquit 1")\
+end\
+\
+for _, package in ipairs(registry.get_installed_packages()) do\
+  print(package.name)\
+end\
+\
+vim.cmd("qa!")\
+EOF' +qa
+}
+
 for arg in "$@"; do
     case "$arg" in
         --refresh-lockfile)
@@ -83,12 +142,38 @@ if [[ "$refresh_lockfile" == "1" ]]; then
     fi
     echo "Lockfile refresh complete. Commit dotfiles/nvim/.config/nvim/lazy-lock.json for deterministic installs."
 else
-    echo "Syncing Neovim plugins (headless)..."
-    nvim --headless "+Lazy! sync" +qa
+    if lazy_lock_and_plugins_in_sync; then
+        echo "Neovim plugins already match lazy-lock.json; skipping plugin sync."
+    else
+        echo "Plugin state differs from lazy-lock.json; restoring pinned plugin state (headless)..."
+        nvim --headless "+Lazy! restore" +qa
+    fi
 fi
 
-echo "Installing Mason LSP servers (headless): ${required_lsp_servers[*]}"
-nvim --headless "+MasonInstall ${required_lsp_servers[*]}" +qa
+declare -a installed_mason_servers=()
+if mapfile -t installed_mason_servers < <(get_installed_mason_servers); then
+    declare -A installed_mason_set=()
+    for server in "${installed_mason_servers[@]}"; do
+        installed_mason_set["$server"]=1
+    done
+
+    missing_lsp_servers=()
+    for server in "${required_lsp_servers[@]}"; do
+        if [[ -z "${installed_mason_set[$server]+x}" ]]; then
+            missing_lsp_servers+=("$server")
+        fi
+    done
+else
+    echo "Warning: could not query installed Mason packages; installing the canonical server set." >&2
+    missing_lsp_servers=("${required_lsp_servers[@]}")
+fi
+
+if [[ ${#missing_lsp_servers[@]} -eq 0 ]]; then
+    echo "All Mason LSP servers from lsp_servers.txt are already installed; skipping MasonInstall."
+else
+    echo "Installing missing Mason LSP servers (headless): ${missing_lsp_servers[*]}"
+    nvim --headless "+MasonInstall ${missing_lsp_servers[*]}" +qa
+fi
 
 if [[ "$benchmark_startup" == "1" ]]; then
     if [[ -f "$benchmark_script" ]]; then


### PR DESCRIPTION
### Motivation
- Reduce repeated network and install work during Neovim provisioning by skipping full plugin sync when local state already matches the deterministic `lazy-lock.json` file. 
- Avoid reinstalling already-present Mason LSP servers by only installing missing servers declared in `dotfiles/nvim/.config/nvim/lsp_servers.txt`.
- Preserve the explicit upgrade workflow which uses `--refresh-lockfile` to intentionally update plugins and regenerate the lockfile.

### Description
- Add `lazy_lock_and_plugins_in_sync()` which runs a headless `nvim` Lua check of `lazy.core.config` and `lazy.core.lock` to validate lockfile coverage, plugin presence, and that checked-out HEADs match pinned commits, returning early if everything is already in sync.
- When not using `--refresh-lockfile`, skip `Lazy! sync` and either skip plugin actions if in-sync or run `Lazy! restore` (pinned state) when drift is detected, keeping lockfile determinism.
- Add `get_installed_mason_servers()` that queries `mason-registry` from headless `nvim`, compare installed servers to `lsp_servers.txt`, and run `MasonInstall` only for the missing servers with a fallback to install the canonical list if the registry cannot be queried.
- Keep `--refresh-lockfile` behavior unchanged (still runs `nvim --headless "+Lazy! update" "+Lazy! lock" +qa` and invokes the existing lockfile coverage checker script when present).

### Testing
- Ran a shell syntax check with `bash -n scripts/setup-nvim.sh` which succeeded.
- Attempted to run `shellcheck scripts/setup-nvim.sh` but `shellcheck` is not installed in this environment so that linter step was skipped with a warning.
- The updated script was committed and basic repository checks (script parse and commit) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0454f0b48326b3622d472415149a)