### PR TITLE
Align WezTerm fallback with generated renderer baseline contract

### DIFF
--- a/dotfiles/terminal/.config/tino/validate-renderer-contract.sh
+++ b/dotfiles/terminal/.config/tino/validate-renderer-contract.sh
@@ -140,6 +140,27 @@ symbol_for_status() {
     esac
 }
 
+
+check_wezterm_fallback_schema() {
+    local fallback_file="$repo_root/dotfiles/terminal/.config/wezterm/wezterm.lua"
+
+    rg -q '^-- Safe baseline fallback when wezterm.generated.lua is unavailable\.$' "$fallback_file"
+    rg -q '^    font = wezterm\.font_with_fallback\(\{$' "$fallback_file"
+    rg -q '^    window_background_opacity = ' "$fallback_file"
+    rg -q '^    use_fancy_tab_bar = false,$' "$fallback_file"
+    rg -q '^    hide_tab_bar_if_only_one_tab = true,$' "$fallback_file"
+    rg -q '^    window_padding = \{ left = [0-9]+, right = [0-9]+, top = [0-9]+, bottom = [0-9]+ \},$' "$fallback_file"
+    rg -q '^    colors = \{$' "$fallback_file"
+    rg -q '^        foreground = "#' "$fallback_file"
+    rg -q '^        background = "#' "$fallback_file"
+    rg -q '^        cursor_bg = "#' "$fallback_file"
+    rg -q '^        cursor_fg = "#' "$fallback_file"
+    rg -q '^        selection_bg = "#' "$fallback_file"
+    rg -q '^        ansi = \{ .+ \},$' "$fallback_file"
+    rg -q '^        brights = \{ .+ \},$' "$fallback_file"
+}
+
+
 build_report() {
     local format="$1"
     local output
@@ -198,6 +219,8 @@ build_report() {
 
     printf '%b\n' "$output"
 }
+
+check_wezterm_fallback_schema
 
 for provider in "${providers[@]}"; do
     for field in "${TINO_TERMINAL_CONTRACT_FIELDS[@]}"; do

--- a/dotfiles/terminal/.config/wezterm/wezterm.lua
+++ b/dotfiles/terminal/.config/wezterm/wezterm.lua
@@ -6,9 +6,32 @@ end
 local profile = generated .. "/wezterm/wezterm.generated.lua"
 local ok, conf = pcall(dofile, profile)
 if ok then
+    -- Authoritative terminal profile rendered by terminal-profile.sh.
     return conf
 end
 
+local wezterm = require("wezterm")
+
+-- Safe baseline fallback when wezterm.generated.lua is unavailable.
 return {
+    font = wezterm.font_with_fallback({
+        "CaskaydiaCove Nerd Font",
+        "JetBrains Mono",
+        "FiraCode Nerd Font",
+        "Noto Color Emoji",
+    }),
     font_size = 13.0,
+    window_background_opacity = 0.92,
+    use_fancy_tab_bar = false,
+    hide_tab_bar_if_only_one_tab = true,
+    window_padding = { left = 10, right = 10, top = 8, bottom = 8 },
+    colors = {
+        foreground = "#f2f2f2",
+        background = "#000000",
+        cursor_bg = "#FC17DA",
+        cursor_fg = "#000000",
+        selection_bg = "#301050",
+        ansi = { "#000000", "#ff66c4", "#b2ff59", "#ffff66", "#66b2ff", "#845CFF", "#66fff2", "#f2f2f2" },
+        brights = { "#666666", "#ff66c4", "#b2ff59", "#ffff66", "#66b2ff", "#FC17DA", "#66fff2", "#ffffff" },
+    },
 }

--- a/tests/test_validate_renderer_contract.py
+++ b/tests/test_validate_renderer_contract.py
@@ -52,3 +52,15 @@ def test_validate_renderer_contract_emits_markdown_report(tmp_path: Path) -> Non
     report = report_file.read_text(encoding="utf-8")
     assert "| Provider | FPS | Opacity | Effects |" in report
     assert "| windows-terminal | ❌ unsupported | ✅ applied | ✅ applied |" in report
+
+
+def test_wezterm_fallback_matches_baseline_contract() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    fallback = (repo_root / "dotfiles/terminal/.config/wezterm/wezterm.lua").read_text(encoding="utf-8")
+
+    assert "-- Authoritative terminal profile rendered by terminal-profile.sh." in fallback
+    assert "-- Safe baseline fallback when wezterm.generated.lua is unavailable." in fallback
+    assert "font_with_fallback" in fallback
+    assert "window_background_opacity" in fallback
+    assert "window_padding" in fallback
+    assert "colors = {" in fallback


### PR DESCRIPTION
### Motivation
- Ensure the WezTerm fallback returns the same baseline shape and defaults as the generated profile so renderer consumers can rely on a consistent contract when `wezterm.generated.lua` is missing. 
- Keep the generated profile authoritative while providing a deterministic safe baseline for unsupported or missing generated configs. 
- Extend renderer contract validation to assert the fallback schema fields (not only generated outputs) so CI/QA can detect regressions in fallback defaults. 

### Description
- Expanded `dotfiles/terminal/.config/wezterm/wezterm.lua` fallback table to include a font fallback list (`font_with_fallback`), `window_background_opacity`, tab-bar defaults (`use_fancy_tab_bar`, `hide_tab_bar_if_only_one_tab`), `window_padding`, and the baseline `colors` palette (foreground/background/cursor/selection/ansi/brights), and added a comment clarifying the generated file is authoritative and the table is a safe baseline. 
- Preserved generated-file precedence via `pcall(dofile, profile)` unchanged so the `wezterm.generated.lua` remains authoritative when present. 
- Added `check_wezterm_fallback_schema()` to `dotfiles/terminal/.config/tino/validate-renderer-contract.sh` and invoke it before provider capability checks to validate fallback schema fields with `rg` patterns. 
- Added `test_wezterm_fallback_matches_baseline_contract()` to `tests/test_validate_renderer_contract.py` to assert the presence of contract markers and key fallback fields in the fallback file. 

### Testing
- Ran the renderer contract script with `bash dotfiles/terminal/.config/tino/validate-renderer-contract.sh --report-format json --report-file /tmp/r.json`, which completed successfully and reported validation for 5 providers. 
- Executed unit tests with `pytest -q tests/test_validate_renderer_contract.py`, and all tests passed (`3 passed`). 
- Attempted `shellcheck dotfiles/terminal/.config/tino/validate-renderer-contract.sh` but `shellcheck` is not installed in the environment so linting was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80dcda51483269cc66e28ba5566ba)