### PR TITLE
Gate Starship cloud modules via normalized shell toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ Terminal profile values flow through one path:
 
 `~/.config/ghostty/ghostty.toml` is generated output and should not be treated as an authored source file.
 
+
+#### Starship cloud toggle normalization
+
+Cloud prompt visibility is decided in `dotfiles/shell/.zshrc` before `starship init` runs.
+
+- External toggles: `STARSHIP_ENABLE_K8S`, `STARSHIP_ENABLE_AWS`
+- True values (enable): `1`, `true`, `yes`, `on`
+- False values (force-disable): `0`, `false`, `no`, `off`
+- Internal helper env vars passed to Starship detection: `TINO_STARSHIP_SHOW_K8S`, `TINO_STARSHIP_SHOW_AWS`
+
+Host overlays in `hosts/*/.config/tino/host-overrides.sh` can opt in cleanly by exporting `STARSHIP_ENABLE_K8S=1` and/or `STARSHIP_ENABLE_AWS=1`.
+
 Standard bootstrap command (repo root):
 
 Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; provisioning is handled by `./scripts/setup-nvim.sh` (headless `Lazy! sync` + explicit Mason LSP installs, requires Neovim >= 0.8) so first interactive startup is deterministic. Intentional plugin upgrades should use `./scripts/setup-nvim.sh --refresh-lockfile` (runs `Lazy! update` + `Lazy! lock`, then lock coverage validation) and can be re-checked manually with `python scripts/check-nvim-lockfile.py`. Runtime self-healing is opt-in with `TINO_NVIM_AUTO_BOOTSTRAP=1` (default is disabled/offline-friendly), and `TINO_NVIM_OFFLINE=1` forces warning-only startup behavior. Startup benchmarking is available via `scripts/benchmark_nvim_startup.sh`; `scripts/setup-nvim.sh` runs it only when `TINO_NVIM_BENCHMARK_STARTUP=1` and now auto-passes `TINO_NVIM_MAX_STARTUP_MS` from either explicit env override or host profile defaults (`TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS`). Current SLO defaults are desktop=100ms and work_laptop=140ms.

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -188,8 +188,12 @@ For TPM specifically, `./scripts/install_common.sh` is the canonical recovery pa
 
 Cloud modules are context-gated so they do not appear in unrelated shells:
 
-- `kubernetes` appears when kube context environment is present (`KUBECONFIG`) or when explicitly enabled via `STARSHIP_ENABLE_K8S`.
-- `aws` appears when AWS context environment is present (`AWS_PROFILE` or `AWS_VAULT`) or when explicitly enabled via `STARSHIP_ENABLE_AWS`.
+- `.zshrc` normalizes cloud toggles before `starship init` and exports internal helper vars consumed by Starship:
+  - `TINO_STARSHIP_SHOW_K8S` for the `kubernetes` module
+  - `TINO_STARSHIP_SHOW_AWS` for the `aws` module
+- `STARSHIP_ENABLE_K8S` and `STARSHIP_ENABLE_AWS` only enable when set to one of: `1`, `true`, `yes`, `on` (case-insensitive).
+- Explicit disable values are `0`, `false`, `no`, `off` (case-insensitive); these force-hide the module by unsetting helper vars even if cloud env vars are present.
+- If no explicit disable is set, existing context still auto-detects (`KUBECONFIG` for Kubernetes; `AWS_PROFILE`/`AWS_VAULT` for AWS).
 
 ### Recommended profile defaults
 
@@ -206,7 +210,7 @@ Use host overlays to set stable defaults based on machine role:
     - `export STARSHIP_ENABLE_K8S=1`
     - `export STARSHIP_ENABLE_AWS=1`
 
-Tip: prefer setting these in host-specific override files instead of global shell defaults so behavior stays intentional per machine.
+Tip: prefer setting these in host-specific override files instead of global shell defaults so behavior stays intentional per machine. Toggle values are normalized; prefer `1`/`0` for clarity, and `true|yes|on` / `false|no|off` are also supported.
 
 ## Troubleshooting
 

--- a/dotfiles/shell/.config/starship.toml
+++ b/dotfiles/shell/.config/starship.toml
@@ -76,13 +76,13 @@ symbol = "☸ "
 format = "[$symbol$context( \\($namespace\\))]($style) "
 style = "fg:cyan"
 disabled = false
-detect_env_vars = ["KUBECONFIG", "STARSHIP_ENABLE_K8S"]
+detect_env_vars = ["TINO_STARSHIP_SHOW_K8S"]
 
 [aws]
 symbol = "󰸏 "
 format = "[$symbol$profile( \\($region\\))]($style) "
 style = "fg:yellow"
