### PR TITLE
Persist resolved terminal provider when fallback occurs

### DIFF
--- a/scripts/setup-terminal-provider.sh
+++ b/scripts/setup-terminal-provider.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 provider="${1:-}"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 strict_mode="${TINO_TERMINAL_STRICT:-1}"
+persist_fallback_mode="${TINO_TERMINAL_PERSIST_FALLBACK:-0}"
 selected_provider="$provider"
 readonly TERMINAL_CAPABILITY_PROBE_ORDER=(ghostty wezterm kitty alacritty)
 
@@ -173,6 +174,59 @@ resolve_provider_via_capability_probe() {
     return 1
 }
 
+upsert_host_override_provider() {
+    local override_path="$1"
+    local persisted_provider="$2"
+
+    mkdir -p "$(dirname "$override_path")"
+
+    if [[ ! -f "$override_path" ]]; then
+        printf '# Host-specific overrides for tino.\n' >"$override_path"
+    fi
+
+    if rg -q '^export TINO_TERMINAL_PROVIDER=' "$override_path"; then
+        python - "$override_path" "$persisted_provider" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+provider = sys.argv[2]
+lines = path.read_text(encoding="utf-8").splitlines()
+updated = []
+for line in lines:
+    if line.startswith("export TINO_TERMINAL_PROVIDER="):
+        updated.append(f'export TINO_TERMINAL_PROVIDER="{provider}"')
+    else:
+        updated.append(line)
+path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+PY
+        return
+    fi
+
+    if [[ -s "$override_path" ]]; then
+        printf '\n' >>"$override_path"
+    fi
+    printf 'export TINO_TERMINAL_PROVIDER="%s"\n' "$persisted_provider" >>"$override_path"
+}
+
+handle_persisted_fallback_provider() {
+    local requested_provider="$1"
+    local fallback_provider="$2"
+    local host_override_path="$XDG_CONFIG_TINO_DIR/host-overrides.sh"
+
+    if [[ "$persist_fallback_mode" == "1" ]]; then
+        upsert_host_override_provider "$host_override_path" "$fallback_provider"
+        echo "Persisted fallback provider in $host_override_path: $requested_provider -> $fallback_provider" >&2
+        return
+    fi
+
+    if [[ "$persist_fallback_mode" == "print" ]]; then
+        echo "Fallback provider detected ($requested_provider -> $fallback_provider). Persist with:" >&2
+        echo "  export TINO_TERMINAL_PROVIDER=\"$fallback_provider\"" >&2
+        echo "Then add/update that line in $host_override_path for deterministic future sessions." >&2
+    fi
+}
+
 ensure_provider_installed() {
     if [[ "$provider" == "windows-terminal" ]]; then
         return
@@ -189,6 +243,7 @@ ensure_provider_installed() {
         selected_provider="$fallback_provider"
         if [[ "$selected_provider" != "$provider" ]]; then
             echo "Warning: preferred provider '$provider' is unavailable; using '$selected_provider' based on capability probe." >&2
+            handle_persisted_fallback_provider "$provider" "$selected_provider"
         fi
         return
     fi
@@ -213,6 +268,7 @@ validate_windows_terminal_inputs() {
 }
 
 profile_script="${XDG_CONFIG_HOME:-$HOME/.config}/tino/terminal-profile.sh"
+XDG_CONFIG_TINO_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/tino"
 if [[ ! -x "$profile_script" ]]; then
     echo "Error: missing terminal profile contract at $profile_script" >&2
     exit 1

--- a/tests/test_setup_terminal_provider.py
+++ b/tests/test_setup_terminal_provider.py
@@ -19,6 +19,11 @@ def _create_minimal_bin(tmp_path: Path, *, include_kitty: bool = False) -> Path:
     (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
     (bin_dir / "bash").symlink_to("/bin/bash")
 
+    for optional_tool in ("mkdir", "python", "python3", "rg"):
+        tool_path = shutil.which(optional_tool)
+        if tool_path:
+            (bin_dir / optional_tool).symlink_to(tool_path)
+
     if include_kitty:
         kitty = bin_dir / "kitty"
         kitty.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
@@ -272,3 +277,76 @@ def test_setup_terminal_provider_uses_preference_env_for_fallback_order(tmp_path
 
     assert render_log.read_text().strip() == "alacritty " + str(repo)
     assert "Terminal provider configured: alacritty" in result.stdout
+
+
+def test_setup_terminal_provider_persists_fallback_provider_when_enabled(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    render_log = tmp_path / "render.log"
+    xdg_config_home = _create_terminal_profile(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        f"echo \"$@\" > '{render_log}'\n",
+    )
+    bin_dir = _create_minimal_bin(tmp_path, include_kitty=True)
+    host_overrides = xdg_config_home / "tino" / "host-overrides.sh"
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "XDG_CONFIG_HOME": str(xdg_config_home),
+            "PATH": str(bin_dir),
+            "TINO_TERMINAL_PERSIST_FALLBACK": "1",
+        }
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "ghostty"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert render_log.read_text().strip() == "kitty " + str(repo)
+    assert 'export TINO_TERMINAL_PROVIDER="kitty"' in host_overrides.read_text(encoding="utf-8")
+    assert "Persisted fallback provider" in output
+
+
+def test_setup_terminal_provider_prints_persist_instructions_when_requested(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    xdg_config_home = _create_terminal_profile(tmp_path)
+    bin_dir = _create_minimal_bin(tmp_path, include_kitty=True)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "XDG_CONFIG_HOME": str(xdg_config_home),
+            "PATH": str(bin_dir),
+            "TINO_TERMINAL_PERSIST_FALLBACK": "print",
+        }
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "ghostty"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert "Fallback provider detected (ghostty -> kitty). Persist with:" in output
+    assert 'export TINO_TERMINAL_PROVIDER="kitty"' in output


### PR DESCRIPTION
### Motivation
- Make terminal provider selection deterministic by persisting a resolved fallback into host overrides when the requested provider is unavailable.
- Reduce repeated fallback churn across sessions by recording the effective `TINO_TERMINAL_PROVIDER` so subsequent runs honor the persisted choice.

### Description
- Add `TINO_TERMINAL_PERSIST_FALLBACK` handling to `scripts/setup-terminal-provider.sh` with modes `1` (persist) and `print` (emit exact export instruction). 
- Implement `upsert_host_override_provider()` to create/update `~/.config/tino/host-overrides.sh` and `handle_persisted_fallback_provider()` to wire persistence/printing when a fallback is detected. 
- Expose `XDG_CONFIG_TINO_DIR` and call the persistence helper when `selected_provider != requested_provider`. 
- Add tests in `tests/test_setup_terminal_provider.py` to cover persistence and instruction-printing modes and update the test helper `_create_minimal_bin()` to symlink minimal external tools (`mkdir`, `python`, `python3`, `rg`) when available.

### Testing
- Ran shell syntax check: `bash -n scripts/setup-terminal-provider.sh` which succeeded. 
- Ran targeted unit tests: `python -m pytest tests/test_setup_terminal_provider.py` which completed with all tests passing (10 passed).
- Verified changes were committed as part of the PR branch and include updates to `scripts/setup-terminal-provider.sh` and `tests/test_setup_terminal_provider.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0b49952c8326b65943da79c2b766)