### PR TITLE
Define canonical terminal provider policy with deterministic fallback and QA guard

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -41,6 +41,20 @@ The terminal experience is composed of four layers:
    - Provider-specific setup/rendering is routed through one script.
    - Shared profile defaults are interpreted through renderer capability contracts.
 
+### Canonical provider policy
+
+Provider defaults are policy-driven and deterministic:
+
+- **Linux/macOS desktop hosts:** canonical provider is **Ghostty**.
+- **Windows hosts:** canonical provider is **Windows Terminal**.
+- **WezTerm, Kitty, and Alacritty** are supported as **fallback/compatibility targets** when the canonical provider is unavailable or when explicitly requested.
+
+Implementation details:
+
+- `dotfiles/terminal/.config/tino/terminal-profile.sh --canonical-provider` resolves the host canonical provider.
+- `scripts/setup-terminal-provider.sh` logs provider resolution decisions and uses explicit fallback logs when it must deviate from the requested/canonical provider.
+- `scripts/qa_terminal_modernization.sh` warns when active host defaults (`TINO_TERMINAL_PROVIDER` from defaults + host override) do not match canonical provider policy.
+
 ## Host overrides model (`hosts/desktop`, `hosts/work_laptop`)
 
 Configuration precedence is:

--- a/dotfiles/terminal/.config/tino/terminal-profile.sh
+++ b/dotfiles/terminal/.config/tino/terminal-profile.sh
@@ -26,6 +26,42 @@ readonly TINO_TERMINAL_PROVIDER_DEFAULT_ORDER=(
     alacritty
 )
 
+terminal_is_windows_host() {
+    case "${OSTYPE:-}" in
+        msys*|cygwin*|win32*)
+            return 0
+            ;;
+    esac
+
+    if [[ "${OS:-}" == "Windows_NT" ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+terminal_canonical_provider() {
+    local override_provider="${TINO_TERMINAL_CANONICAL_PROVIDER:-}"
+
+    case "$override_provider" in
+        ghostty|wezterm|kitty|alacritty|windows-terminal)
+            printf '%s\n' "$override_provider"
+            return 0
+            ;;
+        "")
+            ;;
+        *)
+            ;;
+    esac
+
+    if terminal_is_windows_host; then
+        printf 'windows-terminal\n'
+        return 0
+    fi
+
+    printf 'ghostty\n'
+}
+
 readonly TINO_TERMINAL_CONTRACT_PROVIDERS=(
     ghostty
     wezterm
@@ -51,7 +87,7 @@ terminal_provider_preferences() {
         done
     fi
 
-    combined=("${normalized[@]}" "${TINO_TERMINAL_PROVIDER_DEFAULT_ORDER[@]}")
+    combined=("$(terminal_canonical_provider)" "${normalized[@]}" "${TINO_TERMINAL_PROVIDER_DEFAULT_ORDER[@]}")
 
     awk '!seen[$0]++' < <(printf '%s\n' "${combined[@]}")
 }
@@ -176,6 +212,11 @@ render_provider() {
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ ${1:-} == "--provider-preferences" ]]; then
         terminal_provider_preferences
+        exit 0
+    fi
+
+    if [[ ${1:-} == "--canonical-provider" ]]; then
+        terminal_canonical_provider
         exit 0
     fi
 

--- a/scripts/qa_terminal_modernization.sh
+++ b/scripts/qa_terminal_modernization.sh
@@ -136,6 +136,8 @@ zshrc_path="$repo_root/dotfiles/shell/.zshrc"
 starship_config_path="$repo_root/dotfiles/shell/.config/starship.toml"
 tmux_config_path="$repo_root/dotfiles/tmux/.tmux.conf"
 renderer_contract_script="$repo_root/dotfiles/terminal/.config/tino/validate-renderer-contract.sh"
+terminal_profile_script="$repo_root/dotfiles/terminal/.config/tino/terminal-profile.sh"
+terminal_defaults_path="$repo_root/dotfiles/terminal/.config/tino/terminal-defaults.sh"
 lockfile_check_script="$repo_root/scripts/check-nvim-lockfile.py"
 benchmark_script="$repo_root/scripts/benchmark_nvim_startup.sh"
 
