### PR TITLE
Add terminal profile JSON schema and validation; wire into setup and renderer checks

### DIFF
--- a/dotfiles/terminal/.config/tino/terminal-profile.schema.json
+++ b/dotfiles/terminal/.config/tino/terminal-profile.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/d0ttino/terminal-profile.schema.json",
+  "title": "Tino Terminal Profile Contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "provider",
+    "opacity",
+    "fps",
+    "effects",
+    "palette"
+  ],
+  "properties": {
+    "provider": {
+      "type": "string",
+      "enum": ["ghostty", "wezterm", "kitty", "alacritty", "windows-terminal"]
+    },
+    "opacity": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "fps": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 360
+    },
+    "effects": {
+      "type": "string",
+      "anyOf": [
+        {
+          "enum": ["on", "off", "true", "false", "yes", "no", "0", "1", "none"]
+        },
+        {
+          "pattern": "^(/|\\.|~).+"
+        }
+      ]
+    },
+    "palette": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "background",
+        "foreground",
+        "cursor",
+        "selection",
+        "color_0",
+        "color_1",
+        "color_2",
+        "color_3",
+        "color_4",
+        "color_5",
+        "color_6",
+        "color_7",
+        "color_8",
+        "color_9",
+        "color_10",
+        "color_11",
+        "color_12",
+        "color_13",
+        "color_14",
+        "color_15"
+      ],
+      "properties": {
+        "background": {"$ref": "#/$defs/hexColor"},
+        "foreground": {"$ref": "#/$defs/hexColor"},
+        "cursor": {"$ref": "#/$defs/hexColor"},
+        "selection": {"$ref": "#/$defs/hexColor"},
+        "color_0": {"$ref": "#/$defs/hexColor"},
+        "color_1": {"$ref": "#/$defs/hexColor"},
+        "color_2": {"$ref": "#/$defs/hexColor"},
+        "color_3": {"$ref": "#/$defs/hexColor"},
+        "color_4": {"$ref": "#/$defs/hexColor"},
+        "color_5": {"$ref": "#/$defs/hexColor"},
+        "color_6": {"$ref": "#/$defs/hexColor"},
+        "color_7": {"$ref": "#/$defs/hexColor"},
+        "color_8": {"$ref": "#/$defs/hexColor"},
+        "color_9": {"$ref": "#/$defs/hexColor"},
+        "color_10": {"$ref": "#/$defs/hexColor"},
+        "color_11": {"$ref": "#/$defs/hexColor"},
+        "color_12": {"$ref": "#/$defs/hexColor"},
+        "color_13": {"$ref": "#/$defs/hexColor"},
+        "color_14": {"$ref": "#/$defs/hexColor"},
+        "color_15": {"$ref": "#/$defs/hexColor"}
+      }
+    }
+  },
+  "$defs": {
+    "hexColor": {
+      "type": "string",
+      "pattern": "^#[0-9a-fA-F]{6}$"
+    }
+  }
+}

--- a/dotfiles/terminal/.config/tino/terminal-profile.sh
+++ b/dotfiles/terminal/.config/tino/terminal-profile.sh
@@ -12,6 +12,35 @@ source_if_exists() {
     fi
 }
 
