### PR TITLE
Add QA Terminal Modernization workflow and enforce report-based gate

### DIFF
--- a/.github/workflows/qa-terminal-modernization.yml
+++ b/.github/workflows/qa-terminal-modernization.yml
@@ -1,0 +1,113 @@
+name: QA Terminal Modernization
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - 'dotfiles/shell/**'
+      - 'dotfiles/tmux/**'
+      - 'dotfiles/terminal/**'
+      - 'dotfiles/nvim/**'
+      - 'hosts/**'
+      - 'scripts/qa_terminal_modernization.sh'
+      - 'scripts/benchmark_nvim_startup.sh'
+      - 'scripts/check-nvim-lockfile.py'
+      - '.github/workflows/qa-terminal-modernization.yml'
+      - 'README.md'
+  pull_request:
+    paths:
+      - 'dotfiles/shell/**'
+      - 'dotfiles/tmux/**'
+      - 'dotfiles/terminal/**'
+      - 'dotfiles/nvim/**'
+      - 'hosts/**'
+      - 'scripts/qa_terminal_modernization.sh'
+      - 'scripts/benchmark_nvim_startup.sh'
+      - 'scripts/check-nvim-lockfile.py'
+      - '.github/workflows/qa-terminal-modernization.yml'
+      - 'README.md'
+
+jobs:
+  qa-terminal-modernization:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      QA_REPORT: .cache/tino/qa-terminal-modernization/report.json
+      QA_RENDERER_REPORT: .cache/tino/qa-terminal-modernization/renderer-contract.json
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install QA dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh tmux neovim ripgrep fd-find stow curl
+          curl -fsSL https://starship.rs/install.sh | sh -s -- --yes --bin-dir "$HOME/.local/bin"
+          printf '%s\n' "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run terminal modernization QA script
+        id: qa
+        continue-on-error: true
+        run: ./scripts/qa_terminal_modernization.sh
+
+      - name: Upload QA reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-terminal-modernization-report
+          path: |
+            .cache/tino/qa-terminal-modernization/report.json
+            .cache/tino/qa-terminal-modernization/renderer-contract.json
+          if-no-files-found: error
+
+      - name: Enforce QA gate policy
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report_path = Path('.cache/tino/qa-terminal-modernization/report.json')
+          if not report_path.exists():
+              raise SystemExit(f'Missing QA report: {report_path}')
+
+          report = json.loads(report_path.read_text(encoding='utf-8'))
+          checks = {check['id']: check for check in report.get('checks', [])}
+
+          allowed_warning_prefixes = ('diagnostics_',)
+          disallowed_failures = []
+          disallowed_warnings = []
+          allowed_warnings = []
+
+          for check in checks.values():
+              status = check.get('status')
+              check_id = check.get('id', '<unknown>')
+              details = check.get('details', '')
+              is_allowed_warning = status == 'warn' and check_id.startswith(allowed_warning_prefixes)
+
+              if is_allowed_warning:
+                  allowed_warnings.append(f"{check_id}: {details}")
+                  continue
+
+              if status == 'fail':
+                  disallowed_failures.append(f"{check_id}: {details}")
+              elif status == 'warn':
+                  disallowed_warnings.append(f"{check_id}: {details}")
+
+          print('Allowed warnings (provider/runtime diagnostics only):')
+          if allowed_warnings:
+              for item in allowed_warnings:
+                  print(f'  - {item}')
+          else:
+              print('  - none')
+
+          if disallowed_failures or disallowed_warnings:
+              print('\nDisallowed QA results detected:')
+              for item in disallowed_failures:
+                  print(f'  - FAIL {item}')
+              for item in disallowed_warnings:
+                  print(f'  - WARN {item}')
+              raise SystemExit(1)
+
+          print('\nQA gate policy passed.')
+          PY

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ Terminal modernization acceptance gate (run after shell/tmux/nvim/terminal profi
 ./scripts/qa_terminal_modernization.sh
 ```
 
+GitHub Actions enforces the same gate via the `QA Terminal Modernization` workflow. Protect `main` by requiring the `qa-terminal-modernization` status check, and download the `qa-terminal-modernization-report` artifact when you need the published `.cache/tino/qa-terminal-modernization/report.json` and renderer contract JSON outputs from CI. The workflow's policy is explicit: provider/runtime binary absence is allowed to surface as warnings for the `diagnostics_*` checks, while contract and regression checks (for example renderer validation, Neovim/zsh/tmux regressions, and required tool presence) must stay green.
+
 
 ## Changelog (auto‑updated)
 


### PR DESCRIPTION
### Motivation
- Promote the existing terminal QA script from a local convention to an enforceable CI quality gate to catch renderer/contract/regression regressions before merges. 
- Explicitly allow provider/runtime binary absence to surface as warnings while treating contract and regression checks as failures.

### Description
- Add a new GitHub Actions workflow `QA Terminal Modernization` that runs `./scripts/qa_terminal_modernization.sh` for changes touching terminal/shell/tmux/nvim/hosts and the QA scripts. 
- Publish `.cache/tino/qa-terminal-modernization/report.json` and `.cache/tino/qa-terminal-modernization/renderer-contract.json` as the `qa-terminal-modernization-report` artifact. 
- Enforce an explicit policy step that permits `diagnostics_*` warnings (provider/runtime binary absence) but fails the job for any non-allowed warnings or any `fail` statuses from the JSON report. 
- Document the workflow name, the required `qa-terminal-modernization` status check, artifact contents and the warn/fail policy in `README.md` next to the existing QA script guidance.

### Testing
- Parsed the new workflow YAML with `yaml.safe_load` to validate syntax, which succeeded. 
- Executed `./scripts/qa_terminal_modernization.sh` locally to exercise report generation, which produced the JSON reports but returned a failing overall status in this container due to missing runtime binaries (expected in the CI runner). 
- Verified the workflow publishes the expected artifact paths and that the enforcement step detects provider diagnostics as allowed warnings while failing on contract/regression failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa8f1d8ac83269b9312873128343a)