@@ -239,6 +241,45 @@ if command -v tmux >/dev/null 2>&1; then
     fi
 else
     record_check "tmux_runtime_sanity" "tmux can start with managed config" "warn" "tmux binary not found on PATH; skipped runtime sanity"
+fi
+
+
+active_host_profile="${TINO_HOST_PROFILE:-}"
+if [[ -z "$active_host_profile" ]]; then
+    detected_host_for_profile="$(hostname 2>/dev/null || true)"
+    active_host_profile="$(resolve_host_overlay "$repo_root/hosts" "$detected_host_for_profile")"
+fi
+
+active_provider_default=""
+if [[ -f "$terminal_defaults_path" ]]; then
+    active_provider_default="$(
+        unset TINO_TERMINAL_PROVIDER
+        source "$terminal_defaults_path"
+        if [[ -n "$active_host_profile" ]]; then
+            host_override_path="$repo_root/hosts/$active_host_profile/.config/tino/host-overrides.sh"
+            if [[ -f "$host_override_path" ]]; then
+                source "$host_override_path"
+            fi
+        fi
+        printf '%s' "${TINO_TERMINAL_PROVIDER:-}"
+    )"
+fi
+
+canonical_provider=""
+if [[ -x "$terminal_profile_script" ]]; then
+    canonical_provider="$(bash "$terminal_profile_script" --canonical-provider 2>/dev/null || true)"
+fi
+
+if [[ -z "$canonical_provider" ]]; then
+    canonical_provider="ghostty"
+fi
+
+if [[ -z "$active_provider_default" ]]; then
+    record_check "terminal_provider_default_policy" "active host default provider matches canonical provider policy" "warn" "unable to resolve active provider default from terminal defaults/host overrides"
+elif [[ "$active_provider_default" == "$canonical_provider" ]]; then
+    record_check "terminal_provider_default_policy" "active host default provider matches canonical provider policy" "pass" "active_default=$active_provider_default canonical=$canonical_provider host_profile=${active_host_profile:-none}"
+else
+    record_check "terminal_provider_default_policy" "active host default provider matches canonical provider policy" "warn" "active_default=$active_provider_default canonical=$canonical_provider host_profile=${active_host_profile:-none}; non-canonical defaults should be treated as compatibility fallback"
 fi
 
 if [[ -x "$renderer_contract_script" ]]; then

--- a/scripts/setup-terminal-provider.sh
+++ b/scripts/setup-terminal-provider.sh
@@ -6,7 +6,39 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 strict_mode="${TINO_TERMINAL_STRICT:-1}"
 persist_fallback_mode="${TINO_TERMINAL_PERSIST_FALLBACK:-0}"
 selected_provider="$provider"
-readonly TERMINAL_CAPABILITY_PROBE_ORDER=(ghostty wezterm kitty alacritty)
+readonly TERMINAL_CAPABILITY_PROBE_ORDER=(ghostty wezterm kitty alacritty windows-terminal)
+
+canonical_provider=""
+
+log_provider_resolution() {
+    local message="$1"
+    echo "Provider resolution: $message" >&2
+}
+
+resolve_canonical_provider() {
+    if [[ -x "$profile_script" ]]; then
+        local resolved
+        resolved="$("$profile_script" --canonical-provider 2>/dev/null || true)"
+        if [[ -n "$resolved" ]]; then
+            printf '%s' "$resolved"
+            return 0
+        fi
+    fi
+
+    case "${OSTYPE:-}" in
+        msys*|cygwin*|win32*)
+            printf 'windows-terminal'
+            return 0
+            ;;
+    esac
+    if [[ "${OS:-}" == "Windows_NT" ]]; then
+        printf 'windows-terminal'
+        return 0
+    fi
+
+    printf 'ghostty'
+}
+
 
 if [[ -z "$provider" ]]; then
     echo "Usage: $(basename "$0") <ghostty|wezterm|kitty|alacritty|windows-terminal>" >&2
