### PR TITLE
Add one-time zsh plugin missing hints

### DIFF
--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -10,6 +10,38 @@ source_if_readable() {
     fi
 }
 
+tino_warn_missing_zsh_plugin_once() {
+    local plugin_name="$1"
+    local plugin_entrypoint="$2"
+    local plugin_repo_url="$3"
+
+    if [[ -r "$plugin_entrypoint" ]]; then
+        return
+    fi
+
+    local warn_stamp="${XDG_CACHE_HOME:-$HOME/.cache}/d0ttino/zsh-${plugin_name}-missing-hint-shown"
+    if [[ -f "$warn_stamp" ]]; then
+        return
+    fi
+
+    mkdir -p "$(dirname "$warn_stamp")"
+
+    local install_common_script=""
+    if [[ -n "${D0TTINO_REPO_ROOT:-}" && -f "${D0TTINO_REPO_ROOT}/scripts/install_common.sh" ]]; then
+        install_common_script="${D0TTINO_REPO_ROOT}/scripts/install_common.sh"
+    elif [[ -f "$HOME/.local/share/d0ttino/scripts/install_common.sh" ]]; then
+        install_common_script="$HOME/.local/share/d0ttino/scripts/install_common.sh"
+    fi
+
+    if [[ -n "$install_common_script" ]]; then
+        printf 'Warning: zsh plugin "%s" is missing (%s). Run: %s\n' "$plugin_name" "$plugin_entrypoint" "$install_common_script" >&2
+    else
+        printf 'Warning: zsh plugin "%s" is missing (%s). Run: git clone --depth 1 %s %s\n' "$plugin_name" "$plugin_entrypoint" "$plugin_repo_url" "$ZSH_PLUGIN_DIR/$plugin_name" >&2
+    fi
+
+    : > "$warn_stamp"
+}
+
 TINO_ZSH_STARTUP_BUDGET_WARM_MS="${TINO_ZSH_STARTUP_BUDGET_WARM_MS:-80}"
 TINO_ZSH_STARTUP_BUDGET_COLD_MS="${TINO_ZSH_STARTUP_BUDGET_COLD_MS:-150}"
 
@@ -104,10 +136,18 @@ if command -v starship >/dev/null; then
     eval "$(starship init zsh)"
 fi
 
+tino_warn_missing_zsh_plugin_once \
+    "zsh-autosuggestions" \
+    "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh" \
+    "https://github.com/zsh-users/zsh-autosuggestions"
 source_if_readable "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
 
 # Keep syntax-highlighting as the final Phase-1 interactive enhancement so
 # it can wrap widgets defined by prompt/plugins and reduce ordering surprises.
+tino_warn_missing_zsh_plugin_once \
+    "zsh-syntax-highlighting" \
+    "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" \
+    "https://github.com/zsh-users/zsh-syntax-highlighting"
 source_if_readable "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 # Phase 2: deferred non-critical/non-prompt startup path.


### PR DESCRIPTION
### Motivation
- Ensure users get a clear, one-time hint when common zsh plugin entrypoints are missing so they can remediate quickly. 
- Keep interactive startup fast and non-blocking by avoiding network or heavy work during shell initialization.

### Description
- Add `tino_warn_missing_zsh_plugin_once` to `dotfiles/shell/.zshrc` to test plugin entrypoint readability and emit a cache-stamped one-time warning under `${XDG_CACHE_HOME:-$HOME/.cache}/d0ttino/`.
- Prefer to suggest the local `scripts/install_common.sh` remediation when available, otherwise print an explicit `git clone --depth 1 <repo> <dest>` command. 
- Invoke this helper before sourcing `zsh-autosuggestions` and `zsh-syntax-highlighting` so warnings appear without blocking or performing installs.

### Testing
- Ran `zsh -n dotfiles/shell/.zshrc` to syntax-check the file but it could not run because `zsh` is not installed in the container (test failed due to missing tool).
- Ran `shellcheck dotfiles/shell/.zshrc` for linting but it could not run because `shellcheck` is not installed in the container (test failed due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab093cbdec8326a5cd319d5dbf8ba8)