### PR TITLE
Prefer Windows Terminal automatic renderer and add schema-aware merge fallback

### DIFF
--- a/dotfiles/terminal/.config/tino/renderers/windows-terminal.sh
+++ b/dotfiles/terminal/.config/tino/renderers/windows-terminal.sh
@@ -38,6 +38,7 @@ output="$repo_root/windows-terminal/terminal-profile-overrides.json"
 mkdir -p "$(dirname "$output")"
 cat > "$output" <<EOC
 {
+  "rendering.graphicsAPI": "automatic",
   "profiles": {
     "defaults": {
       "font": {
@@ -77,7 +78,8 @@ cat > "$output" <<EOC
   "tinoContract": {
     "unsupported": {
       "TINO_TERMINAL_FPS": "windows-terminal has no profile-level refresh/fps override; retained as no-op",
-      "TINO_WINDOWS_TERMINAL_ACRYLIC_SUPPORTED": "set false to force deterministic fallback (opaque background, useAcrylic=false) on unsupported environments"
+      "TINO_WINDOWS_TERMINAL_ACRYLIC_SUPPORTED": "set false to force deterministic fallback (opaque background, useAcrylic=false) on unsupported environments",
+      "rendering.graphicsAPI": "older schema/runtime combinations may ignore this setting; generator falls back to base settings without it when schema is unrecognized"
     }
   }
 }

--- a/windows-terminal/README.md
+++ b/windows-terminal/README.md
@@ -32,3 +32,20 @@ supports profile-level acrylic settings (Windows 10 1903+ / Windows 11 with
 modern Windows Terminal releases). On older or restricted environments, use the
 fallback toggle above to avoid inconsistent rendering behavior.
 
+
+## Rendering engine preference and schema fallback
+
+The generated settings prefer the Windows Terminal automatic rendering engine
+via `"rendering.graphicsAPI": "automatic"` in both `settings.base.json` and
+`terminal-profile-overrides.json`.
+
+When `generate_settings.py` merges overrides:
+
+- If the base file uses the Windows Terminal profiles schema (or already
+  contains `rendering.graphicsAPI`), the override is applied.
+- If the base file appears to target a different/older schema, the merge script
+  skips this key and prints a warning to stderr rather than emitting a possibly
+  invalid setting.
+
+This keeps generated output compatible across schema and version mismatches
+while still preferring the automatic renderer when supported.

--- a/windows-terminal/generate_settings.py
+++ b/windows-terminal/generate_settings.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 import argparse
 
+SUPPORTED_RENDERING_GRAPHICS_APIS = {"automatic", "direct2d", "direct3d11"}
+
 
 def load_json(path: Path) -> dict[str, object]:
     try:
@@ -39,7 +41,30 @@ def merge_profiles(common: dict[str, object], override: dict[str, object]) -> di
     return result
 
 
+
+
+def should_merge_graphics_api(data: dict[str, object]) -> bool:
+    schema_value = data.get("$schema")
+    if isinstance(schema_value, str) and "terminal-profiles-schema" in schema_value:
+        return True
+    return "rendering.graphicsAPI" in data
+
+
+def merge_top_level_overrides(data: dict[str, object], overrides: dict[str, object]) -> dict[str, object]:
+    graphics_api = overrides.get("rendering.graphicsAPI")
+    if isinstance(graphics_api, str) and graphics_api in SUPPORTED_RENDERING_GRAPHICS_APIS:
+        if should_merge_graphics_api(data):
+            data["rendering.graphicsAPI"] = graphics_api
+        else:
+            print(
+                "Skipping rendering.graphicsAPI override because base settings schema does not match terminal-profiles-schema",
+                file=sys.stderr,
+            )
+    return data
+
 def merge_terminal_overrides(data: dict[str, object], overrides: dict[str, object]) -> dict[str, object]:
+    data = merge_top_level_overrides(data, overrides)
+
     profiles_override = overrides.get("profiles", {})
     profiles = data.get("profiles", {})
     defaults_override = profiles_override.get("defaults", {})

--- a/windows-terminal/settings.base.json
+++ b/windows-terminal/settings.base.json
@@ -1,6 +1,7 @@
 {
   "$help": "https://aka.ms/terminal-documentation",
   "$schema": "https://aka.ms/terminal-profiles-schema",
+  "rendering.graphicsAPI": "automatic",
   "actions": [
     {
       "command": {

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -1,6 +1,7 @@
 {
   "$help": "https://aka.ms/terminal-documentation",
   "$schema": "https://aka.ms/terminal-profiles-schema",
+  "rendering.graphicsAPI": "automatic",
   "actions": [
     {
       "command": {

--- a/windows-terminal/terminal-profile-overrides.json
+++ b/windows-terminal/terminal-profile-overrides.json
@@ -1,10 +1,12 @@
 {
+  "rendering.graphicsAPI": "automatic",
   "profiles": {
     "defaults": {
       "font": {
         "face": "CaskaydiaCove Nerd Font",
         "size": 13
       },
+      "useAcrylic": true,
       "acrylicOpacity": 0.92,
       "colorScheme": "Blacklight"
     }
@@ -32,52 +34,13 @@
       "foreground": "#f2f2f2",
       "cursorColor": "#FC17DA",
       "selectionBackground": "#301050"
-    },
-    {
-      "name": "Dracula",
-      "black": "#21222C",
-      "red": "#FF5555",
-      "green": "#50FA7B",
-      "yellow": "#F1FA8C",
-      "blue": "#BD93F9",
-      "purple": "#FF79C6",
-      "cyan": "#8BE9FD",
-      "white": "#F8F8F2",
-      "brightBlack": "#6272A4",
-      "brightRed": "#FF6E6E",
-      "brightGreen": "#69FF94",
-      "brightYellow": "#FFFFA5",
-      "brightBlue": "#D6ACFF",
-      "brightPurple": "#FF92DF",
-      "brightCyan": "#A4FFFF",
-      "brightWhite": "#FFFFFF",
-      "background": "#21222C",
-      "foreground": "#F8F8F2",
-      "cursorColor": "#FF79C6",
-      "selectionBackground": "#44475A"
-    },
-    {
-      "name": "Solarized Dark",
-      "black": "#073642",
-      "red": "#dc322f",
-      "green": "#859900",
-      "yellow": "#b58900",
-      "blue": "#268bd2",
-      "purple": "#d33682",
-      "cyan": "#2aa198",
-      "white": "#eee8d5",
-      "brightBlack": "#002b36",
-      "brightRed": "#cb4b16",
-      "brightGreen": "#586e75",
-      "brightYellow": "#657b83",
-      "brightBlue": "#839496",
-      "brightPurple": "#6c71c4",
-      "brightCyan": "#93a1a1",
-      "brightWhite": "#fdf6e3",
-      "background": "#002b36",
-      "foreground": "#93a1a1",
-      "cursorColor": "#93a1a1",
-      "selectionBackground": "#073642"
     }
-  ]
+  ],
+  "tinoContract": {
+    "unsupported": {
+      "TINO_TERMINAL_FPS": "windows-terminal has no profile-level refresh/fps override; retained as no-op",
+      "TINO_WINDOWS_TERMINAL_ACRYLIC_SUPPORTED": "set false to force deterministic fallback (opaque background, useAcrylic=false) on unsupported environments",
+      "rendering.graphicsAPI": "older schema/runtime combinations may ignore this setting; generator falls back to base settings without it when schema is unrecognized"
+    }
+  }
 }


### PR DESCRIPTION
### Motivation
- Ensure Windows Terminal prefers the best available renderer by explicitly requesting the automatic graphics API where supported, while avoiding emitting invalid keys for older/other schemas.
- Keep generated `settings.json` stable across Windows Terminal versions and schema mismatches by making the merge logic schema-aware.

### Description
- Emit `"rendering.graphicsAPI": "automatic"` from the renderer into `windows-terminal/terminal-profile-overrides.json` and add the same key to `windows-terminal/settings.base.json` so the preference is present in both override and base inputs.
- Update `windows-terminal/generate_settings.py` to recognize supported graphics API values and merge the top-level `rendering.graphicsAPI` only when the base file appears to target the terminal profiles schema (or already contains the key), printing a warning and skipping the key otherwise.
- Regenerate `windows-terminal/terminal-profile-overrides.json` and `windows-terminal/settings.json` via the existing generation flow so committed outputs include the new preference and consistent acrylic settings from the renderer.
- Document the rendering-engine preference and the generator's fallback behavior for schema/version mismatches in `windows-terminal/README.md` and record a note in the renderer `tinoContract` unsupported section.

### Testing
- Ran the renderer and produced overrides with `dotfiles/terminal/.config/tino/terminal-profile.sh windows-terminal <repo-root>` and observed output generation succeeded (passed).
- Regenerated merged settings with `python windows-terminal/generate_settings.py windows-terminal/settings.base.json windows-terminal/settings.json` and the command completed successfully (passed).
- Ran the contract validator `dotfiles/terminal/.config/tino/validate-renderer-contract.sh` which reported validation passed for providers (passed).
- Performed static checks: `python -m py_compile windows-terminal/generate_settings.py` and `python -m json.tool` on `windows-terminal/terminal-profile-overrides.json`, `windows-terminal/settings.json`, and `windows-terminal/settings.base.json`, all of which succeeded (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7eb7a8b7883268f3822cff95b7962)