### PR TITLE
Refactor bootstrap plan/apply behavior; add `--set-default-shell` and QA smoke check

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/terminal/.config/wezterm/wezterm.lua` → optional GPU-accelerated WezTerm profile aligned with shell/tmux colors
 - `dotfiles/terminal/.config/tino/ghostty.toml.tmpl` → authored Ghostty template (renderer input)
 - `dotfiles/terminal/.config/tino/renderers/*.sh` → provider renderers that generate concrete config files from the terminal profile contract
-- `scripts/bootstrap-dev-env.sh` → primary declarative bootstrap workflow with auditable stages. It orchestrates dependency install planning, `scripts/install_dotfiles.sh`, `scripts/setup-nvim.sh`, `scripts/setup-terminal-provider.sh`, and renderer contract validation. It emits both JSON and human-readable reports (host overlay, provider chosen, versions, skipped steps) and supports `--plan` to print exact actions without mutating state.
+- `scripts/bootstrap-dev-env.sh` → primary declarative bootstrap workflow with auditable stages. It orchestrates dependency install/apply (`scripts/install_common.sh`), `scripts/install_dotfiles.sh`, `scripts/setup-nvim.sh`, `scripts/setup-terminal-provider.sh`, and renderer contract validation. It emits both JSON and human-readable reports (host overlay, provider chosen, versions, skipped steps, dependency install mode/dry-run). `--plan` is the only dry-run path; default apply mode performs real dependency installation.
 - `scripts/install_common.sh` → legacy/compatibility bootstrap script; still available for broader OS-specific automation and optional Windows provisioning flags, and remains the canonical TPM installer/recovery path (`~/.tmux/plugins/tpm/tpm`).
 - `scripts/setup-terminal-provider.sh <provider>` → entry point for provider-specific setup/rendering (`ghostty|wezterm|kitty|alacritty|windows-terminal`) via `~/.config/tino/terminal-profile.sh`
 - `scripts/qa_terminal_modernization.sh` → canonical terminal modernization acceptance gate after config changes (zsh/tmux/starship/nvim/renderer contract checks) with human-readable output + CI JSON report (`.cache/tino/qa-terminal-modernization/report.json`).
@@ -276,11 +276,15 @@ Expected artifacts are written under `.cache/tino/nvim-startup/`:
 ./scripts/bootstrap-dev-env.sh
 ```
 
+Apply mode is mutating by design: it runs `scripts/install_common.sh` without `--dry-run` during the `dependency-install` stage. Default-shell behavior can be controlled deterministically with `--set-default-shell <prompt|force|skip>` (default `prompt`).
+
 Preview-only plan mode:
 
 ```bash
 ./scripts/bootstrap-dev-env.sh --plan
 ```
+
+In plan mode, dependency installation is preview-only and always runs `install_common.sh --dry-run --set-default-shell=skip`.
 
 Terminal modernization acceptance gate (run after shell/tmux/nvim/terminal profile changes):
 

--- a/scripts/bootstrap-dev-env.sh
+++ b/scripts/bootstrap-dev-env.sh
@@ -7,17 +7,20 @@ scripts_dir="$repo_root/scripts"
 plan_mode=0
 host_overlay=""
 provider_override=""
+set_default_shell_mode="prompt"
 report_dir="${TINO_BOOTSTRAP_REPORT_DIR:-$repo_root/.cache/tino/bootstrap-dev-env}"
 
 usage() {
     cat <<USAGE
-Usage: $(basename "$0") [--plan] [--host NAME] [--provider NAME] [--report-dir DIR]
+Usage: $(basename "$0") [--plan] [--host NAME] [--provider NAME] [--set-default-shell MODE] [--report-dir DIR]
 
 Declarative bootstrap for development environments with auditable stages.
 
   --plan            Print exact actions without mutating state
   --host NAME       Explicit host overlay passed to install_dotfiles.sh
   --provider NAME   Terminal provider override (ghostty|wezterm|kitty|alacritty|windows-terminal)
+  --set-default-shell MODE
+                    Default-shell policy forwarded to install_common.sh (prompt|force|skip; default: prompt)
   --report-dir DIR  Output directory for reports (default: $report_dir)
   -h, --help        Show this help message
 USAGE
@@ -37,6 +40,14 @@ while [[ $# -gt 0 ]]; do
             provider_override="${2:-}"
             shift 2
             ;;
+        --set-default-shell)
+            set_default_shell_mode="${2:-}"
+            shift 2
+            ;;
+        --set-default-shell=*)
+            set_default_shell_mode="${1#*=}"
+            shift
+            ;;
         --report-dir)
             report_dir="${2:-}"
             shift 2
@@ -52,6 +63,19 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ -z "$set_default_shell_mode" ]]; then
+    echo "Error: --set-default-shell requires one of: prompt, force, skip" >&2
+    exit 1
+fi
+
+case "$set_default_shell_mode" in
+    prompt|force|skip) ;;
+    *)
+        echo "Error: unsupported --set-default-shell mode '$set_default_shell_mode' (expected: prompt, force, skip)" >&2
+        exit 1
+        ;;
+esac
 
 terminal_provider_supported() {
     case "$1" in
@@ -169,8 +193,17 @@ renderer_report="$report_dir/renderer-contract.json"
 planned_actions=()
 skipped_steps=()
 
+dependency_install_mode="planned"
+dependency_install_dry_run=1
+
 # Stages
-run_stage "dependency-install" "bash '$scripts_dir/install_common.sh' --dry-run --set-default-shell=skip --terminal '$provider_chosen'"
+dependency_install_cmd="bash '$scripts_dir/install_common.sh' --dry-run --set-default-shell=skip --terminal '$provider_chosen'"
+if [[ $plan_mode -eq 0 ]]; then
+    dependency_install_cmd="bash '$scripts_dir/install_common.sh' --set-default-shell='$set_default_shell_mode' --terminal '$provider_chosen'"
+    dependency_install_mode="applied"
+    dependency_install_dry_run=0
+fi
+run_stage "dependency-install" "$dependency_install_cmd"
 
 dotfiles_cmd="bash '$scripts_dir/install_dotfiles.sh' --conflict=abort"
 if [[ -n "$host_overlay" ]]; then
@@ -197,6 +230,8 @@ provider_version="$(version_of "$provider_binary")"
     printf 'Host overlay: %s\n' "${host_overlay:-none}"
     printf 'Provider chosen: %s\n' "$provider_chosen"
     printf 'Provider version: %s\n' "$provider_version"
+    printf 'Dependency install mode: %s\n' "$dependency_install_mode"
+    printf 'Dependency install dry-run: %s\n' "$( [[ $dependency_install_dry_run -eq 1 ]] && echo 'yes' || echo 'no' )"
     printf '\nPlanned actions:\n'
     for action in "${planned_actions[@]}"; do
         printf '  - %s\n' "$action"
@@ -219,6 +254,8 @@ provider_version="$(version_of "$provider_binary")"
     printf '  "host_overlay": "%s",\n' "$(json_escape "${host_overlay:-none}")"
     printf '  "provider_chosen": "%s",\n' "$(json_escape "$provider_chosen")"
     printf '  "provider_version": "%s",\n' "$(json_escape "$provider_version")"
+    printf '  "dependency_install_mode": "%s",\n' "$(json_escape "$dependency_install_mode")"
+    printf '  "dependency_install_dry_run": %s,\n' "$( [[ $dependency_install_dry_run -eq 1 ]] && echo 'true' || echo 'false' )"
     printf '  "planned_actions": [\n'
     for i in "${!planned_actions[@]}"; do
         comma=","

--- a/scripts/qa_terminal_modernization.sh
+++ b/scripts/qa_terminal_modernization.sh
@@ -245,6 +245,20 @@ fi
 run_check_command "nvim_lockfile" "Neovim lazy-lock.json covers declared plugins" \
     python3 "$lockfile_check_script" || true
 
+required_apply_binaries=(zsh starship tmux nvim stow rg fd)
+missing_apply_binaries=()
+for binary in "${required_apply_binaries[@]}"; do
+    if ! command -v "$binary" >/dev/null 2>&1; then
+        missing_apply_binaries+=("$binary")
+    fi
+done
+
+if (( ${#missing_apply_binaries[@]} == 0 )); then
+    record_check "bootstrap_apply_binaries" "bootstrap apply-mode dependencies are present on PATH" "pass" "found: ${required_apply_binaries[*]}"
+else
+    record_check "bootstrap_apply_binaries" "bootstrap apply-mode dependencies are present on PATH" "fail" "missing: ${missing_apply_binaries[*]} (run ./scripts/bootstrap-dev-env.sh in apply mode)"
+fi
+
 if command -v nvim >/dev/null 2>&1; then
     run_check_command "nvim_startup_threshold" "Neovim startup benchmark is within threshold (${benchmark_threshold} ms)" \
         env TINO_NVIM_MAX_STARTUP_MS="$benchmark_threshold" bash "$benchmark_script" || true


### PR DESCRIPTION
### Motivation

- Make `--plan` the only path that uses dry-run semantics so dependency installation behavior is explicit and deterministic.
- Allow callers to control default-shell policy (`prompt|force|skip`) when running the real (apply) bootstrap pass.
- Improve observability by recording whether dependency installation was planned vs applied in bootstrap reports.
- Provide an automated smoke check to catch missing apply-mode binaries early in QA/CI.

### Description

- Added a new CLI flag `--set-default-shell <prompt|force|skip>` to `scripts/bootstrap-dev-env.sh` with validation and help text, defaulting to `prompt` and forwarded to `scripts/install_common.sh` in apply mode. 
- Split `dependency-install` stage command construction so plan mode keeps `install_common.sh --dry-run --set-default-shell=skip` while apply mode runs `install_common.sh` without `--dry-run` and with the configured `--set-default-shell` value. 
- Extended the human-readable and JSON bootstrap reports with `dependency_install_mode` and `dependency_install_dry_run` fields to indicate whether dependencies were actually installed or only planned. 
- Added an apply-mode dependency smoke check to `scripts/qa_terminal_modernization.sh` that verifies required binaries (`zsh`, `starship`, `tmux`, `nvim`, `stow`, `rg`, `fd`) are present on `PATH` and records a failing check with actionable guidance when missing. 
- Updated `README.md` bootstrap section to document the deterministic behavior: plan mode is preview-only, apply mode is mutating, and the new `--set-default-shell` passthrough.

### Testing

- Ran a shell syntax/parse check `bash -n scripts/bootstrap-dev-env.sh scripts/qa_terminal_modernization.sh scripts/install_common.sh`, which succeeded. 
- Executed `./scripts/bootstrap-dev-env.sh --help` to validate CLI usage text, which printed the updated help successfully. 
- Executed `./scripts/bootstrap-dev-env.sh --plan --set-default-shell force` to validate plan-mode behavior and report fields, which produced a plan summary showing the dry-run dependency-install invocation. 
- Ran `./scripts/qa_terminal_modernization.sh` which surfaced a failing `bootstrap_apply_binaries` check because the expected apply-mode binaries are not present in this test environment, and this failure is intentional and expected for the new smoke check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f1eb509c8326918d0ea07986c10b)