### PR TITLE
Lock install_common plugin checkouts to manifest SHAs

### DIFF
--- a/metadata/plugin-lock.json
+++ b/metadata/plugin-lock.json
@@ -1,0 +1,24 @@
+{
+  "plugins": {
+    "zsh-autosuggestions": {
+      "repo": "https://github.com/zsh-users/zsh-autosuggestions.git",
+      "sha": "85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5"
+    },
+    "zsh-syntax-highlighting": {
+      "repo": "https://github.com/zsh-users/zsh-syntax-highlighting.git",
+      "sha": "1d85c692615a25fe2293bdd44b34c217d5d2bf04"
+    },
+    "tpm": {
+      "repo": "https://github.com/tmux-plugins/tpm.git",
+      "sha": "99469c4a9b1ccf77fade25842dc7bafbc8ce9946"
+    },
+    "tmux-resurrect": {
+      "repo": "https://github.com/tmux-plugins/tmux-resurrect.git",
+      "sha": "cff343cf9e81983d3da0c8562b01616f12e8d548"
+    },
+    "tmux-continuum": {
+      "repo": "https://github.com/tmux-plugins/tmux-continuum.git",
+      "sha": "0698e8f4b17d6454c71bf5212895ec055c578da0"
+    }
+  }
+}

--- a/scripts/install_common.sh
+++ b/scripts/install_common.sh
@@ -161,25 +161,63 @@ run_pwsh() {
 }
 
 plugin_root="$HOME/.local/share/zsh/plugins"
-autosuggest_repo="https://github.com/zsh-users/zsh-autosuggestions"
-syntax_highlight_repo="https://github.com/zsh-users/zsh-syntax-highlighting"
 tmux_plugin_root="$HOME/.tmux/plugins"
-tpm_repo="https://github.com/tmux-plugins/tpm"
+plugin_lock_file="$repo_root/metadata/plugin-lock.json"
 
