### PR TITLE
Add optional runtime diagnostics for terminal providers in QA modernization gate

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -131,7 +131,42 @@ dotfiles/terminal/.config/tino/validate-renderer-contract.sh --report-format mar
 
 Ensure the selected provider reports expected support and that unsupported features degrade gracefully.
 
-### 3) Missing plugin detection
+### 3) Optional runtime diagnostics (portable/warn-only)
+
+`./scripts/qa_terminal_modernization.sh` also attempts provider runtime diagnostics when binaries are present.
+
+Behavior:
+
+- If a provider binary exists and diagnostics commands succeed, the check is `pass` and includes version + renderer hint output.
+- If a provider binary is missing or hint collection fails, the check is recorded as `warn` (never `fail`) to keep CI portable across heterogeneous runners.
+
+Provider command examples (run manually when debugging):
+
+```bash
+# WezTerm
+wezterm --version
+wezterm --help | sed -n '1,120p' | rg -m1 'webgpu|opengl|software'
+
+# Ghostty
+ghostty +version
+ghostty +help | sed -n '1,200p' | rg -m1 'renderer|opengl|metal|vulkan'
+
+# Kitty
+kitty --version
+kitty --debug-config 2>/dev/null | rg -m1 'renderer|opengl|vulkan|metal'
+
+# Alacritty
+alacritty --version
+alacritty --print-events --config-file /dev/null 2>&1 | rg -m1 'Renderer|GL|Vulkan'
+```
+
+Expected QA summary patterns:
+
+- `✅ [diagnostics_<provider>_runtime] ...` with details like `version: <value> | renderer_hint: <value>`.
+- `⚠️ [diagnostics_<provider>_runtime] ...` with details like `<binary> not found on PATH; runtime diagnostics skipped`.
+- `⚠️ [diagnostics_<provider>_runtime] ...` with details like `renderer_hint: unavailable (...)` when version works but hint probing does not.
+
+### 4) Missing plugin detection
 
 - Confirm shell plugin directories exist (or were cloned by bootstrap).
 - Confirm tmux plugin manager assets are present (`~/.tmux/plugins/tpm/tpm`).

--- a/scripts/qa_terminal_modernization.sh
+++ b/scripts/qa_terminal_modernization.sh
@@ -113,6 +113,42 @@ run_check_command() {
     return 1
 }
 
+capture_terminal_runtime_diagnostic() {
+    local check_id="$1"
+    local description="$2"
+    local binary_name="$3"
+    local version_subcommand="$4"
+    local hint_subcommand="$5"
+    local hint_label="$6"
+
+    if ! command -v "$binary_name" >/dev/null 2>&1; then
+        record_check "$check_id" "$description" "warn" "$binary_name not found on PATH; runtime diagnostics skipped"
+        return
+    fi
+
+    local version_output=""
+    if ! version_output="$(bash -lc "$version_subcommand" 2>&1)"; then
+        record_check "$check_id" "$description" "warn" "$binary_name found but failed to collect version diagnostics: ${version_output:-command failed}"
+        return
+    fi
+
+    local details="version: ${version_output:-unknown}"
+    if [[ -n "$hint_subcommand" ]]; then
+        local hint_output=""
+        if hint_output="$(bash -lc "$hint_subcommand" 2>&1)"; then
+            details+=" | ${hint_label}: ${hint_output:-none}"
+            record_check "$check_id" "$description" "pass" "$details"
+            return
+        fi
+
+        details+=" | ${hint_label}: unavailable (${hint_output:-command failed})"
+        record_check "$check_id" "$description" "warn" "$details"
+        return
+    fi
+
+    record_check "$check_id" "$description" "pass" "$details"
+}
+
 measure_zsh_startup_ms() {
     local zsh_path="$1"
     local profile_flag="$2"
@@ -288,6 +324,38 @@ if [[ -x "$renderer_contract_script" ]]; then
 else
     record_check "renderer_contract" "terminal renderer contract validation passes" "fail" "renderer contract script missing or not executable: $renderer_contract_script"
 fi
+
+capture_terminal_runtime_diagnostic \
+    "diagnostics_wezterm_runtime" \
+    "WezTerm runtime diagnostics (version + renderer hint)" \
+    "wezterm" \
+    "wezterm --version" \
+    "wezterm --help | sed -n '1,120p' | rg -m1 'webgpu|opengl|software' || true" \
+    "renderer_hint"
+
+capture_terminal_runtime_diagnostic \
+    "diagnostics_ghostty_runtime" \
+    "Ghostty runtime diagnostics (version + renderer hint)" \
+    "ghostty" \
+    "ghostty +version" \
+    "ghostty +help | sed -n '1,200p' | rg -m1 'renderer|opengl|metal|vulkan' || true" \
+    "renderer_hint"
+
+capture_terminal_runtime_diagnostic \
+    "diagnostics_kitty_runtime" \
+    "Kitty runtime diagnostics (version + renderer hint)" \
+    "kitty" \
+    "kitty --version" \
+    "kitty --debug-config 2>/dev/null | rg -m1 'renderer|opengl|vulkan|metal' || true" \
+    "renderer_hint"
+
+capture_terminal_runtime_diagnostic \
+    "diagnostics_alacritty_runtime" \
+    "Alacritty runtime diagnostics (version + renderer hint)" \
+    "alacritty" \
+    "alacritty --version" \
+    "alacritty --print-events --config-file /dev/null 2>&1 | rg -m1 'Renderer|GL|Vulkan' || true" \
+    "renderer_hint"
 
 pass_count=0
 warn_count=0


### PR DESCRIPTION
### Motivation

- Improve QA insight by capturing optional runtime diagnostics (version + renderer hints) for common terminal providers when their binaries are available. 
- Keep CI portable by treating missing or partially-unavailable diagnostics as `warn` rather than failing the gate. 

### Description

- Add a reusable helper `capture_terminal_runtime_diagnostic` in `scripts/qa_terminal_modernization.sh` to probe a provider binary for version and renderer-capability hints and record results via the existing QA reporting mechanism. 
- Wire probes for `wezterm`, `ghostty`, `kitty`, and `alacritty` (version command + a renderer-hint probe) and normalize outcomes to `pass`/`warn` without introducing hard `fail` states. 
- Document the new diagnostics behavior and provide example commands and expected QA-summary output in `docs/terminal.md`. 
- Keep existing JSON/text report outputs and overall gating logic unchanged except for the added diagnostic entries. 

### Testing

- Ran `bash -n scripts/qa_terminal_modernization.sh` to validate script syntax, which succeeded. 
- Executed `./scripts/qa_terminal_modernization.sh` end-to-end which completed successfully and produced a human-readable QA summary and JSON report (the run emitted `warn` entries because provider binaries were not present in the runner). 
- Attempted to run `shellcheck` but it was not installed in the environment, so linting was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d354f5f483269bff42b190b2b41b)