### PR TITLE
Simplify PowerShell prompt to Starship only

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -160,7 +160,7 @@ Update the package with `scoop update tino`.
    ```
    The helper automatically runs `fix-path.ps1` to clean up duplicate entries and ensure your `bin` directory is included.
    If `$Env:USERPROFILE` isn't defined (e.g. on Linux), it falls back to `$HOME`.
-4. Restart the terminal or run `. $PROFILE` to reload the profile and load the new settings.
+4. Restart the terminal or run `. $PROFILE` to reload the profile and load the new settings. The managed PowerShell profile keeps Starship as the only prompt/status layer, while optional helpers such as `PSReadLine` and `zoxide` remain separate from prompt rendering.
 
 ## WSL
 
@@ -512,4 +512,3 @@ When the new dashboard implementation lands:
    ```
 3. Browse to <http://localhost:3000> to open the dashboard.
 4. See [the dashboard guide](dashboard.md) for development tips.
-

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -27,7 +27,9 @@ The terminal experience is composed of four layers:
 - `dotfiles/shell/.config/starship.toml` is the single prompt configuration source for all supported shells.
 - `dotfiles/shell/.zshrc` owns the zsh prompt bootstrap (`eval "$(starship init zsh)"`).
 - `powershell/user_profile.ps1` owns the PowerShell prompt bootstrap (`starship init powershell`) and points `STARSHIP_CONFIG` at the tracked Starship config.
-- Keep prompt behavior Starship-only across managed shell profiles.
+- Keep prompt behavior Starship-only across managed shell profiles; do not add shell-specific prompt decorators like `posh-git`.
+- Git branch/status context in PowerShell should come from the shared Starship `git_branch` and `git_status` modules, not a separate PowerShell-only layer.
+- Optional helpers such as `PSReadLine` and `zoxide` are fine when they improve editing or navigation without duplicating prompt/status output.
 
 2. **Multiplexer (`tmux`)**
    - Stable session management and keybinding layer.

--- a/docs/thm.md
+++ b/docs/thm.md
@@ -16,6 +16,10 @@ colors. Palettes are defined under `palettes/` – besides the default
 `blacklight` scheme, example palettes such as `dracula` and
 `solarized-dark` are provided.
 
+On Windows, this means the managed PowerShell experience stays aligned with the
+shared Starship theme; prompt Git context and status indicators come from
+Starship modules rather than separate PowerShell-only prompt decorators.
+
 Set the `THM_REPO_ROOT` environment variable if you want to apply a palette to
 a different repository location. Install the CLI with `pip install -e .[cli]`
 so the `thm` command works properly.

--- a/powershell/user_profile.ps1
+++ b/powershell/user_profile.ps1
@@ -1,14 +1,11 @@
 # === dev-setup profile ==================================================
-# Starship prompt
+# Starship is the only prompt/status layer.
 if (Get-Command starship -ErrorAction SilentlyContinue) {
     $Env:STARSHIP_CONFIG = Join-Path (Split-Path $PSScriptRoot -Parent) 'starship.toml'
     Invoke-Expression ((& starship init powershell) -join "`n")
 }
 
-# posh-git (branch + status decorations)
-Import-Module posh-git -ErrorAction SilentlyContinue
-
-# fzf tab-completion
+# Optional line editing enhancements that do not replace the prompt.
 if (Get-Module -ListAvailable -Name PSReadLine) {
     Import-Module PSReadLine
     Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete

--- a/tests/test_powershell.py
+++ b/tests/test_powershell.py
@@ -11,7 +11,6 @@ def test_user_profile_not_empty():
 def test_user_profile_contains_required_commands():
     lines = USER_PROFILE_PATH.read_text().splitlines()
     assert any("starship" in line.lower() for line in lines), "starship invocation missing"
-    assert any("posh-git" in line.lower() for line in lines), "posh-git invocation missing"
     assert any("zoxide" in line.lower() for line in lines), "zoxide invocation missing"
 
 
@@ -40,16 +39,18 @@ def test_zoxide_after_fzf_block():
 
 
 def test_profile_handles_missing_tools_gracefully():
-    """Starship, posh-git and zoxide should be optional."""
+    """Starship and zoxide should be optional."""
     lines = [line.lower() for line in USER_PROFILE_PATH.read_text().splitlines()]
 
     starship_line = next((line for line in lines if "get-command starship" in line), "")
     assert "if (get-command starship" in starship_line
     assert "-erroraction silentlycontinue" in starship_line
 
-    posh_git_line = next((line for line in lines if "import-module posh-git" in line), "")
-    assert "-erroraction silentlycontinue" in posh_git_line
-
     zoxide_line = next((line for line in lines if "get-command zoxide" in line), "")
     assert "if (get-command zoxide" in zoxide_line
     assert "-erroraction silentlycontinue" in zoxide_line
+
+
+def test_user_profile_does_not_import_posh_git():
+    text = USER_PROFILE_PATH.read_text().lower()
+    assert "posh-git" not in text


### PR DESCRIPTION
### Motivation
- Reduce duplication and conflicting prompt decorations by making Starship the single prompt/status layer for PowerShell and remove a secondary PowerShell-only Git decoration path.
- Stop depending on `posh-git` for branch/status decorations and instead rely on the shared `dotfiles/shell/.config/starship.toml` Starship modules for Git context.
- Keep optional helpers (editing/navigation) such as `PSReadLine` and `zoxide` only when they do not duplicate prompt/status responsibilities.

### Description
- Remove `Import-Module posh-git` from `powershell/user_profile.ps1` and update the header comment to state Starship is the only prompt/status layer, while preserving optional `PSReadLine` and `zoxide` initialization.
- Update `tests/test_powershell.py` to stop asserting `posh-git` is present, add `test_user_profile_does_not_import_posh_git()` to prevent regressions, and keep checks for Starship and `zoxide` ordering and optionality.
- Update `docs/terminal.md` to explicitly note PowerShell should not add shell-specific prompt decorators and that Git branch/status should come from the shared Starship modules.
- Update `docs/installation.md` and `docs/thm.md` to document the simplified PowerShell model and that prompt/theme alignment on Windows is driven by Starship.

### Testing
- Ran `ruff check tests/test_powershell.py`, which passed successfully.
- Ran `pytest tests/test_powershell.py`, which failed in this environment due to `tests/conftest.py` importing `requests` (module not installed), not because of the changed PowerShell tests themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab92a06dc83268be7078d2f756c46)