### PR TITLE
Refactor bootstrap install orchestration and extract shared install context

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Dotfiles are organized into explicit stow-style packages under `dotfiles/` with 
 - `dotfiles/terminal/.config/tino/ghostty.toml.tmpl` → authored Ghostty template (renderer input)
 - `dotfiles/terminal/.config/tino/renderers/*.sh` → provider renderers that generate concrete config files from the terminal profile contract
 - `scripts/bootstrap-dev-env.sh` → primary declarative bootstrap workflow with auditable stages. It orchestrates dependency install/apply (`scripts/install_common.sh`), `scripts/install_dotfiles.sh`, `scripts/setup-nvim.sh`, `scripts/setup-terminal-provider.sh`, and renderer contract validation. It emits both JSON and human-readable reports (host overlay, provider chosen, versions, skipped steps, dependency install mode/dry-run, default shell policy, and login shell post-check `login_shell_matches_zsh`). `--plan` is the only dry-run path; default apply mode performs real dependency installation.
-- `scripts/install_common.sh` → legacy/compatibility bootstrap script; still available for broader OS-specific automation and optional Windows provisioning flags, and remains the canonical TPM installer/recovery path (`~/.tmux/plugins/tpm/tpm`).
+- `scripts/install_common.sh` → internal dependency/setup primitive used by `scripts/bootstrap-dev-env.sh`; it now focuses on package/tool provisioning and narrow recovery tasks such as TPM/plugin/font installation, and remains the canonical TPM recovery path (`~/.tmux/plugins/tpm/tpm`).
 - `scripts/setup-terminal-provider.sh <provider>` → entry point for provider-specific setup/rendering (`ghostty|wezterm|kitty|alacritty|windows-terminal`) via `~/.config/tino/terminal-profile.sh`
 - `scripts/qa_terminal_modernization.sh` → canonical terminal modernization acceptance gate after config changes (zsh/tmux/starship/nvim/renderer contract checks) with human-readable output + CI JSON report (`.cache/tino/qa-terminal-modernization/report.json`).
 - `scripts/install_dotfiles.sh` → deploys managed dotfiles into the user target (for example `$HOME`) by writing tracked rc files/symlinks; `dotfiles/shell/.zshrc` is the source of truth for plugin sourcing and `starship init`.
@@ -224,7 +224,8 @@ Expected behavior:
 
 | Flow | Purpose | Writes/symlinks in user target (`$HOME`/XDG paths) |
 | --- | --- | --- |
-| `./scripts/install_common.sh` | Bootstrap dependencies + deploy managed dotfiles | Installs tools/assets (e.g. zsh plugins, Neovim/Ghostty assets) and invokes `scripts/install_dotfiles.sh` to create/update managed rc file symlinks. |
+| `./scripts/bootstrap-dev-env.sh` | Canonical end-to-end bootstrap | Orchestrates dependency setup, dotfile deployment, Neovim provisioning, terminal provider rendering, and validation/reporting. |
+| `./scripts/install_common.sh` | Internal dependency/recovery helper | Installs baseline tools/assets and narrow recovery items (for example zsh plugins, TPM, fonts, palettes, hooks, optional Windows helpers) without driving the full bootstrap flow. |
 | `./scripts/install_dotfiles.sh [--host ...]` | Dotfile deployment only | Creates/updates tracked rc/config symlinks from `dotfiles/` (and optional `hosts/`) into the user target. |
 | `./scripts/migrate-shell-config.sh [--force]` | Optional legacy import | Writes `~/.config/zsh/{env,aliases,functions}.zsh` fragments from legacy bash content + backup; does not manage tracked dotfile symlinks. |
 
@@ -234,7 +235,7 @@ Terminal profile values flow through one path:
 
 1. `~/.config/tino/terminal-defaults.sh` provides shared defaults.
 2. `~/.config/tino/host-overrides.sh` applies host-specific overrides.
-3. `TINO_TERMINAL_PROVIDER` is selected from defaults/overrides unless `--terminal` is passed to `scripts/install_common.sh`.
+3. `TINO_TERMINAL_PROVIDER` is selected from defaults/overrides unless `--provider` is passed to `scripts/bootstrap-dev-env.sh` or `--terminal` is passed to the internal `scripts/install_common.sh` helper.
 4. `~/.config/tino/terminal-profile.sh` loads both files and runs a renderer from `~/.config/tino/renderers/*.sh`.
 5. The renderer writes provider output files (for Ghostty: `~/.config/ghostty/ghostty.toml`).
 