-detect_env_vars = ["AWS_PROFILE", "AWS_VAULT", "STARSHIP_ENABLE_AWS"]
+detect_env_vars = ["TINO_STARSHIP_SHOW_AWS"]
 
 [time]
 disabled = false

--- a/dotfiles/shell/.zshrc
+++ b/dotfiles/shell/.zshrc
@@ -10,6 +10,38 @@ source_if_readable() {
     fi
 }
 
+tino_env_is_truthy() {
+    local value="${1:-}"
+    value="${value:l}"
+    [[ "$value" == "1" || "$value" == "true" || "$value" == "yes" || "$value" == "on" ]]
+}
+
+tino_env_is_falsey() {
+    local value="${1:-}"
+    value="${value:l}"
+    [[ "$value" == "0" || "$value" == "false" || "$value" == "no" || "$value" == "off" ]]
+}
+
+tino_apply_cloud_prompt_gate() {
+    local k8s_toggle="${STARSHIP_ENABLE_K8S:-}"
+    local aws_toggle="${STARSHIP_ENABLE_AWS:-}"
+
+    unset TINO_STARSHIP_SHOW_K8S
+    unset TINO_STARSHIP_SHOW_AWS
+
+    if tino_env_is_truthy "$k8s_toggle"; then
+        export TINO_STARSHIP_SHOW_K8S=1
+    elif ! tino_env_is_falsey "$k8s_toggle" && [[ -n "${KUBECONFIG:-}" ]]; then
+        export TINO_STARSHIP_SHOW_K8S=1
+    fi
+
+    if tino_env_is_truthy "$aws_toggle"; then
+        export TINO_STARSHIP_SHOW_AWS=1
+    elif ! tino_env_is_falsey "$aws_toggle" && [[ -n "${AWS_PROFILE:-}${AWS_VAULT:-}" ]]; then
+        export TINO_STARSHIP_SHOW_AWS=1
+    fi
+}
+
 tino_warn_missing_zsh_plugin_once() {
     local plugin_name="$1"
     local plugin_entrypoint="$2"
@@ -131,6 +163,7 @@ source_if_readable "$ZSH_CONFIG_DIR/functions.zsh"
 source_if_readable "$ZSH_CONFIG_DIR/env.zsh"
 source_if_readable "$HOME/.config/tino/terminal-defaults.sh"
 source_if_readable "$HOME/.config/tino/host-overrides.sh"
+tino_apply_cloud_prompt_gate
 
 if command -v starship >/dev/null; then
     eval "$(starship init zsh)"

--- a/hosts/desktop/.config/tino/host-overrides.sh
+++ b/hosts/desktop/.config/tino/host-overrides.sh
@@ -10,3 +10,7 @@ export TINO_POWER_MODE="performance"
 
 # Neovim startup SLO guardrail defaults for this host profile.
 export TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS="100"
+# Cloud prompt opt-ins (accepted true values: 1|true|yes|on; false values: 0|false|no|off).
+# export STARSHIP_ENABLE_K8S="1"
+# export STARSHIP_ENABLE_AWS="1"
+

--- a/hosts/work_laptop/.config/tino/host-overrides.sh
+++ b/hosts/work_laptop/.config/tino/host-overrides.sh
@@ -10,3 +10,7 @@ export TINO_POWER_MODE="balanced"
 
 # Neovim startup SLO guardrail defaults for this host profile.
 export TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS="140"
+# Cloud prompt opt-ins (accepted true values: 1|true|yes|on; false values: 0|false|no|off).
+# export STARSHIP_ENABLE_K8S="1"
+# export STARSHIP_ENABLE_AWS="1"
+


### PR DESCRIPTION
### Motivation

- Make Starship cloud module visibility deterministic and safe by normalizing user toggle values in the shell before Starship initializes. 
- Avoid accidental prompt noise by treating explicit false values as a force-hide even when cloud env vars are present.

### Description

- Add `tino_env_is_truthy`, `tino_env_is_falsey`, and `tino_apply_cloud_prompt_gate` to `dotfiles/shell/.zshrc` and invoke the gate before running `starship init` so normalized helper vars are available at prompt init time. 
- Export internal helper vars `TINO_STARSHIP_SHOW_K8S` and `TINO_STARSHIP_SHOW_AWS` from `.zshrc` instead of relying on raw provider env vars or `STARSHIP_ENABLE_*` directly. 
- Update `dotfiles/shell/.config/starship.toml` to use `detect_env_vars = [

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80c1189808326959fd0eba4255df2)