@@ -80,6 +112,14 @@ provider_install_url() {
 provider_is_available() {
     local provider_name="$1"
     local binary
+
+    if [[ "$provider_name" == "windows-terminal" ]]; then
+        case "${OSTYPE:-}" in
+            msys*|cygwin*|win32*) return 0 ;;
+        esac
+        [[ "${OS:-}" == "Windows_NT" ]] && return 0
+        return 1
+    fi
 
     binary="$(provider_binary "$provider_name")" || return 1
     command -v "$binary" >/dev/null 2>&1
@@ -161,14 +201,16 @@ resolve_provider_via_capability_probe() {
     fi
 
     if [[ ${#candidates[@]} -eq 0 ]]; then
-        candidates=("${TERMINAL_CAPABILITY_PROBE_ORDER[@]}")
+        candidates=("$canonical_provider" "${TERMINAL_CAPABILITY_PROBE_ORDER[@]}")
     fi
 
     for candidate in "${candidates[@]}"; do
         if provider_is_available "$candidate"; then
+            log_provider_resolution "probe selected '$candidate' (canonical='$canonical_provider', requested='$provider')"
             echo "$candidate"
             return 0
         fi
+        log_provider_resolution "probe skipped unavailable candidate '$candidate'"
     done
 
     return 1
@@ -228,13 +270,25 @@ handle_persisted_fallback_provider() {
 }
 
 ensure_provider_installed() {
+    canonical_provider="$(resolve_canonical_provider)"
+    log_provider_resolution "host canonical provider is '$canonical_provider'"
+
     if [[ "$provider" == "windows-terminal" ]]; then
+        selected_provider="$provider"
+        log_provider_resolution "explicit provider '$provider' requested; skipping install checks"
         return
+    fi
+
+    if [[ "$provider" != "$canonical_provider" ]]; then
+        log_provider_resolution "requested '$provider' differs from canonical '$canonical_provider' (compatibility target requested)"
+    else
+        log_provider_resolution "requested provider matches canonical policy"
     fi
 
     attempt_provider_install "$provider"
     if provider_is_available "$provider"; then
         selected_provider="$provider"
+        log_provider_resolution "selected '$selected_provider' after availability check"
         return
     fi
 
@@ -242,7 +296,7 @@ ensure_provider_installed() {
     if fallback_provider="$(resolve_provider_via_capability_probe)"; then
         selected_provider="$fallback_provider"
         if [[ "$selected_provider" != "$provider" ]]; then
-            echo "Warning: preferred provider '$provider' is unavailable; using '$selected_provider' based on capability probe." >&2
+            echo "Warning: requested provider '$provider' is unavailable; using fallback '$selected_provider'." >&2
             handle_persisted_fallback_provider "$provider" "$selected_provider"
         fi
         return

--- a/tests/test_setup_terminal_provider.py
+++ b/tests/test_setup_terminal_provider.py
@@ -201,7 +201,7 @@ def test_setup_terminal_provider_falls_back_to_first_available_provider(tmp_path
     )
 
     output = f"{result.stdout}\n{result.stderr}"
-    assert "using 'kitty' based on capability probe" in output
+    assert "using fallback 'kitty'" in output
     assert render_log.read_text().strip() == "kitty " + str(repo)
     assert "Terminal provider configured: kitty" in result.stdout
 
@@ -350,3 +350,43 @@ def test_setup_terminal_provider_prints_persist_instructions_when_requested(tmp_
     output = f"{result.stdout}\n{result.stderr}"
     assert "Fallback provider detected (ghostty -> kitty). Persist with:" in output
     assert 'export TINO_TERMINAL_PROVIDER="kitty"' in output
+
+
+def test_setup_terminal_provider_logs_compatibility_target_request(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    render_log = tmp_path / "render.log"
+    xdg_config_home = _create_terminal_profile(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        "if [[ ${1:-} == '--canonical-provider' ]]; then\n"
+        "  echo ghostty\n"
+        "  exit 0\n"
+        "fi\n"
+        f"echo \"$@\" > '{render_log}'\n",
+    )
+    bin_dir = _create_minimal_bin(tmp_path)
+    wezterm = bin_dir / "wezterm"
+    wezterm.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    wezterm.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({"XDG_CONFIG_HOME": str(xdg_config_home), "PATH": str(bin_dir)})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "wezterm"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert "compatibility target requested" in output
+    assert render_log.read_text().strip() == "wezterm " + str(repo)
+    assert "Terminal provider configured: wezterm" in result.stdout

--- a/tests/test_terminal_profile.py
+++ b/tests/test_terminal_profile.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def _copy_terminal_profile(tmp_path: Path) -> Path:
+    repo_root = Path(__file__).resolve().parents[1]
+    profile_src = repo_root / "dotfiles" / "terminal" / ".config" / "tino" / "terminal-profile.sh"
+    profile_dst = tmp_path / "terminal-profile.sh"
+    profile_dst.write_text(profile_src.read_text(encoding="utf-8"), encoding="utf-8")
+    profile_dst.chmod(0o755)
+    return profile_dst
+
+
+def test_terminal_profile_canonical_provider_defaults_to_ghostty(tmp_path: Path) -> None:
+    profile = _copy_terminal_profile(tmp_path)
+    result = subprocess.run(["/bin/bash", str(profile), "--canonical-provider"], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "ghostty"
+
+
+def test_terminal_profile_canonical_provider_windows_host(tmp_path: Path) -> None:
+    profile = _copy_terminal_profile(tmp_path)
+    env = os.environ.copy()
+    env.update({"OS": "Windows_NT"})
+    result = subprocess.run(
+        ["/bin/bash", str(profile), "--canonical-provider"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "windows-terminal"
+
+
+def test_terminal_profile_preferences_prioritize_canonical_provider(tmp_path: Path) -> None:
+    profile = _copy_terminal_profile(tmp_path)
+    env = os.environ.copy()
+    env.update({"TINO_TERMINAL_PROVIDER_PREFERENCES": "kitty,wezterm"})
+    result = subprocess.run(["/bin/bash", str(profile), "--provider-preferences"], env=env, capture_output=True, text=True, check=True)
+    providers = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert providers[0] == "ghostty"
+    assert providers[:4] == ["ghostty", "kitty", "wezterm", "alacritty"]


### PR DESCRIPTION
### Motivation
- Establish a deterministic canonical terminal-provider policy (Linux/macOS desktop → Ghostty, Windows → Windows Terminal) and treat other renderers as fallbacks/compatibility targets.
- Prefer a single, predictable provider ordering so installs and CI behavior are consistent across hosts.
- Surface mismatches between active host defaults and the canonical policy through QA so maintainers are aware of compatibility-only defaults.

### Description
- Documented the canonical provider policy in `docs/terminal.md` and described the implementation details for resolution and QA. (`docs/terminal.md`)
- Added host-aware canonical resolution helpers to the profile contract: `terminal_is_windows_host` and `terminal_canonical_provider`, and exposed `--canonical-provider` as a contract CLI option. Preference ordering now injects the canonical provider first. (`dotfiles/terminal/.config/tino/terminal-profile.sh`)
- Updated the provider setup flow to resolve the canonical provider and log decisions deterministically, to include `windows-terminal` in probe order on Windows hosts, and to treat requested-but-non-canonical providers as explicit compatibility targets with clear logs and fallback handling. (`scripts/setup-terminal-provider.sh`)
- Made `provider_is_available` aware of Windows Terminal semantics so probe resolution can treat it as available on Windows hosts. (`scripts/setup-terminal-provider.sh`)
- Added a QA assertion (`terminal_provider_default_policy`) to `scripts/qa_terminal_modernization.sh` that warns when the active defaults (defaults + host overlay) do not match the canonical provider policy. (`scripts/qa_terminal_modernization.sh`)
- Updated and added tests to cover canonical-provider behavior, deterministic preference ordering, and compatibility-target logging. (`tests/test_setup_terminal_provider.py`, `tests/test_terminal_profile.py`)

### Testing
- Verified script syntax with `bash -n scripts/setup-terminal-provider.sh dotfiles/terminal/.config/tino/terminal-profile.sh scripts/qa_terminal_modernization.sh` (no syntax errors).
- Ran unit tests with `pytest -q tests/test_setup_terminal_provider.py tests/test_terminal_profile.py` and all tests passed (`14 passed`).
- Ran linter with `ruff check tests/test_setup_terminal_provider.py tests/test_terminal_profile.py` and checks passed.
- Executed the QA gate `bash scripts/qa_terminal_modernization.sh`; it completed successfully but reported overall `warn` due to missing runtime tools in the execution environment (zsh/starship/nvim/tmux); the new `terminal_provider_default_policy` check passed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cfd94be88326a182787e93aae7a3)