@@ -252,7 +253,7 @@ Cloud prompt visibility is decided in `dotfiles/shell/.zshrc` before `starship i
 
 Host overlays in `hosts/*/.config/tino/host-overrides.sh` can opt in cleanly by exporting `STARSHIP_ENABLE_K8S=1` and/or `STARSHIP_ENABLE_AWS=1`.
 
-Standard bootstrap command (repo root):
+Standard bootstrap command (repo root, recommended):
 
 Neovim plugin revisions are pinned in `dotfiles/nvim/.config/nvim/lazy-lock.json`; provisioning is handled by `./scripts/setup-nvim.sh` (headless `Lazy! sync` + explicit Mason LSP installs, requires Neovim >= 0.10) so first interactive startup is deterministic. Baseline 0.10 aligns with the modern Lua/LSP plugin architecture used across this repo and avoids split support paths for legacy APIs. Intentional plugin upgrades should use `./scripts/setup-nvim.sh --refresh-lockfile` (runs `Lazy! update` + `Lazy! lock`, then lock coverage validation) and can be re-checked manually with `python scripts/check-nvim-lockfile.py`. Runtime self-healing is opt-in with `TINO_NVIM_AUTO_BOOTSTRAP=1` (default is disabled/offline-friendly), and `TINO_NVIM_OFFLINE=1` forces warning-only startup behavior. Startup benchmarking is available via `scripts/benchmark_nvim_startup.sh`; `scripts/setup-nvim.sh` runs it only when `TINO_NVIM_BENCHMARK_STARTUP=1` and now auto-passes `TINO_NVIM_MAX_STARTUP_MS` from either explicit env override or host profile defaults (`TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS`). Current SLO defaults are desktop=80ms and work_laptop=140ms. The desktop budget is intentionally stricter so UI-facing hosts catch startup regressions before they become noticeable in interactive editing.
 
@@ -288,7 +289,7 @@ Expected artifacts are written under `.cache/tino/nvim-startup/`:
 ./scripts/bootstrap-dev-env.sh
 ```
 
-Apply mode is mutating by design: it runs `scripts/install_common.sh` without `--dry-run` during the `dependency-install` stage. `--set-default-shell <prompt|force|skip>` is explicit policy: by default bootstrap chooses `prompt` for interactive local sessions and `skip` for CI/non-interactive contexts.
+Apply mode is mutating by design: it is the only recommended orchestration entrypoint and calls `scripts/install_common.sh` without `--dry-run` during the `dependency-install` stage. `--set-default-shell <prompt|force|skip>` is explicit policy: by default bootstrap chooses `prompt` for interactive local sessions and `skip` for CI/non-interactive contexts.
 
 Canonical recommendation by environment type:
 
@@ -304,7 +305,7 @@ Preview-only plan mode:
 ./scripts/bootstrap-dev-env.sh --plan
 ```
 
-In plan mode, dependency installation is preview-only and always runs `install_common.sh --dry-run --set-default-shell=skip`.
+In plan mode, dependency installation is preview-only and always runs the internal helper as `install_common.sh --dry-run --set-default-shell=skip`.
 
 Terminal modernization acceptance gate (run after shell/tmux/nvim/terminal profile changes):
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -43,7 +43,7 @@ From the repository root:
 
 This is the primary workflow. It runs the dependency/bootstrap stages in order:
 
-1. `scripts/install_common.sh`
+1. `scripts/install_common.sh` (internal dependency/setup stage)
 2. `scripts/install_dotfiles.sh --host desktop`
 3. `scripts/setup-nvim.sh`
 4. `scripts/setup-terminal-provider.sh <resolved-provider>`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,11 +4,7 @@ Follow these steps to set up the configuration files on a new system. The
 `install.sh` and `bootstrap.ps1` wrappers now only parse command line options
 and delegate all work to the shared helpers. These helpers detect the
 environment, fix your `PATH`, install fonts, sync color palettes and configure
-Git hooks. After cloning the repository **install `stow`** and run
-`scripts/install_dotfiles.sh` to link the packages. If `stow` is missing the
-script now prints `Error: GNU Stow is required`. Then fetch and run the
-cross-platform installer with a
-single command:
+Git hooks. After cloning the repository, use `scripts/bootstrap-dev-env.sh` as the single orchestration entrypoint. Install `stow` first because bootstrap delegates dotfile deployment to `scripts/install_dotfiles.sh`. If `stow` is missing the script now prints `Error: GNU Stow is required`. Then fetch and run the cross-platform installer with a single command:
 
 
 ```bash
@@ -49,16 +45,14 @@ Stow:
 1. Clone the repository and enter the project directory.
 2. Install `stow` with your package manager if it is not already
    available.
-3. Execute `bash scripts/install_dotfiles.sh` to symlink the packages.
-4. Run `./install.sh` to install fonts, palettes and Git hooks.
-5. Restart your shell to load the new configuration.
+3. Execute `./scripts/bootstrap-dev-env.sh` to install dependencies, deploy dotfiles, provision Neovim, and render the terminal provider configuration.
+4. Restart your shell to load the new configuration.
 
 ```bash
 git clone https://github.com/d0tTino/d0tTino.git
 cd d0tTino
 sudo apt-get install stow   # or brew install stow
-bash scripts/install_dotfiles.sh
-./install.sh
+./scripts/bootstrap-dev-env.sh
 ```
 
 ## Prerequisites
@@ -145,14 +139,7 @@ Update the package with `scoop update tino`.
    run `bash scripts/install_dotfiles.sh` to link the packages with GNU Stow.
    Ensure `stow` is installed first or the script will exit with
    `Error: GNU Stow is required`.
-3. From an elevated PowerShell window, run `bootstrap.ps1` (or call
-   `install.sh` from a regular shell). The wrappers simply forward their
-   arguments to the common installer which cleans up your PATH, installs fonts,
-   syncs palettes and sets up Git hooks. The helper also runs `pre-commit install`
-   automatically. You must run the PowerShell script from an **elevated** window
-   so that it can modify the user PATH. Pass the appropriate flags to install
-   the core tools automatically. The
-   equivalent command using `install.sh` is shown below:
+3. From an elevated PowerShell window, run `bootstrap.ps1` (or call `install.sh` from a regular shell) only when you specifically need the legacy wrapper path. For repository clones, prefer `scripts/bootstrap-dev-env.sh`, which is the canonical orchestration flow and delegates limited dependency/recovery work to `scripts/install_common.sh`. The wrappers simply forward their arguments to the common installer which cleans up your PATH, installs fonts, syncs palettes and sets up Git hooks. The helper also runs `pre-commit install` automatically. You must run the PowerShell script from an **elevated** window so that it can modify the user PATH. Pass the appropriate flags to install the core tools automatically. The equivalent command using `install.sh` is shown below:
    ```bash
    ./install.sh --winget --windows-terminal --install-wsl --setup-wsl
    # PowerShell alternative
@@ -212,10 +199,9 @@ sudo bash scripts/setup-wsl.sh
 2. Run `scripts/install_dotfiles.sh` to link the packages with GNU Stow. Ensure
    `stow` is installed, otherwise the script prints `Error: GNU Stow is required`.
    Pass `--dry-run` to preview the commands or `--target DIR` to change the destination.
-3. Run `install.sh` to clean up your PATH and install the shared resources. This
-   also executes `pre-commit install` so the hooks run automatically:
+3. Run `scripts/bootstrap-dev-env.sh` to execute the full staged bootstrap. Use `install.sh` only when you explicitly want the legacy wrapper path. Bootstrap handles dependency setup, dotfile deployment, Neovim provisioning, terminal provider setup, and reporting. For recovery-only actions such as TPM/fonts/palettes/hooks, `scripts/install_common.sh` remains available as a lower-level helper.
    ```bash
-   ./install.sh
+   ./scripts/bootstrap-dev-env.sh
    ```
    Windows users can run the PowerShell variant from an elevated session:
    ```powershell
@@ -225,13 +211,13 @@ sudo bash scripts/setup-wsl.sh
 
 ### Default shell policy recommendations
 
-Use `scripts/bootstrap-dev-env.sh` when you want auditable staging and an explicit shell-selection policy:
+Use `scripts/bootstrap-dev-env.sh` as the canonical install/bootstrap command. It provides auditable staging and an explicit shell-selection policy:
 
 - **Interactive local development** (recommended): `./scripts/bootstrap-dev-env.sh --set-default-shell=prompt`
 - **CI / non-interactive automation** (recommended): `./scripts/bootstrap-dev-env.sh --set-default-shell=skip`
 - **Unattended workstation provisioning** (optional): `./scripts/bootstrap-dev-env.sh --set-default-shell=force`
 
-If you omit `--set-default-shell`, bootstrap defaults to `prompt` in interactive sessions and `skip` in CI/non-interactive contexts. In non-interactive `prompt` paths, the installer emits a deferred action message with the exact manual command (`chsh -s <zsh-path>`). Bootstrap reports include `login_shell_matches_zsh: true|false` as a dedicated post-check.
+If you omit `--set-default-shell`, bootstrap defaults to `prompt` in interactive sessions and `skip` in CI/non-interactive contexts. In non-interactive `prompt` paths, the installer emits a deferred action message with the exact manual command (`chsh -s <zsh-path>`). Bootstrap reports include `login_shell_matches_zsh: true|false` as a dedicated post-check. Treat `scripts/install_common.sh` as an internal dependency/recovery primitive rather than a parallel top-level workflow.
 
 ### Troubleshooting package managers
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -78,10 +78,10 @@ This model ensures you can keep a single operational workflow while still tuning
 From repository root:
 
 ```bash
-# 1) Common bootstrap entrypoint
-./scripts/install_common.sh
+# 1) Canonical bootstrap entrypoint
+./scripts/bootstrap-dev-env.sh
 
-# 2) Terminal provider setup (explicit provider)
+# 2) Terminal provider recovery or explicit re-render
 ./scripts/setup-terminal-provider.sh ghostty
 
 # 3) Neovim provisioning (plugins + Mason/LSP assets)
@@ -90,9 +90,9 @@ From repository root:
 
 Recommended flow:
 
-1. Run `install_common.sh` for baseline dependencies and managed dotfiles.
-2. Run `setup-terminal-provider.sh <provider>` if you need to switch or re-render provider configs.
-3. Run `setup-nvim.sh` after Neovim/plugin ecosystem changes.
+1. Run `bootstrap-dev-env.sh` for the full staged install flow.
+2. Run `setup-terminal-provider.sh <provider>` only if you need to switch or re-render provider configs after bootstrap.
+3. Run `setup-nvim.sh` after Neovim/plugin ecosystem changes when you are reprovisioning editor assets outside the main bootstrap flow.
 4. Keep Neovim at >= 0.10; this baseline matches the repo's modern Lua/LSP plugin architecture and keeps provisioning/QA behavior consistent.
 
 ## Validation checklist
@@ -177,7 +177,7 @@ Expected QA summary patterns:
 - Confirm Neovim headless setup completed without missing provider/plugin errors.
 
 If any plugin class is missing, re-run the canonical setup scripts above in order.
-For TPM specifically, `./scripts/install_common.sh` is the canonical recovery path.
+For TPM, fonts, palettes, and similar recovery-only setup, `./scripts/install_common.sh` remains the canonical lower-level recovery path.
 
 
 ## Starship prompt modules and cloud-context toggles

--- a/scripts/bootstrap-dev-env.sh
+++ b/scripts/bootstrap-dev-env.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 scripts_dir="$repo_root/scripts"
+# shellcheck source=scripts/lib/install-context.sh
+source "$scripts_dir/lib/install-context.sh"
 
 plan_mode=0
 host_overlay=""
@@ -82,76 +84,6 @@ case "$set_default_shell_mode" in
         ;;
 esac
 
-terminal_provider_supported() {
-    case "$1" in
-        ghostty|wezterm|kitty|alacritty|windows-terminal)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
-resolve_host_overlay() {
-    local raw_host="$1"
-    local hosts_root="$repo_root/hosts"
-
-    [[ -z "$raw_host" ]] && return 0
-
-    local normalized_lower="${raw_host,,}"
-    local normalized_slug
-    normalized_slug="$(printf '%s' "$normalized_lower" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
-    local short_host="${normalized_lower%%.*}"
-    local short_slug
-    short_slug="$(printf '%s' "$short_host" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
-
-    local -a candidates=("$raw_host" "$normalized_lower" "$normalized_slug" "$short_host" "$short_slug")
-    local candidate
-    for candidate in "${candidates[@]}"; do
-        [[ -z "$candidate" ]] && continue
-        if [[ -d "$hosts_root/$candidate" ]]; then
-            printf '%s' "$candidate"
-            return 0
-        fi
-    done
-}
-
-resolve_provider() {
-    local resolved_host="$1"
-    local provider=""
-    local defaults_path="$repo_root/dotfiles/terminal/.config/tino/terminal-defaults.sh"
-    local host_override_path=""
-
-    if [[ -f "$defaults_path" ]]; then
-        # shellcheck disable=SC1090
-        source "$defaults_path"
-    fi
-
-    if [[ -n "$resolved_host" ]]; then
-        host_override_path="$repo_root/hosts/$resolved_host/.config/tino/host-overrides.sh"
-        if [[ -f "$host_override_path" ]]; then
-            # shellcheck disable=SC1090
-            source "$host_override_path"
-        fi
-    fi
-
-    provider="${provider_override:-${TINO_TERMINAL_PROVIDER:-}}"
-    if [[ -z "$provider" ]]; then
-        case "${OSTYPE:-}" in
-            msys*|cygwin*|win32*|windows*) provider="windows-terminal" ;;
-            *) provider="ghostty" ;;
-        esac
-    fi
-
-    if ! terminal_provider_supported "$provider"; then
-        echo "Error: unsupported provider '$provider'" >&2
-        exit 1
-    fi
-
-    printf '%s' "$provider"
-}
-
 get_login_shell() {
     local shell_path=""
     local user_name="${USER:-$(id -un 2>/dev/null || true)}"
@@ -219,7 +151,7 @@ if [[ -z "$host_overlay" ]]; then
     host_overlay="$(resolve_host_overlay "$detected_host")"
 fi
 
-provider_chosen="$(resolve_provider "$host_overlay")"
+provider_chosen="$(resolve_terminal_provider "$host_overlay" "$provider_override")"
 
 mkdir -p "$report_dir"
 json_report="$report_dir/bootstrap-summary.json"

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -3,20 +3,10 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 scripts="$repo_root/scripts"
+# shellcheck source=scripts/lib/install-context.sh
+source "$scripts/lib/install-context.sh"
 
-# Determine the platform when OSTYPE is not provided
-if [[ -z "${OSTYPE:-}" ]]; then
-    OSTYPE="$(uname -s)"
-fi
-
-# Normalize Windows variants and lower-case the final value
-case $OSTYPE in
-    CYGWIN*|cygwin*) OSTYPE="cygwin" ;;
-    MINGW*|mingw*|MSYS*|msys*) OSTYPE="msys" ;;
-    Windows_NT*) OSTYPE="windows" ;;
-esac
-
-OSTYPE="${OSTYPE,,}"
+OSTYPE="$(normalize_ostype "${OSTYPE:-}")"
 
 run_cmd() {
     if $dry_run; then
@@ -160,72 +150,6 @@ install_terminal_provider() {
     run_cmd bash "$scripts/setup-terminal-provider.sh" "$provider"
 }
 
-terminal_provider_supported() {
-    local provider="$1"
-    case "$provider" in
-        ghostty|wezterm|kitty|alacritty|windows-terminal)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
-resolve_terminal_provider_from_config() {
-    local provider=""
-    local defaults_path="$repo_root/dotfiles/terminal/.config/tino/terminal-defaults.sh"
-    local host_name="$1"
-    local host_override_path=""
-
-    if [[ -f "$defaults_path" ]]; then
-        # shellcheck disable=SC1090
-        source "$defaults_path"
-    fi
-
-    if [[ -n "$host_name" ]]; then
-        host_override_path="$repo_root/hosts/$host_name/.config/tino/host-overrides.sh"
-        if [[ -f "$host_override_path" ]]; then
-            # shellcheck disable=SC1090
-            source "$host_override_path"
-        fi
-    fi
-
-    provider="${TINO_TERMINAL_PROVIDER:-}"
-    if [[ -z "$provider" ]]; then
-        if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == windows* ]]; then
-            provider="windows-terminal"
-        else
-            provider="ghostty"
-        fi
-    fi
-
-    echo "$provider"
-}
-
-resolve_nvim_benchmark_threshold_from_config() {
-    local host_name="$1"
-    local host_override_path=""
-
-    if [[ -n "$host_name" ]]; then
-        host_override_path="$repo_root/hosts/$host_name/.config/tino/host-overrides.sh"
-        if [[ -f "$host_override_path" ]]; then
-            local host_threshold=""
-            local profile_default_threshold=""
-            host_threshold="$({ source "$host_override_path"; printf '%s' "${TINO_NVIM_MAX_STARTUP_MS:-}"; })"
-            profile_default_threshold="$({ source "$host_override_path"; printf '%s' "${TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS:-}"; })"
-            if [[ -n "$host_threshold" ]]; then
-                echo "$host_threshold"
-                return
-            fi
-            if [[ -n "$profile_default_threshold" ]]; then
-                echo "$profile_default_threshold"
-                return
-            fi
-        fi
-    fi
-}
-
 run_pwsh() {
     local script=$1
     shift
@@ -256,39 +180,6 @@ clone_plugin_if_missing() {
 
     run_cmd mkdir -p "$(dirname "$destination")"
     run_cmd git clone "$repo_url" "$destination"
-}
-
-resolve_host_overlay() {
-    local hosts_root="$1"
-    local raw_host="$2"
-
-    if [[ -z "$raw_host" ]]; then
-        return
-    fi
-
-    local normalized_lower="${raw_host,,}"
-    local normalized_slug
-    normalized_slug="$(printf '%s' "$normalized_lower" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
-    local short_host="${normalized_lower%%.*}"
-    local short_slug
-    short_slug="$(printf '%s' "$short_host" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
-
-    local -a candidates=(
-        "$raw_host"
-        "$normalized_lower"
-        "$normalized_slug"
-        "$short_host"
-        "$short_slug"
-    )
-
-    local candidate
-    for candidate in "${candidates[@]}"; do
-        [[ -z "$candidate" ]] && continue
-        if [[ -d "$hosts_root/$candidate" ]]; then
-            echo "$candidate"
-            return
-        fi
-    done
 }
 
 get_login_shell() {
@@ -454,11 +345,11 @@ if [[ -n "$host_override" ]]; then
     resolved_host="$host_override"
 else
     detected_host="$(hostname 2>/dev/null || true)"
-    resolved_host="$(resolve_host_overlay "$repo_root/hosts" "$detected_host")"
+    resolved_host="$(resolve_host_overlay "$detected_host")"
 fi
 
 if [[ -z "$terminal_provider" ]]; then
-    terminal_provider="$(resolve_terminal_provider_from_config "$resolved_host")"
+    terminal_provider="$(resolve_terminal_provider "$resolved_host")"
 fi
 
 if ! terminal_provider_supported "$terminal_provider"; then
@@ -478,20 +369,10 @@ else
     clone_plugin_if_missing "$syntax_highlight_repo" "$plugin_root/zsh-syntax-highlighting"
     clone_plugin_if_missing "$tpm_repo" "$tmux_plugin_root/tpm"
 
-    dotfiles_args=()
-    if [[ -n "$host_override" ]]; then
-        if [[ ! -d "$repo_root/hosts/$host_override" ]]; then
-            echo "Error: host overlay '$host_override' does not exist" >&2
-            exit 1
-        fi
-        dotfiles_args+=(--host "$host_override")
-    elif [[ -n "$resolved_host" ]]; then
-        dotfiles_args+=(--host "$resolved_host")
+    if [[ -n "$host_override" && ! -d "$repo_root/hosts/$host_override" ]]; then
+        echo "Error: host overlay '$host_override' does not exist" >&2
+        exit 1
     fi
-    if [[ -f "$scripts/install_dotfiles.sh" ]]; then
-        run_cmd bash "$scripts/install_dotfiles.sh" --conflict=abort "${dotfiles_args[@]}"
-    fi
-
     if [[ -f "$scripts/setup-nvim.sh" ]]; then
         benchmark_env=()
         setup_nvim_host="${host_override:-${resolved_host:-}}"
@@ -508,8 +389,6 @@ else
     fi
 
     set_default_shell "$set_default_shell_mode"
-
-    install_terminal_provider "$terminal_provider"
 
     run_cmd bash "$scripts/setup-hooks.sh"
     run_cmd bash "$scripts/helpers/install_fonts.sh"

--- a/scripts/lib/install-context.sh
+++ b/scripts/lib/install-context.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+if [[ -n "${TINO_INSTALL_CONTEXT_LIB_SOURCED:-}" ]]; then
+    return 0
+fi
+TINO_INSTALL_CONTEXT_LIB_SOURCED=1
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+normalize_ostype() {
+    local raw_ostype="${1:-${OSTYPE:-}}"
+
+    if [[ -z "$raw_ostype" ]]; then
+        raw_ostype="$(uname -s 2>/dev/null || true)"
+    fi
+
+    case "$raw_ostype" in
+        CYGWIN*|cygwin*) printf '%s\n' 'cygwin' ;;
+        MINGW*|mingw*|MSYS*|msys*) printf '%s\n' 'msys' ;;
+        Windows_NT*) printf '%s\n' 'windows' ;;
+        *) printf '%s\n' "${raw_ostype,,}" ;;
+    esac
+}
+
+terminal_provider_supported() {
+    case "$1" in
+        ghostty|wezterm|kitty|alacritty|windows-terminal)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+resolve_host_overlay() {
+    local raw_host="$1"
+    local hosts_root="${2:-$repo_root/hosts}"
+
+    [[ -z "$raw_host" ]] && return 0
+
+    local normalized_lower="${raw_host,,}"
+    local normalized_slug
+    normalized_slug="$(printf '%s' "$normalized_lower" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+    local short_host="${normalized_lower%%.*}"
+    local short_slug
+    short_slug="$(printf '%s' "$short_host" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+
+    local -a candidates=("$raw_host" "$normalized_lower" "$normalized_slug" "$short_host" "$short_slug")
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        [[ -z "$candidate" ]] && continue
+        if [[ -d "$hosts_root/$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+}
+
+resolve_terminal_provider() {
+    local resolved_host="${1:-}"
+    local provider_override="${2:-}"
+    local normalized_ostype
+    normalized_ostype="$(normalize_ostype "${3:-${OSTYPE:-}}")"
+    local provider=""
+    local defaults_path="$repo_root/dotfiles/terminal/.config/tino/terminal-defaults.sh"
+    local host_override_path=""
+
+    if [[ -f "$defaults_path" ]]; then
+        # shellcheck disable=SC1090
+        source "$defaults_path"
+    fi
+
+    if [[ -n "$resolved_host" ]]; then
+        host_override_path="$repo_root/hosts/$resolved_host/.config/tino/host-overrides.sh"
+        if [[ -f "$host_override_path" ]]; then
+            # shellcheck disable=SC1090
+            source "$host_override_path"
+        fi
+    fi
+
+    provider="${provider_override:-${TINO_TERMINAL_PROVIDER:-}}"
+    if [[ -z "$provider" ]]; then
+        case "$normalized_ostype" in
+            msys*|cygwin*|win32*|windows*) provider='windows-terminal' ;;
+            *) provider='ghostty' ;;
+        esac
+    fi
+
+    if ! terminal_provider_supported "$provider"; then
+        echo "Error: unsupported terminal provider '$provider' (supported: ghostty|wezterm|kitty|alacritty|windows-terminal)" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$provider"
+}
+
+resolve_nvim_benchmark_threshold_from_config() {
+    local host_name="$1"
+    local host_override_path=""
+
+    if [[ -n "$host_name" ]]; then
+        host_override_path="$repo_root/hosts/$host_name/.config/tino/host-overrides.sh"
+        if [[ -f "$host_override_path" ]]; then
+            local host_threshold=""
+            local profile_default_threshold=""
+            host_threshold="$({ source "$host_override_path"; printf '%s' "${TINO_NVIM_MAX_STARTUP_MS:-}"; })"
+            profile_default_threshold="$({ source "$host_override_path"; printf '%s' "${TINO_NVIM_PROFILE_DEFAULT_MAX_STARTUP_MS:-}"; })"
+            if [[ -n "$host_threshold" ]]; then
+                printf '%s\n' "$host_threshold"
+                return 0
+            fi
+            if [[ -n "$profile_default_threshold" ]]; then
+                printf '%s\n' "$profile_default_threshold"
+                return 0
+            fi
+        fi
+    fi
+}

--- a/scripts/qa_terminal_modernization.sh
+++ b/scripts/qa_terminal_modernization.sh
@@ -5,39 +5,8 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 report_dir="${TINO_QA_REPORT_DIR:-$repo_root/.cache/tino/qa-terminal-modernization}"
 json_report="${TINO_QA_JSON_REPORT:-$report_dir/report.json}"
 renderer_json_report="${TINO_QA_RENDERER_JSON_REPORT:-$report_dir/renderer-contract.json}"
-
-resolve_host_overlay() {
-    local hosts_root="$1"
-    local raw_host="$2"
-
-    if [[ -z "$raw_host" ]]; then
-        return
-    fi
-
-    local normalized_lower="${raw_host,,}"
-    local normalized_slug
-    normalized_slug="$(printf '%s' "$normalized_lower" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
-    local short_host="${normalized_lower%%.*}"
-    local short_slug
-    short_slug="$(printf '%s' "$short_host" | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
-
-    local -a candidates=(
-        "$raw_host"
-        "$normalized_lower"
-        "$normalized_slug"
-        "$short_host"
-        "$short_slug"
-    )
-
-    local candidate
-    for candidate in "${candidates[@]}"; do
-        [[ -z "$candidate" ]] && continue
-        if [[ -d "$hosts_root/$candidate" ]]; then
-            printf '%s\n' "$candidate"
-            return
-        fi
-    done
-}
+# shellcheck source=scripts/lib/install-context.sh
+source "$repo_root/scripts/lib/install-context.sh"
 
 resolve_benchmark_threshold() {
     local default_threshold="100"
@@ -46,7 +15,7 @@ resolve_benchmark_threshold() {
     if [[ -z "$selected_host" ]]; then
         local detected_host
         detected_host="$(hostname 2>/dev/null || true)"
-        selected_host="$(resolve_host_overlay "$repo_root/hosts" "$detected_host")"
+        selected_host="$(resolve_host_overlay "$detected_host")"
     fi
 
     if [[ -n "$selected_host" ]]; then
@@ -322,7 +291,7 @@ fi
 active_host_profile="${TINO_HOST_PROFILE:-}"
 if [[ -z "$active_host_profile" ]]; then
     detected_host_for_profile="$(hostname 2>/dev/null || true)"
-    active_host_profile="$(resolve_host_overlay "$repo_root/hosts" "$detected_host_for_profile")"
+    active_host_profile="$(resolve_host_overlay "$detected_host_for_profile")"
 fi
 
 active_provider_default=""


### PR DESCRIPTION
### Motivation

- Reduce duplicated host/provider resolution and OS-normalization logic across install scripts by moving shared helpers into one reusable library. 
- Make `scripts/bootstrap-dev-env.sh` the single, canonical orchestration entrypoint and shrink `scripts/install_common.sh` to a narrowly scoped dependency/recovery helper. 
- Update docs to steer users toward the canonical flow and document `install_common.sh` as an internal/recovery primitive instead of a parallel top-level workflow.

### Description

- Added a reusable library `scripts/lib/install-context.sh` that provides `normalize_ostype`, `resolve_host_overlay`, `resolve_terminal_provider`, `resolve_nvim_benchmark_threshold_from_config`, and `terminal_provider_supported` helpers. 
- Updated `scripts/bootstrap-dev-env.sh` to source the new library and to call `resolve_terminal_provider` once; removed its duplicated host/provider logic. 
- Updated `scripts/install_common.sh` to source the new library, use `normalize_ostype`, and drop duplicated host/provider/flow-control responsibilities so it focuses on package/tool installation and recovery tasks (TPM/plugins/fonts/hooks/palettes). 
- Updated `scripts/qa_terminal_modernization.sh` to reuse the shared host-resolution helper instead of carrying duplicate logic. 
- Revised `README.md`, `docs/installation.md`, `docs/terminal.md`, and `docs/desktop.md` to recommend `scripts/bootstrap-dev-env.sh` as the canonical bootstrap command and to document `scripts/install_common.sh` as an internal/recovery helper.

### Testing

- Ran syntax checks with `bash -n scripts/bootstrap-dev-env.sh scripts/install_common.sh scripts/qa_terminal_modernization.sh scripts/lib/install-context.sh`, which completed without syntax errors. 
- Attempted `shellcheck` on the modified scripts, but `shellcheck` was not installed in the test environment so linting could not be run here. 
- Exercised the high-level dry-run flow with `bash scripts/bootstrap-dev-env.sh --plan --host desktop --provider ghostty`, which produced the expected planned actions and plan-mode output. 
- Exercised the internal helper in dry-run mode via `bash scripts/install_common.sh --dry-run --host desktop --terminal ghostty --set-default-shell=skip`, which printed the expected package/clone/install steps. 
- Ran `bash scripts/qa_terminal_modernization.sh`, which executed successfully but reported QA failures because required bootstrap-installed binaries (for example `zsh`, `starship`, `tmux`, `nvim`, `stow`, `fd`) are not present on `PATH` in this environment; this is expected for the test runner and does not indicate regressions in the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc13b4935083268e187654d99dec3a)