### PR TITLE
docs: refresh desktop setup guide

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,16 +1,79 @@
 # Desktop Configuration
 
-Desktop-specific overrides now live in host overlays under `hosts/desktop`.
+Desktop-specific settings are modeled as a host overlay in `hosts/desktop`.
+The current desktop flow matches the shared dotfiles architecture described in
+`README.md`, the terminal operations reference, and the install/bootstrap
+scripts.
 
-## Usage
+## Architecture
 
-1. Clone the repository.
-2. Apply the shared dotfile packages you need, for example:
-   ```bash
-   stow --target="$HOME" dotfiles/shell dotfiles/tmux
-   ```
-3. Apply the desktop host overlay:
-   ```bash
-   stow --target="$HOME" hosts/desktop
-   ```
-4. Source `~/.config/tino/host-overrides.sh` from your shell startup file if you use host environment variables.
+The desktop setup is applied in two layers:
+
+1. **Core dotfile packages** from `dotfiles/`
+   - `shell`
+   - `nvim`
+   - `tmux`
+   - `terminal`
+2. **Host overlay** from `hosts/desktop`
+
+This is the same package set used by `scripts/install_dotfiles.sh` when no
+custom `--packages` list is provided, and the same overlay ordering used by
+`scripts/bootstrap-dev-env.sh` when it passes `--host desktop`.
+
+Configuration precedence is:
+
+1. `dotfiles/terminal/.config/tino/terminal-defaults.sh`
+2. `hosts/desktop/.config/tino/host-overrides.sh`
+3. Explicit CLI provider overrides such as `--provider ghostty`
+
+Because the managed `dotfiles/shell/.zshrc` already loads both
+`~/.config/tino/terminal-defaults.sh` and `~/.config/tino/host-overrides.sh`,
+you do **not** need to manually source the host override file when you are using
+this repository's managed shell profile.
+
+## Recommended setup
+
+### Option 1: Use the declarative bootstrap flow
+
+From the repository root:
+
+```bash
+./scripts/bootstrap-dev-env.sh --host desktop
+```
+
+This is the primary workflow. It runs the dependency/bootstrap stages in order:
+
+1. `scripts/install_common.sh`
+2. `scripts/install_dotfiles.sh --host desktop`
+3. `scripts/setup-nvim.sh`
+4. `scripts/setup-terminal-provider.sh <resolved-provider>`
+5. terminal renderer contract validation
+
+Use `--provider <name>` if you want to override the provider selected from the
+base defaults plus the desktop overlay.
+
+### Option 2: Apply the layers directly with Stow
+
+If you only want the dotfiles/overlay layout without the full bootstrap flow,
+apply the same package order manually:
+
+```bash
+# Core defaults first
+stow --target="$HOME" --dir=dotfiles shell nvim tmux terminal
+
+# Desktop host overlay second
+stow --target="$HOME" --dir=hosts desktop
+```
+
+This mirrors the current `scripts/install_dotfiles.sh` behavior:
+core packages first, then the host overlay.
+
+## Expected behavior on desktop hosts
+
+- Shared terminal defaults come from `~/.config/tino/terminal-defaults.sh`.
+- Desktop-only overrides live in `~/.config/tino/host-overrides.sh`.
+- When both files define the same variable, the desktop overlay wins.
+- The desktop overlay can also set `TINO_TERMINAL_PROVIDER`, which is then used
+  unless you explicitly override it with a CLI flag.
+- Managed `.zshrc` loads the defaults first and the desktop overlay second, so
+  shell startup sees the same precedence as the install/bootstrap scripts.


### PR DESCRIPTION
### Motivation

- Update the desktop documentation to match the current dotfiles/install/bootstrap architecture and remove outdated setup guidance.
- Replace the old partial `stow` example and the instruction to manually source host overrides with the canonical package set and host-overlay flow used by the repo's scripts.

### Description

- Rewrote `docs/desktop.md` to describe the two-layer flow: core dotfile packages (`shell`, `nvim`, `tmux`, `terminal`) followed by the `hosts/desktop` overlay.
- Replaced the partial `stow` example with the current `stow --dir=dotfiles shell nvim tmux terminal` plus `stow --dir=hosts desktop` pattern and documented the preferred declarative bootstrap path `./scripts/bootstrap-dev-env.sh --host desktop`.
- Removed the outdated instruction to manually source `~/.config/tino/host-overrides.sh` and noted that the managed `dotfiles/shell/.zshrc` already sources terminal defaults and host overrides.
- Audited `README.md` and `docs/` for the same drift phrases and found no additional files requiring edits.

### Testing

- Ran repository grep audits for outdated phrases (searching for host override sourcing and older partial `stow` examples) which found the drift only in `docs/desktop.md` and confirmed no other docs required changes.
- This is a documentation-only change and, per repo/user policy, no unit tests or linters were executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babd44ec3c8326bb77a6457718d800)