+terminal_profile_schema_validator() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    printf '%s/validate-terminal-profile-schema.py' "$script_dir"
+}
+
+validate_terminal_profile_schema() {
+    local provider="$1"
+    local validator
+    validator="$(terminal_profile_schema_validator)"
+    local python_bin="${PYTHON:-python3}"
+
+    if ! command -v "$python_bin" >/dev/null 2>&1; then
+        python_bin="python"
+    fi
+
+    if ! command -v "$python_bin" >/dev/null 2>&1; then
+        echo "Error: schema validation requires python3 or python in PATH." >&2
+        return 1
+    fi
+
+    if [[ ! -x "$validator" ]]; then
+        echo "Error: missing terminal profile schema validator: $validator" >&2
+        return 1
+    fi
+
+    "$python_bin" "$validator" "$provider"
+}
+
 # Contract fields shared across renderers.
 readonly TINO_TERMINAL_CONTRACT_FIELDS=(
     TINO_TERMINAL_FPS
@@ -221,6 +250,7 @@ render_provider() {
     local repo_root="${2:-}"
 
     load_terminal_profile
+    validate_terminal_profile_schema "$provider"
 
     case "$provider" in
         ghostty)
@@ -246,6 +276,16 @@ render_provider() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ ${1:-} == "--validate-schema" ]]; then
+        if [[ $# -ne 2 ]]; then
+            echo "Usage: $(basename "$0") --validate-schema <provider>" >&2
+            exit 1
+        fi
+        load_terminal_profile
+        validate_terminal_profile_schema "$2"
+        exit 0
+    fi
+
     if [[ ${1:-} == "--provider-preferences" ]]; then
         terminal_provider_preferences
         exit 0

--- a/dotfiles/terminal/.config/tino/validate-renderer-contract.sh
+++ b/dotfiles/terminal/.config/tino/validate-renderer-contract.sh
@@ -55,6 +55,7 @@ providers=("${TINO_TERMINAL_CONTRACT_PROVIDERS[@]}")
 validation_repo_root="$tmp_dir/validation-repo"
 mkdir -p "$validation_repo_root"
 for provider in "${providers[@]}"; do
+    "$XDG_CONFIG_HOME/tino/terminal-profile.sh" --validate-schema "$provider" >/dev/null
     "$XDG_CONFIG_HOME/tino/terminal-profile.sh" "$provider" "$validation_repo_root" >/dev/null
 done
 

--- a/dotfiles/terminal/.config/tino/validate-terminal-profile-schema.py
+++ b/dotfiles/terminal/.config/tino/validate-terminal-profile-schema.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import jsonschema
+
+
+def _schema_path() -> Path:
+    return Path(__file__).with_name("terminal-profile.schema.json")
+
+
+def _coerce_float(field: str, value: str) -> float:
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be a number, got {value!r}") from exc
+
+
+def _coerce_int(field: str, value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an integer, got {value!r}") from exc
+
+
+def build_profile(provider: str) -> dict[str, object]:
+    env = os.environ
+    return {
+        "provider": provider,
+        "opacity": _coerce_float("opacity", env.get("TINO_TERMINAL_OPACITY", "")),
+        "fps": _coerce_int("fps", env.get("TINO_TERMINAL_FPS", "")),
+        "effects": env.get("TINO_TERMINAL_EFFECTS", ""),
+        "palette": {
+            "background": env.get("TINO_TERMINAL_BACKGROUND", ""),
+            "foreground": env.get("TINO_TERMINAL_FOREGROUND", ""),
+            "cursor": env.get("TINO_TERMINAL_CURSOR", ""),
+            "selection": env.get("TINO_TERMINAL_SELECTION", ""),
+            **{f"color_{i}": env.get(f"TINO_TERMINAL_COLOR_{i}", "") for i in range(16)},
+        },
+    }
+
+
+def _format_field(error: jsonschema.ValidationError) -> str:
+    if not error.path:
+        return "<root>"
+    return ".".join(str(part) for part in error.path)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"Usage: {Path(argv[0]).name} <provider>", file=sys.stderr)
+        return 1
+
+    provider = argv[1]
+    schema_path = _schema_path()
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"Error: failed to load terminal profile schema at {schema_path}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        profile = build_profile(provider)
+    except ValueError as exc:
+        print(f"Error: terminal profile schema pre-validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(profile), key=lambda err: list(err.path))
+    if not errors:
+        return 0
+
+    print("Error: terminal profile schema validation failed.", file=sys.stderr)
+    for error in errors:
+        field = _format_field(error)
+        print(f"- field '{field}': {error.message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/setup-terminal-provider.sh
+++ b/scripts/setup-terminal-provider.sh
@@ -329,6 +329,7 @@ if [[ ! -x "$profile_script" ]]; then
 fi
 
 ensure_provider_installed
+"$profile_script" --validate-schema "$selected_provider"
 "$profile_script" "$selected_provider" "$repo_root"
 
 if [[ "$selected_provider" == "windows-terminal" ]]; then

--- a/tests/test_setup_terminal_provider.py
+++ b/tests/test_setup_terminal_provider.py
@@ -390,3 +390,39 @@ def test_setup_terminal_provider_logs_compatibility_target_request(tmp_path: Pat
     assert "compatibility target requested" in output
     assert render_log.read_text().strip() == "wezterm " + str(repo)
     assert "Terminal provider configured: wezterm" in result.stdout
+
+
+def test_setup_terminal_provider_surfaces_schema_validation_field_errors(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(repo_root / "scripts" / "setup-terminal-provider.sh", scripts_dir / "setup-terminal-provider.sh")
+
+    xdg_config_home = _create_terminal_profile(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        "if [[ ${1:-} == '--validate-schema' ]]; then\n"
+        "  echo \"Error: terminal profile schema validation failed.\" >&2\n"
+        "  echo \"- field 'opacity': 1.5 is greater than the maximum of 1\" >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    bin_dir = _create_minimal_bin(tmp_path)
+
+    env = os.environ.copy()
+    env.update({"XDG_CONFIG_HOME": str(xdg_config_home), "PATH": str(bin_dir), "TINO_TERMINAL_STRICT": "0"})
+
+    result = subprocess.run(
+        ["/bin/bash", "scripts/setup-terminal-provider.sh", "windows-terminal"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "field 'opacity'" in output
+    assert "Terminal provider configured" not in output

--- a/tests/test_terminal_profile.py
+++ b/tests/test_terminal_profile.py
@@ -5,10 +5,18 @@ from pathlib import Path
 
 def _copy_terminal_profile(tmp_path: Path) -> Path:
     repo_root = Path(__file__).resolve().parents[1]
-    profile_src = repo_root / "dotfiles" / "terminal" / ".config" / "tino" / "terminal-profile.sh"
+    tino_src = repo_root / "dotfiles" / "terminal" / ".config" / "tino"
+    profile_src = tino_src / "terminal-profile.sh"
     profile_dst = tmp_path / "terminal-profile.sh"
     profile_dst.write_text(profile_src.read_text(encoding="utf-8"), encoding="utf-8")
     profile_dst.chmod(0o755)
+    validator_src = tino_src / "validate-terminal-profile-schema.py"
+    validator_dst = tmp_path / "validate-terminal-profile-schema.py"
+    validator_dst.write_text(validator_src.read_text(encoding="utf-8"), encoding="utf-8")
+    validator_dst.chmod(0o755)
+    schema_src = tino_src / "terminal-profile.schema.json"
+    schema_dst = tmp_path / "terminal-profile.schema.json"
+    schema_dst.write_text(schema_src.read_text(encoding="utf-8"), encoding="utf-8")
     return profile_dst
 
 
@@ -58,3 +66,18 @@ def test_terminal_profile_host_approved_providers_match_canonical_default(tmp_pa
     result = subprocess.run(["/bin/bash", str(profile), "--host-approved-providers"], capture_output=True, text=True, check=True)
     providers = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     assert providers == ["ghostty"]
+
+
+def test_terminal_profile_validate_schema_rejects_invalid_opacity(tmp_path: Path) -> None:
+    profile = _copy_terminal_profile(tmp_path)
+    env = os.environ.copy()
+    env.update({"TINO_TERMINAL_OPACITY": "1.2"})
+    result = subprocess.run(
+        ["/bin/bash", str(profile), "--validate-schema", "ghostty"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "field 'opacity'" in output

--- a/tests/test_validate_renderer_contract.py
+++ b/tests/test_validate_renderer_contract.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -64,3 +65,40 @@ def test_wezterm_fallback_matches_baseline_contract() -> None:
     assert "window_background_opacity" in fallback
     assert "window_padding" in fallback
     assert "colors = {" in fallback
+
+
+def test_terminal_profile_schema_validation_rejects_invalid_fields() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    profile_script = repo_root / "dotfiles" / "terminal" / ".config" / "tino" / "terminal-profile.sh"
+    env = os.environ.copy()
+    env.update({"TINO_TERMINAL_OPACITY": "1.5"})
+
+    result = subprocess.run(
+        ["bash", str(profile_script), "--validate-schema", "ghostty"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "field 'opacity'" in output
+
+
+def test_terminal_profile_schema_validation_accepts_valid_fields() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    profile_script = repo_root / "dotfiles" / "terminal" / ".config" / "tino" / "terminal-profile.sh"
+    env = os.environ.copy()
+    env.update({"TINO_TERMINAL_OPACITY": "0.92", "TINO_TERMINAL_FPS": "120", "TINO_TERMINAL_EFFECTS": "on"})
+
+    result = subprocess.run(
+        ["bash", str(profile_script), "--validate-schema", "ghostty"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stderr == ""


### PR DESCRIPTION
### Motivation
- Ensure terminal profile inputs are validated against a formal contract so renderers receive well-formed values.  
- Surface actionable, field-level errors (including field names) early to aid debugging and prevent invalid rendering outputs.  
- Run validation as part of setup and renderer-contract checks so invalid profiles fail fast and are reported consistently.

### Description
- Add `dotfiles/terminal/.config/tino/terminal-profile.schema.json` defining required fields and constraints for `provider`, `opacity`, `fps`, `effects`, and a complete `palette` with hex color validation.  
- Add `dotfiles/terminal/.config/tino/validate-terminal-profile-schema.py` which builds a profile from environment variables, coerces types, validates with `jsonschema` Draft2020-12, and emits field-specific error lines like `- field 'opacity': ...`.  
- Wire validation into `dotfiles/terminal/.config/tino/terminal-profile.sh` to run schema validation before renderer execution and expose `--validate-schema <provider>` for explicit checks.  
- Invoke schema validation from `scripts/setup-terminal-provider.sh` and `dotfiles/terminal/.config/tino/validate-renderer-contract.sh` so setup and contract-report flows fail with clear errors when profiles are invalid.  
- Add and update tests to cover schema acceptance/rejection and error surfacing in `tests/test_validate_renderer_contract.py`, `tests/test_terminal_profile.py`, and `tests/test_setup_terminal_provider.py`.

### Testing
- Run `pytest -q tests/test_terminal_profile.py tests/test_setup_terminal_provider.py tests/test_validate_renderer_contract.py` and all tests passed (`24 passed`).  
- Run `ruff check` against the new validator and affected tests and linters passed (`All checks passed!`).  
- `shellcheck` was suggested for shell files but is not available in the execution environment (reported in test log).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cb0cf5b88326b480370cb0c723bd)