-clone_plugin_if_missing() {
-    local repo_url=$1
-    local destination=$2
-    if [[ -d "$destination/.git" ]]; then
-        echo "Plugin already installed at $destination"
+lockfile_field_for_plugin() {
+    local plugin_name=$1
+    local field_name=$2
+    local plugin_block
+
+    plugin_block="$(sed -n "/\"$plugin_name\"[[:space:]]*:[[:space:]]*{/,/}/p" "$plugin_lock_file")"
+    if [[ -z "$plugin_block" ]]; then
+        echo ""
         return
     fi
-    if [[ -e "$destination" ]]; then
+
+    printf '%s\n' "$plugin_block" | sed -n "s/.*\"$field_name\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" | head -n1
+}
+
+resolve_locked_plugin() {
+    local plugin_name=$1
+    local repo_url sha
+
+    if [[ ! -f "$plugin_lock_file" ]]; then
+        echo "Error: plugin lock file not found at $plugin_lock_file" >&2
+        exit 1
+    fi
+
+    repo_url="$(lockfile_field_for_plugin "$plugin_name" "repo")"
+    sha="$(lockfile_field_for_plugin "$plugin_name" "sha")"
+    if [[ -z "$repo_url" || -z "$sha" ]]; then
+        echo "Error: missing lock entry for plugin '$plugin_name' in $plugin_lock_file" >&2
+        exit 1
+    fi
+
+    printf '%s\n%s\n' "$repo_url" "$sha"
+}
+
+sync_plugin_to_locked_sha() {
+    local plugin_name=$1
+    local destination=$2
+    local repo_url sha
+
+    mapfile -t plugin_info < <(resolve_locked_plugin "$plugin_name")
+    repo_url="${plugin_info[0]}"
+    sha="${plugin_info[1]}"
+
+    if [[ -d "$destination/.git" ]]; then
+        echo "Updating $plugin_name in $destination"
+    elif [[ -e "$destination" ]]; then
         echo "Skipping $destination because it exists and is not a git checkout" >&2
         return
+    else
+        run_cmd mkdir -p "$(dirname "$destination")"
+        run_cmd git clone "$repo_url" "$destination"
     fi
 
-    run_cmd mkdir -p "$(dirname "$destination")"
-    run_cmd git clone "$repo_url" "$destination"
+    run_cmd git -C "$destination" fetch --all --tags --prune
+    run_cmd git -C "$destination" checkout --detach "$sha"
 }
 
 get_login_shell() {
@@ -365,9 +403,11 @@ if [[ $OSTYPE == msys* || $OSTYPE == cygwin* || $OSTYPE == win32* || $OSTYPE == 
     run_pwsh helpers/install_common.ps1
 else
     ensure_deps zsh starship tmux neovim stow rg fd
-    clone_plugin_if_missing "$autosuggest_repo" "$plugin_root/zsh-autosuggestions"
-    clone_plugin_if_missing "$syntax_highlight_repo" "$plugin_root/zsh-syntax-highlighting"
-    clone_plugin_if_missing "$tpm_repo" "$tmux_plugin_root/tpm"
+    sync_plugin_to_locked_sha "zsh-autosuggestions" "$plugin_root/zsh-autosuggestions"
+    sync_plugin_to_locked_sha "zsh-syntax-highlighting" "$plugin_root/zsh-syntax-highlighting"
+    sync_plugin_to_locked_sha "tpm" "$tmux_plugin_root/tpm"
+    sync_plugin_to_locked_sha "tmux-resurrect" "$tmux_plugin_root/tmux-resurrect"
+    sync_plugin_to_locked_sha "tmux-continuum" "$tmux_plugin_root/tmux-continuum"
 
     if [[ -n "$host_override" && ! -d "$repo_root/hosts/$host_override" ]]; then
         echo "Error: host overlay '$host_override' does not exist" >&2

--- a/tests/test_install_common.py
+++ b/tests/test_install_common.py
@@ -14,8 +14,39 @@ def create_exe(path: Path, contents: str = "#!/usr/bin/env bash\n") -> None:
 def create_git_stub(path: Path, log_path: Path) -> None:
     create_exe(
         path,
-        f"#!/usr/bin/env bash\necho \"$@\" >> '{log_path}'\nif [[ $1 == clone ]]; then\n  /bin/mkdir -p \"$3/.git\"\nfi\n",
+        f"#!/usr/bin/env bash\n"
+        f"echo \"$@\" >> '{log_path}'\n"
+        "if [[ $1 == clone ]]; then\n"
+        "  /bin/mkdir -p \"$3/.git\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [[ $1 == -C ]]; then\n"
+        "  repo_dir=\"$2\"\n"
+        "  shift 2\n"
+        "  if [[ $1 == fetch ]]; then\n"
+        "    exit 0\n"
+        "  fi\n"
+        "  if [[ $1 == checkout ]]; then\n"
+        "    if [[ $2 == --detach ]]; then\n"
+        "      commit_sha=\"$3\"\n"
+        "      if [[ ${#commit_sha} -ne 40 ]]; then\n"
+        "        echo \"invalid sha: $commit_sha\" >&2\n"
+        "        exit 1\n"
+        "      fi\n"
+        "      /bin/mkdir -p \"$repo_dir/.git\"\n"
+        "      printf '%s\\n' \"$commit_sha\" > \"$repo_dir/.git/LOCKED_SHA\"\n"
+        "      exit 0\n"
+        "    fi\n"
+        "  fi\n"
+        "fi\n"
+        "exit 0\n",
     )
+
+
+def copy_plugin_lock(repo_root: Path, repo: Path) -> None:
+    metadata_dir = repo / "metadata"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(repo_root / "metadata" / "plugin-lock.json", metadata_dir / "plugin-lock.json")
 
 
 def test_install_common_runs_without_ostype(tmp_path: Path) -> None:
@@ -28,6 +59,7 @@ def test_install_common_runs_without_ostype(tmp_path: Path) -> None:
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     log = tmp_path / "install.log"
     (scripts_dir / "setup-hooks.sh").write_text(
@@ -85,6 +117,7 @@ def test_install_common_installs_missing_deps_dnf(tmp_path: Path) -> None:
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     log = tmp_path / "install.log"
     (scripts_dir / "setup-hooks.sh").write_text(
@@ -138,6 +171,7 @@ def test_install_common_installs_missing_deps_pacman(tmp_path: Path) -> None:
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     log = tmp_path / "install.log"
     (scripts_dir / "setup-hooks.sh").write_text(
@@ -191,6 +225,7 @@ def test_install_common_setup_flags_linux(tmp_path: Path) -> None:
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     log = tmp_path / "install.log"
     (scripts_dir / "setup-hooks.sh").write_text(
@@ -265,6 +300,7 @@ def test_install_common_setup_flags_windows(tmp_path: Path) -> None:
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     log = tmp_path / "install.log"
     (helpers_dir / "install_common.ps1").write_text(
@@ -317,6 +353,7 @@ def test_install_common_installs_zsh_plugins_without_touching_zshrc(tmp_path: Pa
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     log = tmp_path / "install.log"
     for path, line in [
@@ -368,7 +405,7 @@ def test_install_common_installs_zsh_plugins_without_touching_zshrc(tmp_path: Pa
     assert any("install -y" in line and "zsh" in line for line in apt_lines)
 
     git_lines = git_log.read_text(encoding="utf-8").splitlines()
-    assert sum(1 for line in git_lines if line.startswith("clone ")) == 3
+    assert sum(1 for line in git_lines if line.startswith("clone ")) == 5
 
 
 def test_install_common_does_not_append_plugin_marker_block_to_existing_zshrc(tmp_path: Path) -> None:
@@ -381,6 +418,7 @@ def test_install_common_does_not_append_plugin_marker_block_to_existing_zshrc(tm
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -424,7 +462,7 @@ def test_install_common_does_not_append_plugin_marker_block_to_existing_zshrc(tm
     assert 'eval "$(starship init zsh)"' not in zshrc_content
 
     clone_lines = [line for line in git_log.read_text(encoding="utf-8").splitlines() if line.startswith("clone ")]
-    assert len(clone_lines) == 3
+    assert len(clone_lines) == 5
 
 
 
@@ -439,6 +477,7 @@ def test_install_common_installs_tpm_during_provisioning(tmp_path: Path) -> None
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -477,6 +516,7 @@ def test_install_common_skips_tpm_clone_when_repo_exists(tmp_path: Path) -> None
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -504,6 +544,97 @@ def test_install_common_skips_tpm_clone_when_repo_exists(tmp_path: Path) -> None
     clone_lines = [line for line in git_log.read_text(encoding="utf-8").splitlines() if line.startswith("clone ")]
     assert not any("tmux-plugins/tpm" in line for line in clone_lines)
 
+
+def test_install_common_checks_out_locked_plugin_shas(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_checkout_locked_shas"
+    repo.mkdir()
+
+    scripts_dir = repo / "scripts"
+    helpers_dir = scripts_dir / "helpers"
+    helpers_dir.mkdir(parents=True)
+
+    shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
+
+    for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
+        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    git_log = tmp_path / "git.log"
+
+    for exe in ["curl", "unzip", "zsh", "tmux", "nvim", "cargo", "stow", "rg", "fd"]:
+        create_exe(bin_dir / exe)
+    create_exe(bin_dir / "starship", "#!/usr/bin/env bash\nif [[ $1 == init && $2 == zsh ]]; then\n  echo 'STARSHIP_INIT'\nfi\n")
+    create_git_stub(bin_dir / "git", git_log)
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    env = os.environ.copy()
+    env.update({"OSTYPE": "linux-gnu", "PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(home_dir), "SHELL": "/bin/bash"})
+
+    subprocess.run(["/bin/bash", "scripts/install_common.sh"], cwd=repo, check=True, env=env)
+
+    git_lines = git_log.read_text(encoding="utf-8").splitlines()
+    checkout_lines = [line for line in git_lines if " checkout --detach " in f" {line} "]
+    assert len(checkout_lines) == 5
+    assert any(f"-C {home_dir}/.tmux/plugins/tmux-resurrect checkout --detach " in line for line in git_lines)
+    assert any(f"-C {home_dir}/.tmux/plugins/tmux-continuum checkout --detach " in line for line in git_lines)
+    assert all(len(line.rsplit(" ", 1)[-1]) == 40 for line in checkout_lines)
+
+
+def test_install_common_fails_when_plugin_lock_entry_is_missing(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo_missing_lock_entry"
+    repo.mkdir()
+
+    scripts_dir = repo / "scripts"
+    helpers_dir = scripts_dir / "helpers"
+    helpers_dir.mkdir(parents=True)
+
+    shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
+
+    lock_path = repo / "metadata" / "plugin-lock.json"
+    lock_text = lock_path.read_text(encoding="utf-8")
+    lock_path.write_text(lock_text.replace('"tmux-continuum": {', '"tmux-continuum-missing": {'), encoding="utf-8")
+
+    for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
+        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for exe in ["curl", "unzip", "zsh", "tmux", "nvim", "cargo", "stow", "rg", "fd"]:
+        create_exe(bin_dir / exe)
+    create_exe(bin_dir / "starship", "#!/usr/bin/env bash\nif [[ $1 == init && $2 == zsh ]]; then\n  echo 'STARSHIP_INIT'\nfi\n")
+    create_git_stub(bin_dir / "git", tmp_path / "git.log")
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    (bin_dir / "dirname").symlink_to("/usr/bin/dirname")
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    env = os.environ.copy()
+    env.update({"OSTYPE": "linux-gnu", "PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(home_dir), "SHELL": "/bin/bash"})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/install_common.sh"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "missing lock entry for plugin 'tmux-continuum'" in result.stderr
+
 def test_install_common_runs_install_dotfiles_with_detected_host(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     repo = tmp_path / "repo_dotfiles"
@@ -514,6 +645,7 @@ def test_install_common_runs_install_dotfiles_with_detected_host(tmp_path: Path)
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     log = tmp_path / "install.log"
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
@@ -564,6 +696,7 @@ def test_install_common_passes_explicit_host_to_install_dotfiles(tmp_path: Path)
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -612,6 +745,7 @@ def test_install_common_normalizes_detected_hostname_for_host_overlay(tmp_path: 
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -657,6 +791,7 @@ def test_install_common_selects_terminal_provider_from_defaults(tmp_path: Path) 
     tino_defaults_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -706,6 +841,7 @@ def test_install_common_selects_terminal_provider_from_host_override(tmp_path: P
     host_tino_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -754,6 +890,7 @@ def test_install_common_rejects_unsupported_terminal_provider_from_config(tmp_pa
     tino_defaults_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     (scripts_dir / "setup-hooks.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
     (scripts_dir / "setup-hooks.sh").chmod(0o755)
@@ -833,6 +970,7 @@ def test_install_common_enables_nvim_benchmark_by_default_for_desktop_host(tmp_p
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -883,6 +1021,7 @@ def test_install_common_respects_explicit_nvim_benchmark_disable(tmp_path: Path)
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -935,6 +1074,7 @@ def test_install_common_uses_terminal_provider_entrypoint_for_ghostty(tmp_path: 
     helpers_dir.mkdir(parents=True)
 
     shutil.copy(repo_root / "scripts" / "install_common.sh", scripts_dir / "install_common.sh")
+    copy_plugin_lock(repo_root, repo)
 
     for path in [scripts_dir / "setup-hooks.sh", helpers_dir / "install_fonts.sh", helpers_dir / "sync_palettes.sh"]:
         path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Ensure zsh and tmux plugin installs are reproducible by pinning exact repo URLs and commit SHAs in a tracked manifest.
- Make the install flow deterministic by cloning/fetching and checking out the exact locked SHA rather than using HEAD.
- Fail early with a clear error when the lockfile or a plugin entry is missing to avoid unexpected installs.

### Description
- Add `metadata/plugin-lock.json` containing `repo` and `sha` entries for `zsh-autosuggestions`, `zsh-syntax-highlighting`, `tpm`, `tmux-resurrect`, and `tmux-continuum`.
- Refactor `scripts/install_common.sh` to read the lockfile and introduce `lockfile_field_for_plugin`, `resolve_locked_plugin`, and `sync_plugin_to_locked_sha` helpers that: validate presence, clone when missing, `git fetch` when present, and `git checkout --detach <sha>` to pin installs.
- Replace prior ad-hoc plugin clone calls with `sync_plugin_to_locked_sha` invocations for all five plugins and fail fast with a clear error if a lock entry or lockfile is missing.
- Update `tests/test_install_common.py` to stage the lockfile into test repos, extend the `git` stub to simulate `-C ... fetch` and `checkout --detach` behavior, add `copy_plugin_lock`, assert checkout calls to detached SHAs, and add a test that verifies the script exits with an error if a required lock entry is removed; also update clone-count expectations to account for the additional locked plugins.

### Testing
- Ran `bash -n scripts/install_common.sh` with no syntax errors (success).
- Ran `python -m ruff check tests/test_install_common.py` with all checks passing (success).
- Ran `python -m pytest tests/test_install_common.py` in this environment but it failed due to an unrelated test environment dependency (`tests/conftest.py` requires a pyenv-managed `typer` path not present here), so plugin-related tests could not be executed end-to-end in this CI environment (partial failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69c2ad6a597083269ff102832bccc1ae)