### PR TITLE
Unify terminal provider policy states (Ghostty canonical, WezTerm fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `hosts/desktop` and `hosts/work_laptop` → machine-specific overrides
   - `hosts/desktop/.config/tino/host-overrides.sh` favors richer visuals/high refresh
   - `hosts/work_laptop/.config/tino/host-overrides.sh` keeps effects balanced for battery life
-  - host overlays can also set `TINO_TERMINAL_PROVIDER` (for example, desktop `ghostty` vs. work laptop `wezterm`) and `scripts/install_common.sh` will use that provider when `--terminal` is not provided.
+  - host overlays can also tune terminal policy inputs. In the current tracked profiles, both desktop and work_laptop keep `ghostty` as the default provider, while `hosts/work_laptop` prefers `wezterm` first in fallback order if Ghostty is unavailable. `scripts/install_common.sh` uses the resolved provider when `--terminal` is not provided.
 
 Example:
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -47,15 +47,16 @@ The terminal experience is composed of four layers:
 
 Provider defaults are policy-driven and deterministic:
 
-- **Linux/macOS desktop hosts:** canonical provider is **Ghostty**.
+- **Non-Windows hosts:** canonical provider is **Ghostty**.
 - **Windows hosts:** canonical provider is **Windows Terminal**.
-- **WezTerm, Kitty, and Alacritty** are supported as **fallback/compatibility targets** when the canonical provider is unavailable or when explicitly requested.
+- **Host-approved** defaults are resolved by `terminal-profile.sh`; today that is the same as the canonical provider on every tracked host profile, including `hosts/work_laptop`.
+- **WezTerm, Kitty, and Alacritty** are supported as **fallback/compatibility targets** when the canonical provider is unavailable or when explicitly requested. On `hosts/work_laptop`, WezTerm is the preferred compatibility fallback order, not a first-class default.
 
 Implementation details:
 
-- `dotfiles/terminal/.config/tino/terminal-profile.sh --canonical-provider` resolves the host canonical provider.
+- `dotfiles/terminal/.config/tino/terminal-profile.sh --canonical-provider` resolves the canonical provider, `--host-approved-providers` lists policy-approved defaults, and `--policy-state <provider>` classifies a provider as `canonical`, `host-approved`, or `fallback`.
 - `scripts/setup-terminal-provider.sh` logs provider resolution decisions and uses explicit fallback logs when it must deviate from the requested/canonical provider.
-- `scripts/qa_terminal_modernization.sh` warns when active host defaults (`TINO_TERMINAL_PROVIDER` from defaults + host override) do not match canonical provider policy.
+- `scripts/qa_terminal_modernization.sh` warns only when active host defaults resolve to a fallback-only provider state; canonical and host-approved defaults are treated as policy-compliant.
 
 ## Host overrides model (`hosts/desktop`, `hosts/work_laptop`)
 
@@ -68,7 +69,7 @@ Configuration precedence is:
 Use overlays to keep per-machine deltas small:
 
 - `hosts/desktop`: higher visual fidelity/high-refresh-friendly defaults.
-- `hosts/work_laptop`: balanced settings for battery and thermals.
+- `hosts/work_laptop`: balanced settings for battery and thermals, while keeping Ghostty as the default and preferring WezTerm first in compatibility fallback order.
 
 This model ensures you can keep a single operational workflow while still tuning ergonomics per device.
 

--- a/dotfiles/terminal/.config/tino/terminal-profile.sh
+++ b/dotfiles/terminal/.config/tino/terminal-profile.sh
@@ -62,6 +62,42 @@ terminal_canonical_provider() {
     printf 'ghostty\n'
 }
 
+terminal_host_approved_providers() {
+    local canonical_provider
+    canonical_provider="$(terminal_canonical_provider)"
+    printf '%s\n' "$canonical_provider"
+}
+
+terminal_provider_policy_state() {
+    local provider="$1"
+    local approved_provider=""
+    local canonical_provider
+
+    case "$provider" in
+        ghostty|wezterm|kitty|alacritty|windows-terminal)
+            ;;
+        *)
+            printf 'unsupported\n'
+            return 0
+            ;;
+    esac
+
+    canonical_provider="$(terminal_canonical_provider)"
+    if [[ "$provider" == "$canonical_provider" ]]; then
+        printf 'canonical\n'
+        return 0
+    fi
+
+    while IFS= read -r approved_provider; do
+        if [[ "$provider" == "$approved_provider" ]]; then
+            printf 'host-approved\n'
+            return 0
+        fi
+    done < <(terminal_host_approved_providers)
+
+    printf 'fallback\n'
+}
+
 readonly TINO_TERMINAL_CONTRACT_PROVIDERS=(
     ghostty
     wezterm
@@ -217,6 +253,20 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 
     if [[ ${1:-} == "--canonical-provider" ]]; then
         terminal_canonical_provider
+        exit 0
+    fi
+
+    if [[ ${1:-} == "--host-approved-providers" ]]; then
+        terminal_host_approved_providers
+        exit 0
+    fi
+
+    if [[ ${1:-} == "--policy-state" ]]; then
+        if [[ $# -ne 2 ]]; then
+            echo "Usage: $(basename "$0") --policy-state <provider>" >&2
+            exit 1
+        fi
+        terminal_provider_policy_state "$2"
         exit 0
     fi
 

--- a/hosts/work_laptop/.config/tino/host-overrides.sh
+++ b/hosts/work_laptop/.config/tino/host-overrides.sh
@@ -1,5 +1,6 @@
 # Laptop profile: keep visuals tasteful while reducing battery impact.
-export TINO_TERMINAL_PROVIDER="wezterm"
+# Keep Ghostty as the canonical/default provider; prefer WezTerm first when fallback is needed.
+export TINO_TERMINAL_PROVIDER_PREFERENCES="wezterm kitty alacritty"
 export TINO_TERMINAL_OPACITY="0.96"
 export TINO_TERMINAL_FPS="90"
 export TINO_TERMINAL_EFFECTS="balanced"

--- a/scripts/qa_terminal_modernization.sh
+++ b/scripts/qa_terminal_modernization.sh
@@ -341,8 +341,12 @@ if [[ -f "$terminal_defaults_path" ]]; then
 fi
 
 canonical_provider=""
+provider_policy_state=""
 if [[ -x "$terminal_profile_script" ]]; then
     canonical_provider="$(bash "$terminal_profile_script" --canonical-provider 2>/dev/null || true)"
+    if [[ -n "$active_provider_default" ]]; then
+        provider_policy_state="$(bash "$terminal_profile_script" --policy-state "$active_provider_default" 2>/dev/null || true)"
+    fi
 fi
 
 if [[ -z "$canonical_provider" ]]; then
@@ -350,11 +354,11 @@ if [[ -z "$canonical_provider" ]]; then
 fi
 
 if [[ -z "$active_provider_default" ]]; then
-    record_check "terminal_provider_default_policy" "active host default provider matches canonical provider policy" "warn" "unable to resolve active provider default from terminal defaults/host overrides"
-elif [[ "$active_provider_default" == "$canonical_provider" ]]; then
-    record_check "terminal_provider_default_policy" "active host default provider matches canonical provider policy" "pass" "active_default=$active_provider_default canonical=$canonical_provider host_profile=${active_host_profile:-none}"
+    record_check "terminal_provider_default_policy" "active host default provider matches terminal provider policy" "warn" "unable to resolve active provider default from terminal defaults/host overrides"
+elif [[ "$provider_policy_state" == "canonical" || "$provider_policy_state" == "host-approved" ]]; then
+    record_check "terminal_provider_default_policy" "active host default provider matches terminal provider policy" "pass" "active_default=$active_provider_default policy_state=${provider_policy_state:-unknown} canonical=$canonical_provider host_profile=${active_host_profile:-none}"
 else
-    record_check "terminal_provider_default_policy" "active host default provider matches canonical provider policy" "warn" "active_default=$active_provider_default canonical=$canonical_provider host_profile=${active_host_profile:-none}; non-canonical defaults should be treated as compatibility fallback"
+    record_check "terminal_provider_default_policy" "active host default provider matches terminal provider policy" "warn" "active_default=$active_provider_default policy_state=${provider_policy_state:-fallback} canonical=$canonical_provider host_profile=${active_host_profile:-none}; fallback-only defaults should be treated as policy drift"
 fi
 
 if [[ -f "$powershell_profile_path" ]]; then

--- a/tests/test_terminal_profile.py
+++ b/tests/test_terminal_profile.py
@@ -45,3 +45,16 @@ def test_terminal_profile_preferences_prioritize_canonical_provider(tmp_path: Pa
 def test_windows_terminal_settings_json_is_present() -> None:
     settings_path = Path(__file__).resolve().parents[1] / "windows-terminal" / "settings.json"
     assert settings_path.is_file(), "windows-terminal/settings.json should exist"
+
+
+def test_terminal_profile_policy_state_classifies_wezterm_as_fallback_on_non_windows(tmp_path: Path) -> None:
+    profile = _copy_terminal_profile(tmp_path)
+    result = subprocess.run(["/bin/bash", str(profile), "--policy-state", "wezterm"], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "fallback"
+
+
+def test_terminal_profile_host_approved_providers_match_canonical_default(tmp_path: Path) -> None:
+    profile = _copy_terminal_profile(tmp_path)
+    result = subprocess.run(["/bin/bash", str(profile), "--host-approved-providers"], capture_output=True, text=True, check=True)
+    providers = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert providers == ["ghostty"]


### PR DESCRIPTION
### Motivation
- Resolve ambiguity about whether WezTerm on `hosts/work_laptop` is a first-class default or a fallback by making policy explicit and single-sourced. 
- Keep non-Windows machines canonical on Ghostty while allowing compatibility fallbacks such as WezTerm without surfacing policy drift in setup/docs/QA.

### Description
- Added policy helpers to the terminal profile script: `--host-approved-providers` and `--policy-state <provider>` with functions `terminal_host_approved_providers` and `terminal_provider_policy_state` in `dotfiles/terminal/.config/tino/terminal-profile.sh` to classify providers as `canonical`, `host-approved`, or `fallback`.
- Removed the hardcoded `TINO_TERMINAL_PROVIDER="wezterm"` from `hosts/work_laptop/.config/tino/host-overrides.sh` and replaced it with `TINO_TERMINAL_PROVIDER_PREFERENCES="wezterm kitty alacritty"` so WezTerm is a preferred compatibility fallback rather than a host default.
- Updated QA to consume the new policy state: `scripts/qa_terminal_modernization.sh` now calls the profile script to check `policy-state` and treats canonical/host-approved as compliant while warning only when an active default is a fallback-only provider.
- Synchronized documentation to match the decision by updating `docs/terminal.md` and `README.md` to state Ghostty is the canonical non-Windows provider and WezTerm is a preferred fallback on `work_laptop`.
- Added regression tests in `tests/test_terminal_profile.py` to verify the new CLI helpers classify WezTerm as `fallback` on non-Windows hosts and that `--host-approved-providers` returns the expected approved list.

### Testing
- Syntax-checked the modified scripts with `bash -n dotfiles/terminal/.config/tino/terminal-profile.sh scripts/qa_terminal_modernization.sh hosts/work_laptop/.config/tino/host-overrides.sh` which succeeded.
- Ran `pytest -q tests/test_terminal_profile.py` and observed `6 passed` including the newly added policy-state and host-approved provider tests.
- Ran `pytest -q tests/test_install_common.py -k 'selects_terminal_provider_from_host_override'` which passed (host override selection behavior preserved).
- Executed `./scripts/qa_terminal_modernization.sh`; the terminal policy check passed, and the script reported expected environment warnings because bootstrap binaries (e.g. `zsh`, `starship`, `tmux`, `nvim`, `stow`, `fd`) are not present in this CI/container environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0f303d608326a7b060b07025f496)