### PR TITLE
Remove Oh My Posh from winget manifest and standardize Starship-only prompt docs

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -20,6 +20,14 @@ The terminal experience is composed of four layers:
 1. **Shell (`zsh`)**
    - Interactive runtime entrypoint from managed dotfiles.
    - Loads shared defaults and optional host overrides.
+   - Prompt initialization is Starship-only via `starship init ...`.
+
+### Prompt configuration source of truth
+
+- `dotfiles/shell/.config/starship.toml` is the single prompt configuration source for all supported shells.
+- `dotfiles/shell/.zshrc` owns the zsh prompt bootstrap (`eval "$(starship init zsh)"`).
+- `powershell/user_profile.ps1` owns the PowerShell prompt bootstrap (`starship init powershell`) and points `STARSHIP_CONFIG` at the tracked Starship config.
+- Keep prompt behavior Starship-only across managed shell profiles.
 
 2. **Multiplexer (`tmux`)**
    - Stable session management and keybinding layer.

--- a/winget-packages.json
+++ b/winget-packages.json
@@ -46,9 +46,6 @@
 					"PackageIdentifier" : "RARLab.WinRAR"
 				},
 				{
-					"PackageIdentifier" : "JanDeDobbeleer.OhMyPosh"
-				},
-				{
 					"PackageIdentifier" : "Microsoft.VCRedist.2010.x64"
 				},
 				{


### PR DESCRIPTION
### Motivation

- Remove Oh My Posh package from the Windows package manifest so the bootstrap flow does not install multiple prompt engines.
- Make Starship the single-source-of-truth for prompt configuration across shells and PowerShell to avoid duplication and configuration drift.
- Document the canonical prompt bootstrap locations so maintainer/installer guidance is explicit and discoverable.

### Description

- Deleted the `JanDeDobbeleer.OhMyPosh` entry from `winget-packages.json` so the manifest will no longer install Oh My Posh.
- Added a `Prompt configuration source of truth` section to `docs/terminal.md` that declares `dotfiles/shell/.config/starship.toml` as the canonical prompt config and documents how `dotfiles/shell/.zshrc` and `powershell/user_profile.ps1` bootstrap Starship.
- Ensured the documentation explicitly states that prompt behavior is Starship-only and that Oh My Posh should not be added to managed shell profiles.

### Testing

- Validated the updated manifest JSON with `python -m json.tool winget-packages.json` which succeeded.
- Ran `pytest -q tests/test_powershell.py tests/test_install_common.py tests/test_migrate_shell_config.py` after installing required test dependencies, and the test suite passed with `34 passed`.
- Verified there are no remaining Oh My Posh references via a repository search for the removed identifiers which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c8d554bc832686872bdc3c9d212b)