### PR TITLE
feat: add minimal Python/virtualenv indicator to Starship prompt

### DIFF
--- a/dotfiles/shell/.config/starship.toml
+++ b/dotfiles/shell/.config/starship.toml
@@ -77,7 +77,7 @@ stashed = "📦"
 
 [python]
 symbol = " "
-format = "[$symbol($virtualenv )]($style)"
+format = "[$symbol($virtualenv )($version)]($style) "
 style = "fg:green"
 
 [kubernetes]

--- a/scripts/helpers/starship_spec.py
+++ b/scripts/helpers/starship_spec.py
@@ -48,7 +48,7 @@ STARSHIP_MODULES: list[tuple[str, dict[str, object]]] = [
         "python",
         {
             "symbol": " ",
-            "format": "[$symbol($virtualenv )]($style)",
+            "format": "[$symbol($virtualenv )($version)]($style) ",
             "style": "fg:green",
         },
     ),

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -21,3 +21,13 @@ def test_starship_multiline_format():
     data = load_starship()
     assert data.get('format') == STARSHIP_PROMPT_FORMAT, 'prompt format mismatch'
     assert data.get('add_newline') is False, 'add_newline should be false'
+
+
+def test_starship_python_indicator_is_minimal_and_contextual():
+    data = load_starship()
+    python = data['python']
+    assert python['symbol'] == ' '
+    assert python['style'] == 'fg:green'
+    assert python['format'] == '[$symbol($virtualenv )($version)]($style) '
+    assert '$virtualenv' in python['format']
+    assert '$version' in python['format']

--- a/tests/test_starship_palette.py
+++ b/tests/test_starship_palette.py
@@ -1,9 +1,11 @@
 from starship_expectations import STARSHIP_PROMPT_FORMAT, expected_default_palette, load_starship
 
+
 def test_blacklight_format_and_newline():
     data = load_starship()
     assert data.get('format') == STARSHIP_PROMPT_FORMAT, 'format string mismatch'
     assert data.get('add_newline') is False, 'add_newline should be false'
+
 
 def test_default_palette_colors():
     data = load_starship()
@@ -12,6 +14,13 @@ def test_default_palette_colors():
     palette = data.get('palettes', {}).get(default_name, {})
     for name, value in expected_colors.items():
         assert palette.get(name) == value, f'{name} color mismatch'
+
+
+def test_python_module_palette_alignment():
+    data = load_starship()
+    python = data['python']
+    assert python['style'] == 'fg:green'
+    assert python['symbol'] == ' '
 
 
 


### PR DESCRIPTION
### Motivation
- Provide a lightweight, contextual Python indicator in the Starship prompt that only appears when relevant (active virtualenv or interpreter context) while keeping the prompt low-noise and fast.
- Ensure the Python indicator aligns with the existing palette and prompt structure so generated artifacts and tests remain stable.

### Description
- Update `dotfiles/shell/.config/starship.toml` to render `($virtualenv )($version)` for the `python` module while keeping the `fg:green` style and the existing symbol. 
- Sync the canonical prompt spec in `scripts/helpers/starship_spec.py` to the new `python` module format so generators and tests match the config.
- Add `tests/test_starship.py` assertions to lock the Python module's `symbol`, `style`, and `format` to the new minimal `virtualenv + version` representation.
- Add `tests/test_starship_palette.py` assertions to ensure the Python module continues to use the configured green style and symbol.

### Testing
- Ran the Starship TOML parse check with `python - <<'PY' ... tomllib.loads(...)` which reported `toml parse ok`.
- Ran unit tests with `pytest tests/test_starship.py tests/test_starship_palette.py` and observed all tests passing (`7 passed`).
- Ran lint/static checks with `ruff check tests/test_starship.py tests/test_starship_palette.py tests/starship_expectations.py scripts/helpers/starship_spec.py` which passed.
- Installed local package with `python -m pip install -e .` as part of the test run and dependency resolution succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac23bea4c83269ca3471f4ab14cb9)