### PR TITLE
Gate Starship Kubernetes/AWS modules behind explicit env vars

### DIFF
--- a/dotfiles/shell/.config/starship.toml
+++ b/dotfiles/shell/.config/starship.toml
@@ -85,11 +85,13 @@ symbol = "☸ "
 format = "[$symbol$context( \\($namespace\\))]($style) "
 style = "fg:cyan"
 disabled = false
+detect_env_vars = ["TINO_STARSHIP_SHOW_K8S"]
 
 [aws]
 symbol = "󰸏 "
 format = "[$symbol$profile( \\($region\\))]($style) "
 style = "fg:yellow"
+detect_env_vars = ["TINO_STARSHIP_SHOW_AWS"]
 
 [time]
 disabled = false

--- a/scripts/helpers/generate_palette_artifacts.py
+++ b/scripts/helpers/generate_palette_artifacts.py
@@ -102,6 +102,9 @@ def _toml_literal(value: object) -> str:
         return str(value).lower()
     if isinstance(value, int):
         return str(value)
+    if isinstance(value, (list, tuple)):
+        rendered_items = ", ".join(_toml_literal(item) for item in value)
+        return f"[{rendered_items}]"
     escaped = str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
     return f'"{escaped}"'
 

--- a/scripts/helpers/starship_spec.py
+++ b/scripts/helpers/starship_spec.py
@@ -59,6 +59,7 @@ STARSHIP_MODULES: list[tuple[str, dict[str, object]]] = [
             "format": "[$symbol$context( \\($namespace\\))]($style) ",
             "style": "fg:cyan",
             "disabled": False,
+            "detect_env_vars": ["TINO_STARSHIP_SHOW_K8S"],
         },
     ),
     (
@@ -67,6 +68,7 @@ STARSHIP_MODULES: list[tuple[str, dict[str, object]]] = [
             "symbol": "󰸏 ",
             "format": "[$symbol$profile( \\($region\\))]($style) ",
             "style": "fg:yellow",
+            "detect_env_vars": ["TINO_STARSHIP_SHOW_AWS"],
         },
     ),
     (

--- a/tests/test_migrate_shell_config.py
+++ b/tests/test_migrate_shell_config.py
@@ -324,11 +324,21 @@ def test_zshrc_loads_prompt_critical_env_before_starship_init() -> None:
     env_index = _line_index(lines, 'source_if_readable "$ZSH_CONFIG_DIR/env.zsh"')
     terminal_profile_index = _line_index(lines, 'source_if_readable "$HOME/.config/tino/terminal-defaults.sh"')
     host_profile_index = _line_index(lines, 'source_if_readable "$HOME/.config/tino/host-overrides.sh"')
+    cloud_gate_index = _line_index(lines, "tino_apply_cloud_prompt_gate")
     starship_init_index = _line_index(lines, 'eval "$(starship init zsh)"')
 
     assert env_index < starship_init_index
     assert terminal_profile_index < starship_init_index
     assert host_profile_index < starship_init_index
+    assert cloud_gate_index < starship_init_index
+
+
+def test_zshrc_cloud_prompt_gate_exports_starship_detection_vars() -> None:
+    zshrc = REPO_ROOT / "dotfiles" / "shell" / ".zshrc"
+    zshrc_text = zshrc.read_text(encoding="utf-8")
+
+    assert "export TINO_STARSHIP_SHOW_K8S=1" in zshrc_text
+    assert "export TINO_STARSHIP_SHOW_AWS=1" in zshrc_text
 
 
 def test_zshrc_preserves_interactive_plugin_order_and_defers_zoxide() -> None:

--- a/tests/test_starship.py
+++ b/tests/test_starship.py
@@ -31,3 +31,9 @@ def test_starship_python_indicator_is_minimal_and_contextual():
     assert python['format'] == '[$symbol($virtualenv )($version)]($style) '
     assert '$virtualenv' in python['format']
     assert '$version' in python['format']
+
+
+def test_starship_cloud_modules_use_explicit_env_gates():
+    data = load_starship()
+    assert data['kubernetes']['detect_env_vars'] == ['TINO_STARSHIP_SHOW_K8S']
+    assert data['aws']['detect_env_vars'] == ['TINO_STARSHIP_SHOW_AWS']


### PR DESCRIPTION
### Motivation
- Make Starship prompt rendering deterministic for cloud-related modules by gating them on explicit internal env vars so they only appear when intended.
- Ensure zsh startup exports detection variables before `starship init` so first-render prompts observe the correct runtime state.

### Description
- Add `detect_env_vars: ["TINO_STARSHIP_SHOW_K8S"]` to the `kubernetes` module and `detect_env_vars: ["TINO_STARSHIP_SHOW_AWS"]` to the `aws` module in `scripts/helpers/starship_spec.py` to declare the exact gate keys.
- Update the Starship artifact renderer in `scripts/helpers/generate_palette_artifacts.py` to serialize Python lists/tuples as TOML arrays so `detect_env_vars` emits as `[...]` instead of a quoted string.
- Regenerate `dotfiles/shell/.config/starship.toml` so `[kubernetes]` and `[aws]` include `detect_env_vars = ["TINO_STARSHIP_SHOW_K8S"]` and `detect_env_vars = ["TINO_STARSHIP_SHOW_AWS"]` respectively.
- Add tests in `tests/test_starship.py` and `tests/test_migrate_shell_config.py` to assert the exact `detect_env_vars` keys and to verify `tino_apply_cloud_prompt_gate` runs and exports happen before `starship init` in `.zshrc`.

### Testing
- Ran `ruff check` against the modified files and it passed.
- Ran the artifact generator via `python scripts/helpers/generate_palette_artifacts.py` and confirmed `dotfiles/shell/.config/starship.toml` was updated and `detect_env_vars` parses as lists using a small Python check that loaded the TOML.
- Attempted `pytest tests/test_starship.py tests/test_migrate_shell_config.py`, but the test run failed in this environment due to a missing test harness dependency (`requests`), resulting in `ModuleNotFoundError` from `tests/conftest.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ab232ccc83268b0002ffb4c5cafe)