### PR TITLE
Resolve QA Neovim startup threshold from host profile (desktop=100ms, work_laptop=140ms)

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -89,6 +89,17 @@ For any shell/tmux/nvim/terminal-profile config change, run the canonical accept
 
 The gate emits a human-readable summary to stdout and a machine-readable JSON report at `.cache/tino/qa-terminal-modernization/report.json` for CI ingestion.
 
+Neovim startup threshold resolution in `qa_terminal_modernization.sh` is deterministic:
+
+1. `TINO_QA_NVIM_MAX_STARTUP_MS` (QA-only hard override)
+2. `TINO_NVIM_MAX_STARTUP_MS` (global benchmark override)
+3. Host profile default from `hosts/<profile>/.config/tino/host-overrides.sh`
+   - desktop profile default: `100ms`
+   - work_laptop profile default: `140ms`
+4. Fallback baseline when no host profile is detected: `100ms`
+
+Use `TINO_NVIM_MAX_STARTUP_MS` to temporarily tighten or relax the startup SLO without editing host profiles.
+
 ### 1) Startup timing
 
 - Run warm-start timing checks for interactive shell startup.

--- a/scripts/qa_terminal_modernization.sh
+++ b/scripts/qa_terminal_modernization.sh
@@ -5,7 +5,72 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 report_dir="${TINO_QA_REPORT_DIR:-$repo_root/.cache/tino/qa-terminal-modernization}"
 json_report="${TINO_QA_JSON_REPORT:-$report_dir/report.json}"
 renderer_json_report="${TINO_QA_RENDERER_JSON_REPORT:-$report_dir/renderer-contract.json}"
-benchmark_threshold="${TINO_QA_NVIM_MAX_STARTUP_MS:-${TINO_NVIM_MAX_STARTUP_MS:-250}}"
+
+resolve_host_overlay() {
+    local hosts_root="$1"
+    local raw_host="$2"
+
+    if [[ -z "$raw_host" ]]; then
+        return
+    fi
+
+    local normalized_lower="${raw_host,,}"
+    local normalized_slug
+    normalized_slug="$(printf '%s' "$normalized_lower" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+    local short_host="${normalized_lower%%.*}"
+    local short_slug
+    short_slug="$(printf '%s' "$short_host" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+
+    local -a candidates=(
+        "$raw_host"
+        "$normalized_lower"
+        "$normalized_slug"
+        "$short_host"
+        "$short_slug"
+    )
+
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        [[ -z "$candidate" ]] && continue
+        if [[ -d "$hosts_root/$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return
+        fi
+    done
+}
+
+resolve_benchmark_threshold() {
+    local default_threshold="100"
+    local selected_host="${TINO_HOST_PROFILE:-}"
+
+    if [[ -z "$selected_host" ]]; then
+        local detected_host
+        detected_host="$(hostname 2>/dev/null || true)"
+        selected_host="$(resolve_host_overlay "$repo_root/hosts" "$detected_host")"
+    fi
+
+    if [[ -n "$selected_host" ]]; then
+        local host_override_path="$repo_root/hosts/$selected_host/.config/tino/host-overrides.sh"
+        if [[ -f "$host_override_path" ]]; then
+            local host_threshold=""
+            local profile_default_threshold=""
+            host_threshold="$({ source "$host_override_path"; printf '%s' "${TINO_NVIM_MAX_STARTUP_MS:-}"; })"
+            profile_default_threshold="$({ source "$host_override_path"; printf '%s' "${TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS:-}"; })"
+            if [[ -n "$host_threshold" ]]; then
+                printf '%s\n' "$host_threshold"
+                return
+            fi
+            if [[ -n "$profile_default_threshold" ]]; then
+                printf '%s\n' "$profile_default_threshold"
+                return
+            fi
+        fi
+    fi
+
+    printf '%s\n' "$default_threshold"
+}
+
+benchmark_threshold="${TINO_QA_NVIM_MAX_STARTUP_MS:-${TINO_NVIM_MAX_STARTUP_MS:-$(resolve_benchmark_threshold)}}"
 
 mkdir -p "$report_dir"
 


### PR DESCRIPTION
### Motivation

- Lower the default Neovim startup benchmark to desktop expectations and make QA threshold selection automatic by host profile.
- Prefer host-provided SLOs so laptop/desktop ergonomics (battery vs visuals) influence the QA gate without manual edits.
- Preserve existing override priorities so CI/QA can still force a value when needed.

### Description

- Update `scripts/qa_terminal_modernization.sh` to add `resolve_host_overlay` and `resolve_benchmark_threshold` helpers and to compute `benchmark_threshold` using the precedence `TINO_QA_NVIM_MAX_STARTUP_MS` → `TINO_NVIM_MAX_STARTUP_MS` → host profile values → fallback `100` ms. 
- Host profile values are read from `hosts/<profile>/.config/tino/host-overrides.sh` (looks for `TINO_NVIM_MAX_STARTUP_MS` and `TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS`).
- Set fallback baseline to `100ms` and use host defaults for documented profiles (`desktop` → `100ms`, `work_laptop` → `140ms`).
- Update `docs/terminal.md` validation checklist to document the exact threshold resolution order and mention `TINO_NVIM_MAX_STARTUP_MS` as an override mechanism.

### Testing

- Ran `bash -n scripts/qa_terminal_modernization.sh` to validate syntax, which succeeded. 
- Executed `./scripts/qa_terminal_modernization.sh`, which completed and emitted a summary (overall status `warn` because host environment lacked `nvim`, `tmux`, and `starship` binaries, so related checks were skipped). 
- Verified host-selection behavior with `TINO_HOST_PROFILE=work_laptop ./scripts/qa_terminal_modernization.sh` which reported the Neovim startup threshold as `140 ms` as expected. 
- Verified override precedence by running `TINO_HOST_PROFILE=work_laptop TINO_NVIM_MAX_STARTUP_MS=123 ./scripts/qa_terminal_modernization.sh` and `TINO_HOST_PROFILE=work_laptop TINO_NVIM_MAX_STARTUP_MS=123 TINO_QA_NVIM_MAX_STARTUP_MS=111 ./scripts/qa_terminal_modernization.sh`, which printed the threshold values `123 ms` and `111 ms` respectively, demonstrating correct precedence handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ca92dd7883268e453f127d199e1b)