### PR TITLE
Policy-ize default shell selection in bootstrap workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/terminal/.config/wezterm/wezterm.lua` → optional GPU-accelerated WezTerm profile aligned with shell/tmux colors
 - `dotfiles/terminal/.config/tino/ghostty.toml.tmpl` → authored Ghostty template (renderer input)
 - `dotfiles/terminal/.config/tino/renderers/*.sh` → provider renderers that generate concrete config files from the terminal profile contract
-- `scripts/bootstrap-dev-env.sh` → primary declarative bootstrap workflow with auditable stages. It orchestrates dependency install/apply (`scripts/install_common.sh`), `scripts/install_dotfiles.sh`, `scripts/setup-nvim.sh`, `scripts/setup-terminal-provider.sh`, and renderer contract validation. It emits both JSON and human-readable reports (host overlay, provider chosen, versions, skipped steps, dependency install mode/dry-run). `--plan` is the only dry-run path; default apply mode performs real dependency installation.
+- `scripts/bootstrap-dev-env.sh` → primary declarative bootstrap workflow with auditable stages. It orchestrates dependency install/apply (`scripts/install_common.sh`), `scripts/install_dotfiles.sh`, `scripts/setup-nvim.sh`, `scripts/setup-terminal-provider.sh`, and renderer contract validation. It emits both JSON and human-readable reports (host overlay, provider chosen, versions, skipped steps, dependency install mode/dry-run, default shell policy, and login shell post-check `login_shell_matches_zsh`). `--plan` is the only dry-run path; default apply mode performs real dependency installation.
 - `scripts/install_common.sh` → legacy/compatibility bootstrap script; still available for broader OS-specific automation and optional Windows provisioning flags, and remains the canonical TPM installer/recovery path (`~/.tmux/plugins/tpm/tpm`).
 - `scripts/setup-terminal-provider.sh <provider>` → entry point for provider-specific setup/rendering (`ghostty|wezterm|kitty|alacritty|windows-terminal`) via `~/.config/tino/terminal-profile.sh`
 - `scripts/qa_terminal_modernization.sh` → canonical terminal modernization acceptance gate after config changes (zsh/tmux/starship/nvim/renderer contract checks) with human-readable output + CI JSON report (`.cache/tino/qa-terminal-modernization/report.json`).
@@ -276,7 +276,15 @@ Expected artifacts are written under `.cache/tino/nvim-startup/`:
 ./scripts/bootstrap-dev-env.sh
 ```
 
-Apply mode is mutating by design: it runs `scripts/install_common.sh` without `--dry-run` during the `dependency-install` stage. Default-shell behavior can be controlled deterministically with `--set-default-shell <prompt|force|skip>` (default `prompt`).
+Apply mode is mutating by design: it runs `scripts/install_common.sh` without `--dry-run` during the `dependency-install` stage. `--set-default-shell <prompt|force|skip>` is explicit policy: by default bootstrap chooses `prompt` for interactive local sessions and `skip` for CI/non-interactive contexts.
+
+Canonical recommendation by environment type:
+
+- Interactive local developer machine: `--set-default-shell=prompt` (or omit the flag and accept default policy selection).
+- CI runners: `--set-default-shell=skip`.
+- Unattended workstation provisioning: `--set-default-shell=force`.
+
+Bootstrap summaries now include a dedicated post-check: `login_shell_matches_zsh: true|false`.
 
 Preview-only plan mode:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -223,6 +223,16 @@ sudo bash scripts/setup-wsl.sh
    ```
 4. Launch a new shell to pick up the configuration.
 
+### Default shell policy recommendations
+
+Use `scripts/bootstrap-dev-env.sh` when you want auditable staging and an explicit shell-selection policy:
+
+- **Interactive local development** (recommended): `./scripts/bootstrap-dev-env.sh --set-default-shell=prompt`
+- **CI / non-interactive automation** (recommended): `./scripts/bootstrap-dev-env.sh --set-default-shell=skip`
+- **Unattended workstation provisioning** (optional): `./scripts/bootstrap-dev-env.sh --set-default-shell=force`
+
+If you omit `--set-default-shell`, bootstrap defaults to `prompt` in interactive sessions and `skip` in CI/non-interactive contexts. In non-interactive `prompt` paths, the installer emits a deferred action message with the exact manual command (`chsh -s <zsh-path>`). Bootstrap reports include `login_shell_matches_zsh: true|false` as a dedicated post-check.
+
 ### Troubleshooting package managers
 
 The installer looks for Homebrew on macOS and uses `apt-get`, `dnf` or

--- a/scripts/bootstrap-dev-env.sh
+++ b/scripts/bootstrap-dev-env.sh
@@ -7,7 +7,7 @@ scripts_dir="$repo_root/scripts"
 plan_mode=0
 host_overlay=""
 provider_override=""
-set_default_shell_mode="prompt"
+set_default_shell_mode=""
 report_dir="${TINO_BOOTSTRAP_REPORT_DIR:-$repo_root/.cache/tino/bootstrap-dev-env}"
 
 usage() {
@@ -20,7 +20,7 @@ Declarative bootstrap for development environments with auditable stages.
   --host NAME       Explicit host overlay passed to install_dotfiles.sh
   --provider NAME   Terminal provider override (ghostty|wezterm|kitty|alacritty|windows-terminal)
   --set-default-shell MODE
-                    Default-shell policy forwarded to install_common.sh (prompt|force|skip; default: prompt)
+                    Default-shell policy forwarded to install_common.sh (prompt|force|skip; default: prompt for interactive local use, skip for CI/non-interactive)
   --report-dir DIR  Output directory for reports (default: $report_dir)
   -h, --help        Show this help message
 USAGE
@@ -65,8 +65,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$set_default_shell_mode" ]]; then
-    echo "Error: --set-default-shell requires one of: prompt, force, skip" >&2
-    exit 1
+    if [[ -n "${CI:-}" ]]; then
+        set_default_shell_mode="skip"
+    elif [[ -t 0 ]]; then
+        set_default_shell_mode="prompt"
+    else
+        set_default_shell_mode="skip"
+    fi
 fi
 
 case "$set_default_shell_mode" in
@@ -145,6 +150,37 @@ resolve_provider() {
     fi
 
     printf '%s' "$provider"
+}
+
+get_login_shell() {
+    local shell_path=""
+    local user_name="${USER:-$(id -un 2>/dev/null || true)}"
+
+    if [[ -z "$user_name" ]]; then
+        shell_path="${SHELL:-unknown}"
+        printf '%s' "$shell_path"
+        return
+    fi
+
+    if [[ ${OSTYPE:-} == darwin* ]] && command -v dscl >/dev/null 2>&1; then
+        shell_path="$(dscl . -read "/Users/$user_name" UserShell 2>/dev/null | awk '{print $2}' || true)"
+    elif command -v getent >/dev/null 2>&1; then
+        shell_path="$(getent passwd "$user_name" | cut -d: -f7 || true)"
+    else
+        shell_path="$(awk -F: -v user="$user_name" '$1 == user {print $7}' /etc/passwd 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$shell_path" ]]; then
+        shell_path="${SHELL:-unknown}"
+    fi
+
+    printf '%s' "$shell_path"
+}
+
+login_shell_matches_zsh() {
+    local zsh_path=""
+    zsh_path="$(command -v zsh || true)"
+    [[ -n "$zsh_path" && "$(get_login_shell)" == "$zsh_path" ]]
 }
 
 version_of() {
@@ -232,6 +268,8 @@ provider_version="$(version_of "$provider_binary")"
     printf 'Provider version: %s\n' "$provider_version"
     printf 'Dependency install mode: %s\n' "$dependency_install_mode"
     printf 'Dependency install dry-run: %s\n' "$( [[ $dependency_install_dry_run -eq 1 ]] && echo 'yes' || echo 'no' )"
+    printf 'Default shell policy: %s\n' "$set_default_shell_mode"
+    printf 'login_shell_matches_zsh: %s\n' "$( [[ $plan_mode -eq 1 ]] && echo 'false' || (login_shell_matches_zsh && echo 'true' || echo 'false') )"
     printf '\nPlanned actions:\n'
     for action in "${planned_actions[@]}"; do
         printf '  - %s\n' "$action"
@@ -256,6 +294,8 @@ provider_version="$(version_of "$provider_binary")"
     printf '  "provider_version": "%s",\n' "$(json_escape "$provider_version")"
     printf '  "dependency_install_mode": "%s",\n' "$(json_escape "$dependency_install_mode")"
     printf '  "dependency_install_dry_run": %s,\n' "$( [[ $dependency_install_dry_run -eq 1 ]] && echo 'true' || echo 'false' )"
+    printf '  "default_shell_policy": "%s",\n' "$(json_escape "$set_default_shell_mode")"
+    printf '  "login_shell_matches_zsh": %s,\n' "$( [[ $plan_mode -eq 1 ]] && echo 'false' || (login_shell_matches_zsh && echo 'true' || echo 'false') )"
     printf '  "planned_actions": [\n'
     for i in "${!planned_actions[@]}"; do
         comma=","

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -348,7 +348,7 @@ set_default_shell() {
         prompt)
             if [[ ! -t 0 ]]; then
                 echo "Skipping shell change prompt in non-interactive mode"
-                action_message="Rerun interactively or use --set-default-shell=force"
+                action_message="deferred action required: run 'chsh -s $zsh_path'"
             else
                 read -r -p "Set default shell to $zsh_path using chsh? [y/N] " response
                 if [[ $response =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
### Motivation
- Treat shell selection as an explicit policy decision instead of incidental behavior during bootstrap so automation and CI behave predictably. 
- Provide clear guidance and actionable output when a non-interactive `prompt` path is taken so administrators know the exact manual command to run. 

### Description
- `scripts/install_common.sh`: non-interactive `prompt` now emits a clear deferred-action message with the exact manual command (`chsh -s <zsh-path>`) instead of a generic rerun hint; behavior for `force`/`skip` unchanged and existing reporting preserved. 
- `scripts/bootstrap-dev-env.sh`: expose and forward `--set-default-shell` and make its default policy-driven by environment: default to `prompt` for interactive local sessions, `skip` for CI/non-interactive contexts, and still accept explicit `force|prompt|skip`; added `get_login_shell` and `login_shell_matches_zsh` helpers. 
- Reporting: added `Default shell policy` to the human-readable bootstrap summary and `default_shell_policy` plus `login_shell_matches_zsh` to the JSON bootstrap report as a dedicated post-check. 
- Documentation: updated `README.md` and `docs/installation.md` with canonical recommendations per environment type and a note about the new `login_shell_matches_zsh` post-check and the deferred-action message. 

### Testing
- `bash -n scripts/install_common.sh scripts/bootstrap-dev-env.sh` — syntax check passed. 
- `./scripts/bootstrap-dev-env.sh --plan --report-dir /tmp/tino-bootstrap-check` — produced a readable summary and JSON report including `Default shell policy: skip` and `login_shell_matches_zsh: false`, which validated policy defaulting in plan mode. 
- `bash scripts/install_common.sh --dry-run --set-default-shell=prompt --terminal ghostty 2>&1 | rg -n "Skipping shell change prompt|Action:|Final login shell|deferred action required|set to zsh|Default shell"` — command ran and validated the non-interactive deferred-action output path; environment lacked `zsh` so the `zsh-present` deferred-prompt branch could not be exercised in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b808044ba08326bfa62d431957d77a)