### PR TITLE
Consolidate canonical Windows Terminal configuration authority

### DIFF
--- a/scripts/install-windows-terminal.ps1
+++ b/scripts/install-windows-terminal.ps1
@@ -1,4 +1,5 @@
-# Copy canonical generated Windows Terminal settings into the LocalState folder.
+# Copy canonical generated Windows Terminal settings from
+# windows-terminal/settings.json into the LocalState folder.
 $wtDir = Join-Path $Env:LOCALAPPDATA 'Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState'
 if (-not (Test-Path $wtDir)) {
     New-Item -ItemType Directory -Path $wtDir -Force | Out-Null

--- a/tablet-config/windows-terminal/README.md
+++ b/tablet-config/windows-terminal/README.md
@@ -1,7 +1,17 @@
-# Windows Terminal tablet config
+# Windows Terminal tablet snapshot / host override notes
 
-Windows Terminal settings now have a single canonical source in
-`windows-terminal/`.
+`windows-terminal/` is the only canonical source for Windows Terminal
+configuration.
 
-Use `windows-terminal/settings.base.json` + `windows-terminal/generate_settings.py`
-to regenerate `windows-terminal/settings.json`.
+This `tablet-config/windows-terminal/` directory is **not** a second authority;
+it is reserved for tablet-specific notes, snapshots, or host override examples.
+
+Canonical generation path:
+
+- Base: `windows-terminal/settings.base.json`
+- Generator: `windows-terminal/generate_settings.py`
+- Generated output: `windows-terminal/settings.json`
+
+If you need tablet-specific behavior, keep it as an explicit host override layer
+that is applied after canonical generation, rather than duplicating canonical
+JSON files here.

--- a/windows-terminal/README.md
+++ b/windows-terminal/README.md
@@ -1,11 +1,31 @@
-This folder contains the canonical Windows Terminal configuration.
+This folder is the **canonical source of truth** for Windows Terminal
+configuration in this repository.
+
 Common profile defaults live in `common-profiles.json` and are merged into the
 committed `settings.json` using `generate_settings.py`.
 
-To install these settings automatically, run
+To install these canonical settings automatically, run
 `scripts/install-windows-terminal.ps1` from the repository root. The script
 creates `%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState`
-if needed and copies `settings.json` there.
+if needed and copies `windows-terminal/settings.json` there.
+
+## Configuration layout and precedence
+
+| Layer | Path | Role | Precedence |
+|---|---|---|---|
+| Base config (canonical) | `windows-terminal/settings.base.json` | Maintained source for base Windows Terminal settings. | 1 (lowest) |
+| Common profile defaults (canonical) | `windows-terminal/common-profiles.json` | Shared profile defaults/list merged into base profiles. | 2 |
+| Host/device overrides | `windows-terminal/terminal-profile-overrides.json` | Generated or host-aware overrides (for defaults and schemes). | 3 |
+| Generated output (canonical build artifact) | `windows-terminal/settings.json` | Committed merged output produced by `windows-terminal/generate_settings.py`; copied to LocalState by installer. | 4 (highest, final materialized config) |
+| Legacy tablet snapshot/override example | `tablet-config/windows-terminal/` | Non-canonical snapshot/override docs for tablet-specific workflows. | Informational only; does not override canonical flow unless explicitly consumed by a host script. |
+
+Generate canonical output from the repository root:
+
+```bash
+python windows-terminal/generate_settings.py \
+  windows-terminal/settings.base.json \
+  windows-terminal/settings.json
+```
 
 The settings define `Alt+V` to split the active pane vertically and `Alt+H` to
 split it horizontally. Press `Alt+M` to launch

--- a/windows-terminal/generate_settings.py
+++ b/windows-terminal/generate_settings.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Generate Windows Terminal settings from a base file and common profiles."""
+"""Generate canonical Windows Terminal settings from layered repository inputs.
+
+Canonical paths:
+- base: windows-terminal/settings.base.json
+- common profiles: windows-terminal/common-profiles.json
+- terminal overrides: windows-terminal/terminal-profile-overrides.json
+- generated output: windows-terminal/settings.json
+"""
 import json
 import sys
 from pathlib import Path
@@ -99,14 +106,22 @@ def generate(base: Path, common: Path, output: Path, terminal_overrides: Path | 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("base", type=Path, help="Path to base settings JSON")
-    parser.add_argument("output", type=Path, help="Where to write merged settings")
+    parser.add_argument(
+        "base",
+        type=Path,
+        help="Path to canonical base settings JSON (typically windows-terminal/settings.base.json)",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="Where to write merged settings (typically windows-terminal/settings.json)",
+    )
     parser.add_argument("--common", type=Path, default=Path(__file__).parent / "common-profiles.json")
     parser.add_argument(
         "--terminal-overrides",
         type=Path,
         default=Path(__file__).parent / "terminal-profile-overrides.json",
-        help="Optional generated profile overrides from canonical terminal settings",
+        help="Optional host/device override layer (defaults to windows-terminal/terminal-profile-overrides.json)",
     )
     args = parser.parse_args()
     generate(args.base, args.common, args.output, args.terminal_overrides)


### PR DESCRIPTION
### Motivation

- Establish a single canonical source for Windows Terminal configuration to avoid duplicate authorities and accidental drift. 
- Mark existing `tablet-config/windows-terminal/` as a snapshot/host-override example rather than a second canonical source. 
- Make installer and generator tooling explicitly reference the canonical paths so generation and installation consistently operate on the same files. 

### Description

- Updated `windows-terminal/README.md` to declare `windows-terminal/` as the canonical source and added a configuration layout/precedence table that lists base config, common profiles, host/device overrides, generated output, and legacy tablet snapshot location. 
- Updated `tablet-config/windows-terminal/README.md` to document this directory as a non-canonical snapshot/host-override notes area and show the canonical generation path. 
- Clarified `scripts/install-windows-terminal.ps1` to indicate it copies `windows-terminal/settings.json` as the canonical generated artifact. 
- Enhanced `windows-terminal/generate_settings.py` docstring and CLI help text to reference canonical paths and describe the `--terminal-overrides` semantics as a host/device override layer. 

### Testing

- Ran `pytest -q tests/test_generate_settings.py tests/test_install_windows_terminal.py tests/test_config.py`, which initially failed due to missing test dependencies and required installing `requests` and `typer`. 
- After installing missing dependencies the test run completed with `8 passed, 2 skipped`. 
- Ran `ruff check windows-terminal/generate_settings.py tests/test_generate_settings.py tests/test_install_windows_terminal.py tests/test_config.py` and all lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80f94fbb8832682d0f818838901d5)